### PR TITLE
fix(eda.plot): kde yaxis tick locations

### DIFF
--- a/dataprep/eda/basic/render.py
+++ b/dataprep/eda/basic/render.py
@@ -461,7 +461,7 @@ def hist_kde_viz(
     fig.xaxis.axis_label = col
     _format_axis(fig, df.iloc[0]["left"], df.iloc[-1]["right"], "x")
     if yscale == "linear":
-        _format_axis(fig, 0, df["freq"].max(), "y")
+        _format_axis(fig, 0, max(df["freq"].max(), pdf.max()), "y")
     return Panel(child=fig, title="KDE plot")
 
 


### PR DESCRIPTION
# Description

Changed the maximum kde yaxis tick value to be the max of the bin height or KDE value. 

# How Has This Been Tested?

Manually

# Snapshots:
Before:

![Screen Shot 2020-07-11 at 10 02 06 AM](https://user-images.githubusercontent.com/25874021/87229678-04ea6100-c35f-11ea-86ee-c5ad803c9662.png)

 Now:

![Screen Shot 2020-07-11 at 10 01 44 AM](https://user-images.githubusercontent.com/25874021/87229685-129fe680-c35f-11ea-8c96-e3d3ecc0d7d0.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
