### PR TITLE
fix(eda.report): rename render to show

### DIFF
--- a/dataprep/eda/report.py
+++ b/dataprep/eda/report.py
@@ -43,7 +43,7 @@ class Report:
         # embed into report template created by us here
         return output_html
 
-    def render(self) -> None:
+    def show(self) -> None:
         """
         Render the report. This is useful when calling plot in a for loop.
         """


### PR DESCRIPTION
# Description

Use "show" instead of "render" to show the plot since "show" is more commonly used, e.g. matplotlib.

# How Has This Been Tested?

locally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [ ] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
