### PR TITLE
fix(eda.plot_missing): fix error when change column type

### DIFF
--- a/dataprep/eda/missing/render.py
+++ b/dataprep/eda/missing/render.py
@@ -132,6 +132,10 @@ def render_hist(
 
     if is_categorical(df["x"].dtype):
         radius = 0.99
+
+        # Inputs of FactorRange() have to be sequence of strings,
+        # object only contains numbers can cause errors.(Issue#98).
+        df["x"] = df["x"].astype("str")
         x_range = FactorRange(*df["x"].unique())
     else:
         radius = df["x"][1] - df["x"][0]

--- a/dataprep/tests/eda/test_plot_missing.py
+++ b/dataprep/tests/eda/test_plot_missing.py
@@ -20,7 +20,7 @@ def simpledf() -> dd.DataFrame:
     )
 
     df.columns = ["a", "b", "c", "d"]
-
+    df["a"] = df["a"].astype("object")
     idx = np.arange(1000)
     np.random.shuffle(idx)
     df.iloc[idx[:500], 0] = None
@@ -52,6 +52,11 @@ def test_sanity_compute_4(simpledf: dd.DataFrame) -> None:
 
 def test_sanity_compute_5(simpledf: dd.DataFrame) -> None:
     itmdt = compute_missing(simpledf, x="a", y="d")
+    render_missing(itmdt)
+
+
+def test_column_change_type(simpledf: dd.DataFrame) -> None:
+    itmdt = compute_missing(simpledf, x="b")
     render_missing(itmdt)
 
 


### PR DESCRIPTION


Fixed #98

# Description

Change column type from int to object will no longer cause an error when calling
`plot_missing()`. I restored the dtypes of columns after calling dask.compute() and cast the input of FactorRange() to string. 

# How Has This Been Tested?

Change a column type in test DataFrame and add a corresponding test scenario.


# Snapshots:

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
