### PR TITLE
fix(eda-basic): fixed categorical column when values are non-strings,…

### DIFF
--- a/dataprep/eda/basic/__init__.py
+++ b/dataprep/eda/basic/__init__.py
@@ -21,6 +21,7 @@ def plot(
     bins: int = 10,
     ngroups: int = 10,
     largest: bool = True,
+    nsubgroups: int = 5,
     bandwidth: float = 1.5,
     sample_size: int = 1000,
     value_range: Optional[Tuple[float, float]] = None,
@@ -69,6 +70,10 @@ def plot(
         If true, when grouping over a categorical column, the groups
         with the largest count will be output. If false, the groups
         with the smallest count will be output.
+    nsubgroups : int
+        If x and y are categorical columns, ngroups refers to
+        how many groups to show from column x, and nsubgroups refers to
+        how many subgroups to show from column y in each group in column x.
     bandwidth : float, default 1.5
         Bandwidth for the kernel density estimation.
     sample_size : int, default 1000
@@ -107,6 +112,7 @@ def plot(
         bins=bins,
         ngroups=ngroups,
         largest=largest,
+        nsubgroups=nsubgroups,
         bandwidth=bandwidth,
         sample_size=sample_size,
         value_range=value_range,

--- a/dataprep/eda/basic/__init__.py
+++ b/dataprep/eda/basic/__init__.py
@@ -30,23 +30,23 @@ def plot(
 ) -> Figure:
     """Generates plots for exploratory data analysis.
 
-    If col_x and col_y are unspecified, the distribution of
+    If x and y are unspecified, the distribution of
     each coloumn is plotted. A histogram is plotted if the
     column contains numerical values, and a bar chart is plotted
     if the column contains categorical values.
 
-    If col_x is specified and col_y is unspecified, the
-    distribution of col_x is plotted in various ways. If col_x
+    If x is specified and y is unspecified, the
+    distribution of x is plotted in various ways. If x
     contains categorical values, a bar chart and pie chart are
-    plotted. If col_x contains numerical values, a histogram,
+    plotted. If x contains numerical values, a histogram,
     kernel density estimate plot, box plot, and qq plot are plotted.
 
-    If col_x and col_y are specified, plots depicting
+    If x and y are specified, plots depicting
     the relationship between the variables will be displayed. If
-    col_x and col_y contain numerical values, a scatter plot, hexbin
-    plot, and binned box plot are plotted. If one of col_x and col_y
+    x and y contain numerical values, a scatter plot, hexbin
+    plot, and binned box plot are plotted. If one of x and y
     contain categorical values and the other contains numerical values,
-    a box plot and multi-line histogram are plotted. If col_X and col_y
+    a box plot and multi-line histogram are plotted. If x and y
     contain categorical vales, a nested bar chart, stacked bar chart, and
     heat map are plotted.
 

--- a/dataprep/eda/basic/render.py
+++ b/dataprep/eda/basic/render.py
@@ -105,6 +105,9 @@ def bar_viz(
     # pylint: disable=too-many-arguments
     title = f"{col} ({miss_pct}% missing)" if miss_pct > 0 else f"{col}"
     tooltips = [(f"{col}", "@col"), ("Count", "@cnt"), ("Percent", "@pct{0.2f}%")]
+    if show_yaxis:
+        if len(df) > 10:
+            plot_width = 28 * len(df)
     fig = Figure(
         x_range=list(df["col"]),
         title=title,
@@ -316,7 +319,9 @@ def box_viz(
             )
         else:
             title = f"{y} by {x}"
-
+    if grp_cnt_stats is not None:
+        if grp_cnt_stats["x_show"] > 10:
+            plot_width = 28 * grp_cnt_stats["x_show"]
     fig = figure(
         tools="",
         x_range=list(df["grp"]),
@@ -545,10 +550,11 @@ def nested_viz(
     # pylint: disable=too-many-arguments
     data_source = ColumnDataSource(data=df)
     title = _make_title(grp_cnt_stats, x, y)
-
+    plot_width = 19 * len(df) if len(df) > 50 else plot_width
     fig = figure(
         x_range=FactorRange(*df["grp_names"]),
-        tools=[],
+        tools="hover",
+        tooltips=[("Group", "@grp_names"), ("Count", "@cnt")],
         toolbar_location=None,
         title=title,
         plot_width=plot_width,
@@ -562,9 +568,6 @@ def nested_viz(
         source=data_source,
         line_color="white",
         line_width=3,
-    )
-    fig.add_tools(
-        HoverTool(tooltips=[("Group", "@grp_names"), ("Count", "@cnt")], mode="mouse")
     )
     tweak_figure(fig, "nested")
     fig.yaxis.axis_label = "Count"
@@ -585,6 +588,8 @@ def stacked_viz(
     """
     # pylint: disable=too-many-arguments
     title = _make_title(grp_cnt_stats, x, y)
+    if grp_cnt_stats["x_show"] > 30:
+        plot_width = 32 * grp_cnt_stats["x_show"]
     fig = figure(
         x_range=df["grps"],
         toolbar_location=None,
@@ -635,6 +640,10 @@ def heatmap_viz(
     mapper = LinearColorMapper(
         palette=palette, low=df["cnt"].min() - 0.01, high=df["cnt"].max()
     )
+    if grp_cnt_stats["x_show"] > 60:
+        plot_width = 16 * grp_cnt_stats["x_show"]
+    if grp_cnt_stats["y_show"] > 10:
+        plot_height = 70 + 18 * grp_cnt_stats["y_show"]
     fig = figure(
         x_range=list(set(df["x"])),
         y_range=list(set(df["y"])),


### PR DESCRIPTION
… and updated the box plots

# Description

When the data type of a column is determined to be categorical, we now convert each value in a column to string (on the basis of minimal testing this was not time intensive).
For plot(df,x,y) when one column is categorical and the other is numerical, can now specify the number of groups and whether to see the largest or smallest groups.
Plots get wider if ngroups or nsubgroups is specified by the user and is large.

# How Has This Been Tested?

Manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [ ] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules