### PR TITLE
fix(eda.correlation): truncate axis tick values

### DIFF
--- a/dataprep/eda/correlation/render.py
+++ b/dataprep/eda/correlation/render.py
@@ -14,6 +14,7 @@ from bokeh.models import (
     ColumnDataSource,
     CustomJS,
     FactorRange,
+    FuncTickFormatter,
     HoverTool,
     Legend,
     LegendItem,
@@ -116,6 +117,13 @@ def tweak_figure(fig: Figure) -> None:
     fig.axis.major_label_text_font_size = "9pt"
     fig.axis.major_label_standoff = 0
     fig.xaxis.major_label_orientation = math.pi / 3
+    # truncate axis tick values
+    format_js = """
+        if (tick.length > 15) return tick.substring(0, 13) + '...';
+        else return tick;
+    """
+    fig.xaxis.formatter = FuncTickFormatter(code=format_js)
+    fig.yaxis.formatter = FuncTickFormatter(code=format_js)
 
 
 def render_correlation_heatmaps(
@@ -207,7 +215,6 @@ def render_correlation_single_heatmaps(
         )
 
         fig.add_layout(color_bar, "right")
-
         tab = Panel(child=fig, title=method)
         tabs.append(tab)
 


### PR DESCRIPTION
# Description

Truncate the axis tick values for plot correlation
![Screen Shot 2020-08-05 at 5 05 16 PM](https://user-images.githubusercontent.com/25874021/89475811-dc773c00-d73d-11ea-8ca0-1617ac5c2683.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
