### PR TITLE
fix(eda.plot): fix singular value for KDE and QQ norm plot

### DIFF
--- a/dataprep/eda/basic/compute.py
+++ b/dataprep/eda/basic/compute.py
@@ -567,7 +567,10 @@ def calc_hist_kde(
         }
     )
     pts_rng = np.linspace(minv, maxv, 1000)
-    pdf = gaussian_kde(data.compute())(pts_rng)
+    if minv == maxv:
+        pdf = np.zeros(1000, dtype=np.float64)
+    else:
+        pdf = gaussian_kde(data.compute())(pts_rng)
     return hist_df, pts_rng, pdf
 
 

--- a/dataprep/eda/basic/render.py
+++ b/dataprep/eda/basic/render.py
@@ -1053,11 +1053,17 @@ def render_num(
     fig = hist_viz(df, miss_pct, itmdt["col"], yscale, plot_width, plot_height, True)
     tabs.append(Panel(child=fig, title="histogram"))
     df, pts_rng, pdf = itmdt["kdedata"]
-    tabs.append(
-        hist_kde_viz(df, pts_rng, pdf, itmdt["col"], yscale, plot_width, plot_height)
-    )
+    if np.any(pdf):
+        tabs.append(
+            hist_kde_viz(
+                df, pts_rng, pdf, itmdt["col"], yscale, plot_width, plot_height
+            )
+        )
     actual_qs, theory_qs = itmdt["qqdata"]
-    tabs.append(qqnorm_viz(actual_qs, theory_qs, itmdt["col"], plot_width, plot_height))
+    if np.any(theory_qs[~np.isnan(theory_qs)]):
+        tabs.append(
+            qqnorm_viz(actual_qs, theory_qs, itmdt["col"], plot_width, plot_height)
+        )
     df, outx, outy, _ = itmdt["boxdata"]
     tabs.append(box_viz(df, outx, outy, itmdt["col"], plot_width, plot_height))
     tabs = Tabs(tabs=tabs)

--- a/dataprep/tests/eda/test_plot.py
+++ b/dataprep/tests/eda/test_plot.py
@@ -32,7 +32,8 @@ def simpledf() -> dd.DataFrame:
         ],
         axis=1,
     )
-    df.columns = ["a", "b", "c", "d", "e"]
+    df = pd.concat([df, pd.Series(np.zeros(1000))], axis=1)
+    df.columns = ["a", "b", "c", "d", "e", "f"]
     df["e"] = pd.to_datetime(df["e"])
 
     idx = np.arange(1000)
@@ -45,11 +46,11 @@ def simpledf() -> dd.DataFrame:
 
 
 def test_sanity_compute_1(simpledf: dd.DataFrame) -> None:
-    plot(simpledf, simpledf.columns[0])
+    plot(simpledf, "a")
 
 
 def test_sanity_compute_2(simpledf: dd.DataFrame) -> None:
-    plot(simpledf, simpledf.columns[-1])
+    plot(simpledf, "e")
 
 
 def test_sanity_compute_3(simpledf: dd.DataFrame) -> None:
@@ -57,8 +58,12 @@ def test_sanity_compute_3(simpledf: dd.DataFrame) -> None:
 
 
 def test_sanity_compute_4(simpledf: dd.DataFrame) -> None:
-    plot(simpledf, simpledf.columns[-2], simpledf.columns[-1])
+    plot(simpledf, "d", "e")
 
 
 def test_sanity_compute_5(simpledf: dd.DataFrame) -> None:
-    plot(simpledf, simpledf.columns[0], simpledf.columns[-1])
+    plot(simpledf, "a", "e")
+
+
+def test_sanity_compute_6(simpledf: dd.DataFrame) -> None:
+    plot(simpledf, "f")


### PR DESCRIPTION
Fixed #150 
# Description

Histogram with KDE and Q-Q plot will no longer show up when a singular value is given.

# How Has This Been Tested?

Added a singular value series in test DataFrame and a corresponding test scenario.

# Snapshots:

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
