### PR TITLE
feat(data_connector): Parameter check when calling query()

### DIFF
--- a/dataprep/connector/connector.py
+++ b/dataprep/connector/connector.py
@@ -14,7 +14,7 @@ from jinja2 import Environment, StrictUndefined, Template
 
 from ..errors import UnreachableError
 from .config_manager import config_directory, ensure_config
-from .errors import RequestError, UniversalParameterOverridden
+from .errors import RequestError, UniversalParameterOverridden, InvalidParameterError
 from .implicit_database import ImplicitDatabase, ImplicitTable
 from .int_ref import IntRef
 from .throttler import OrderedThrottler, ThrottleSession
@@ -117,6 +117,11 @@ class Connector:
         **where
             The additional parameters required for the query.
         """
+        allowed_params = self._impdb.tables[table].config["request"]["params"]
+        for key in where:
+            if key not in allowed_params:
+                raise InvalidParameterError(key)
+
         return await self._query_imp(table, where, _auth=_auth, _count=_count)
 
     @property

--- a/dataprep/connector/errors.py
+++ b/dataprep/connector/errors.py
@@ -49,3 +49,18 @@ class UniversalParameterOverridden(Exception):
 
     def __str__(self) -> str:
         return f"the parameter {self.param} is overridden by {self.uparam}"
+
+
+class InvalidParameterError(Exception):
+    """
+    The parameter used in the query is invalid
+    """
+
+    param: str
+
+    def __init__(self, param: str) -> None:
+        super().__init__()
+        self.param = param
+
+    def __str__(self) -> str:
+        return f"the parameter {self.param} is invalid, refer info method"


### PR DESCRIPTION
raises an exception when invalid parameters are passed to the query method

closes #267

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Currently, the query method executes even when invalid parameters are passed by the user. The change involves raising an exception for an invalid parameter, also redirecting the user to refer to the info() method for usage examples.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Snapshots:

Include snapshots for easier review.\
![invalid_param](https://user-images.githubusercontent.com/17384838/91706919-ed944c80-eb33-11ea-8682-718f690deb25.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
