### PR TITLE
feat(eda): add show_browser function

### DIFF
--- a/dataprep/eda/report.py
+++ b/dataprep/eda/report.py
@@ -3,6 +3,7 @@
 """
 
 import sys
+import webbrowser
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
@@ -13,6 +14,8 @@ from bokeh.models import LayoutDOM
 from bokeh.resources import CDN
 from IPython.display import HTML, display
 from jinja2 import Template
+
+from .utils import is_notebook
 
 INLINE_TEMPLATE = Template(
     """
@@ -97,4 +100,29 @@ class Report:
         """
         Render the report. This is useful when calling plot in a for loop.
         """
+
+        # if not call from notebook environment, ref to show_browser function.
+        if not is_notebook():
+            print(
+                "The report is not shown in a notebook environment,"
+                " please try 'show_browser' if you want to open it in browser",
+                file=sys.stderr,
+            )
+
         display(HTML(self._repr_html_()))
+
+    def show_browser(self) -> None:
+        """
+        Open the report in the browser. This is useful when plotting
+        from terminmal or when the fig is very large in notebook.
+        """
+
+        # set delete = False to avoid early delete when user open multiple plots.
+        with NamedTemporaryFile(suffix=".html", delete=False) as tmpf:
+            save(
+                self.to_render,
+                filename=tmpf.name,
+                resources=CDN,
+                title="DataPrep.EDA Report",
+            )
+            webbrowser.open_new_tab(f"file://{tmpf.name}")

--- a/dataprep/tests/data_connector/test_integration.py
+++ b/dataprep/tests/data_connector/test_integration.py
@@ -7,7 +7,7 @@ from ...data_connector import Connector
 
 
 @pytest.mark.skipif(
-    environ.get("DATAPREP_SKIP_CREDENTIAL_TESTS") == "1",
+    environ.get("DATAPREP_SKIP_CREDENTIAL_TESTS", "0") == "0",
     reason="Skip tests that requires credential",
 )
 def test_data_connector() -> None:
@@ -33,7 +33,7 @@ def test_data_connector() -> None:
 
 
 @pytest.mark.skipif(
-    environ.get("DATAPREP_SKIP_CREDENTIAL_TESTS") == "1",
+    environ.get("DATAPREP_SKIP_CREDENTIAL_TESTS", "0") == "0",
     reason="Skip tests that requires credential",
 )
 def test_query_params() -> None:

--- a/dataprep/tests/eda/test_show.py
+++ b/dataprep/tests/eda/test_show.py
@@ -1,0 +1,34 @@
+# type: ignore
+from os import environ
+import dask.dataframe as dd
+import pandas as pd
+import numpy as np
+import pytest
+
+from ...eda import plot, plot_correlation, plot_missing
+from ...eda.utils import to_dask
+
+
+@pytest.fixture(scope="module")  # type: ignore
+def simpledf() -> dd.DataFrame:
+    df = pd.DataFrame(np.random.rand(10, 3), columns=["a", "b", "c"])
+    df = pd.concat([df, pd.Series(["a"] * 10)], axis=1)
+    df.columns = ["a", "b", "c", "d"]
+    df = to_dask(df)
+    return df
+
+
+def test_show(simpledf: dd.DataFrame) -> None:
+    plot(simpledf).show()
+    plot_correlation(simpledf).show()
+    plot_missing(simpledf).show()
+
+
+@pytest.mark.skipif(
+    environ.get("DATAPREP_BROWSER_TESTS", "0") == "0",
+    reason="Skip tests that requires opening browser",
+)
+def test_show_browser(simpledf: dd.DataFrame) -> None:
+    plot(simpledf).show_browser()
+    plot_correlation(simpledf).show_browser()
+    plot_missing(simpledf).show_browser()


### PR DESCRIPTION
# Description
This PR closes #247 and #222. It allows user open the report from browser by calling `plot(df).show_browser()`. This is useful when calling from the terminal.

