### PR TITLE
feat(data_connector): adding support for authorization type QueryParam

### DIFF
--- a/dataprep/data_connector/schema.json
+++ b/dataprep/data_connector/schema.json
@@ -239,6 +239,25 @@
                     "additionalProperties": false
                 },
                 {
+                    "type": "object",
+                    "required": [
+                        "type",
+                        "keyParam"
+                    ],
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "QueryParam"
+                            ]
+                        },
+                        "keyParam": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
                     "type": "string",
                     "enum": [
                         "Bearer"

--- a/dataprep/data_connector/types.py
+++ b/dataprep/data_connector/types.py
@@ -19,11 +19,15 @@ class AuthorizationType(Enum):
     ----
 
     * Bearer: requires 'access_token' presented in user params
+        - added as an Auth Header
+    * QueryParam: requires 'access_token' presented in user params
+        - added as a query string parameter
     * OAuth2: requires 'client_id' and 'client_secret' in user params for
       'ClientCredentials' grant type
     """
 
     Bearer = "Bearer"
+    QueryParam = "QueryParam"
     OAuth2 = "OAuth2"
 
 
@@ -47,6 +51,8 @@ class Authorization:
         """
         if self.auth_type == AuthorizationType.Bearer:  # pylint: disable=no-member
             req_data["headers"]["Authorization"] = f"Bearer {params['access_token']}"
+        elif self.auth_type == AuthorizationType.QueryParam:
+            req_data["params"][self.params["keyParam"]] = params["access_token"]
         elif (
             self.auth_type == AuthorizationType.OAuth2
             and self.params["grantType"] == "ClientCredentials"

--- a/dataprep/tests/data_connector/test_integration.py
+++ b/dataprep/tests/data_connector/test_integration.py
@@ -1,7 +1,15 @@
-from ...data_connector import Connector
+# type: ignore
 from os import environ
 
+import pytest
 
+from ...data_connector import Connector
+
+
+@pytest.mark.skipif(
+    environ.get("DATAPREP_SKIP_CREDENTIAL_TESTS") == "1",
+    reason="Skip tests that requires credential",
+)
 def test_data_connector() -> None:
     token = environ["DATAPREP_DATA_CONNECTOR_YELP_TOKEN"]
     dc = Connector("yelp", _auth={"access_token": token})
@@ -22,3 +30,17 @@ def test_data_connector() -> None:
     df = dc.query("businesses", _count=10000, term="ramen", location="vancouver")
 
     assert len(df) < 1000
+
+
+@pytest.mark.skipif(
+    environ.get("DATAPREP_SKIP_CREDENTIAL_TESTS") == "1",
+    reason="Skip tests that requires credential",
+)
+def test_query_params() -> None:
+
+    token = environ["DATAPREP_DATA_CONNECTOR_YOUTUBE_TOKEN"]
+
+    dc = Connector("youtube", _auth={"access_token": token})
+    df = dc.query("videos", q="covid", part="snippet")
+
+    assert len(df) != 0


### PR DESCRIPTION
The API key gets added as a query string parameter instead of an auth header

Resolves #200

# Description

Adding a new authorization type `TokenParam` that can be defined in the config files since some websites like YouTube requires the key to be added as a query string parameter `key` instead of an Auth header.

When the user provides the auth token while defining the connector object, `dc = Connector(".././DataConnectorConfigs/youtube", _auth={"access_token":<auth_token>})`, a query string parameter called key is to be added to the params request object.
`'params': {'key': 'AIzaSyC2Z29ow99qyV3kdk0CJYTINYgxG48ArqM'}}`.

# How Has This Been Tested?

The changes have been tested by successfully fetching YouTube data. The other auth types are also re-tested to assure that this does not affect the existing types like Bearer and OAuth2.

To reproduce, add `"authorization": "TokenParam"` in the config file for supported websites like YouTube search URL `https://www.googleapis.com/youtube/v3/search`

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
