### PR TITLE
fix(eda): boxplot grow with bins, reformat x/yaxis

### DIFF
--- a/dataprep/eda/basic/compute.py
+++ b/dataprep/eda/basic/compute.py
@@ -365,7 +365,7 @@ def calc_box(
         if is_numerical(df[x].dtype) and is_numerical(df[y].dtype):
             minv, maxv, cnt = dask.compute(df[x].min(), df[x].max(), df[x].nunique())
             if cnt < bins:
-                bins = cnt - 1
+                bins = cnt
             endpts = np.linspace(minv, maxv, num=bins + 1)
             # calculate a box plot over each bin
             df = dd.concat(
@@ -383,6 +383,10 @@ def calc_box(
                 ],
                 axis=1,
             ).compute()
+            endpts_df = pd.DataFrame(
+                [endpts[:-1], endpts[1:]], ["lb", "ub"], df.columns
+            )
+            df = pd.concat([df, endpts_df], axis=0)
         else:
             df, grp_cnt_stats, largest_grps = _calc_groups(df, ngroups, largest)
             # calculate a box plot over each group


### PR DESCRIPTION
# Description

Made the boxplot grow with the number of bins, and reformatted xaxis and yaxis tick values for all plots. Closes issue #104.

# How Has This Been Tested?

I tested this by inspecting the ticks and boxplots on the suicides, titanic and car_crashes datasets (ladder two from seaborn).

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have already squashed the commits and make the commit message conform to the project standard.
- [ ] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules