### PR TITLE
Add code to display inside Google Colab

### DIFF
--- a/dataprep/eda/report.py
+++ b/dataprep/eda/report.py
@@ -2,10 +2,13 @@
     This module implements the Report class.
 """
 
+import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 from bokeh.io import save
+from bokeh.io.notebook import load_notebook
+from bokeh.embed.notebook import notebook_content
 from bokeh.models import LayoutDOM
 from bokeh.resources import CDN
 from IPython.display import HTML, display
@@ -53,6 +56,15 @@ class Report:
         )
 
     def _repr_html_(self) -> str:
+        """
+        Display itself inside a notebook
+        """
+        # Speical case inside Google Colab
+        if "google.colab" in sys.modules:
+            load_notebook(hide_banner=True)
+            script, div, _ = notebook_content(self.to_render)
+            return f"{div}<script>{script}</script>"
+
         # Windows forbids us open the file twice as the result bokeh cannot
         # write to the opened temporary file.
         with NamedTemporaryFile(suffix=".html", delete=False) as tmpf:


### PR DESCRIPTION
# Description

This fixes issue #102 to display plot in Colab correctly.

# How Has This Been Tested?

I test this will a minimal example `plot(df)` where df is `sns.load_dataset('titanic')`

In colab you need to install `dataprep` first with `!pip install -U tornado dataprep` then restart the runtime.

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [ ] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
