### PR TITLE
fix(eda): report permission error on windows

### DIFF
--- a/dataprep/eda/report.py
+++ b/dataprep/eda/report.py
@@ -2,9 +2,11 @@
     This module implements the Report class.
 """
 
+from pathlib import Path
 from tempfile import NamedTemporaryFile
-from bokeh.models import LayoutDOM
+
 from bokeh.io import save
+from bokeh.models import LayoutDOM
 from bokeh.resources import CDN
 
 
@@ -25,9 +27,17 @@ class Report:
         save(self.to_render, filename=filename, resources=CDN, title="Report")
 
     def _repr_html_(self) -> str:
-        with NamedTemporaryFile(suffix=".html") as f:
-            save(self.to_render, filename=f.name, resources=CDN, title="Report")
-            output_html = f.read().decode("utf-8")
+        # Windows forbids us open the file twice as the result bokeh cannot
+        # write to the opened temporary file.
+        with NamedTemporaryFile(suffix=".html", delete=False) as tmpf:
+            pass
+
+        save(self.to_render, filename=tmpf.name, resources=CDN, title="Report")
+        with open(tmpf.name, "r") as f:
+            output_html = f.read()
+
+        # Delete the temporary file
+        Path(tmpf.name).unlink()
 
         # embed into report template created by us here
         return output_html


### PR DESCRIPTION
# Description

Windows doesn't allow a file to open twice while this is exactly what we do to create a report.

fixes #131

# How Has This Been Tested?

On my Linux machine and pending for verifying on windows

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [ ] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules