### PR TITLE
feat(data-connector): support template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ venv.bak/
 .idea
 notebooks/
 bfg.jar
+profiling

--- a/dataprep/data_connector/schema.json
+++ b/dataprep/data_connector/schema.json
@@ -156,7 +156,10 @@
                                 "type": "boolean",
                                 "default": false
                             },
-                            "valueFrom": {
+                            "fromKey": {
+                                "type": "string"
+                            },
+                            "toKey": {
                                 "type": "string"
                             },
                             "template": {

--- a/dataprep/eda/correlation/render.py
+++ b/dataprep/eda/correlation/render.py
@@ -196,7 +196,8 @@ def render_scatter(
     df = itmdt["data"]
     xcol, ycol, *maybe_label = df.columns
 
-    tooltips = [(xcol, f"@{xcol}"), (ycol, f"@{ycol}")]
+    tooltips = [(xcol, f"@{{{xcol}}}"), (ycol, f"@{{{ycol}}}")]
+
     fig = Figure(
         plot_width=plot_width,
         plot_height=plot_height,

--- a/dataprep/eda/missing/render.py
+++ b/dataprep/eda/missing/render.py
@@ -60,7 +60,7 @@ def render_dist(
     assert typ in ["pdf", "cdf"]
     tooltips = [
         (x, "@x"),
-        (typ.upper(), f"@{typ}"),
+        (typ.upper(), f"@{{{typ}}}"),
         ("Label", "@label"),
     ]
     y_range = Range1d(0, df[typ].max() * 1.01)


### PR DESCRIPTION
# Description

This PR makes it possible to define "templates" in the schema. Partially addresses #52.

A possible usage can be 
```json
{
    "request": {
        "params: {
            "template": "{{first_name}}$_{{last_name}}$",
            "required": false,
            "toKey": "q",
        }
    }
}
```
# How Has This Been Tested?

Manually tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules