### PR TITLE
perf(eda.plot): changed drop_null to dropna

### DIFF
--- a/dataprep/eda/distribution/compute/bivariate.py
+++ b/dataprep/eda/distribution/compute/bivariate.py
@@ -14,7 +14,6 @@ from ...dtypes import (
     DTypeDef,
     Nominal,
     detect_dtype,
-    drop_null,
     is_dtype,
 )
 from .common import (
@@ -98,7 +97,7 @@ def compute_bivariate(
         except TypeError:
             df[x] = df[x].astype(str)
 
-        (comps,) = dask.compute(nom_cont_comps(drop_null(df), bins, ngroups, largest))
+        (comps,) = dask.compute(nom_cont_comps(df.dropna(), bins, ngroups, largest))
 
         return Intermediate(
             x=x, y=y, data=comps, ngroups=ngroups, visual_type="cat_and_num_cols"
@@ -110,7 +109,7 @@ def compute_bivariate(
         and is_dtype(ytype, DateTime())
     ):
         x, y = (x, y) if is_dtype(xtype, DateTime()) else (y, x)
-        df = drop_null(df[[x, y]])
+        df = df[[x, y]].dropna()
         dtnum: List[Any] = []
         # line chart
         dtnum.append(dask.delayed(_calc_line_dt)(df, timeunit, agg))
@@ -131,7 +130,7 @@ def compute_bivariate(
         and is_dtype(ytype, DateTime())
     ):
         x, y = (x, y) if is_dtype(xtype, DateTime()) else (y, x)
-        df = drop_null(df[[x, y]])
+        df = df[[x, y]].dropna()
         df[y] = df[y].apply(str, meta=(y, str))
         dtcat: List[Any] = []
         # line chart
@@ -160,7 +159,7 @@ def compute_bivariate(
         except TypeError:
             df[y] = df[y].astype(str)
 
-        (comps,) = dask.compute(drop_null(df).groupby([x, y]).size())
+        (comps,) = dask.compute(df.dropna().groupby([x, y]).size())
 
         return Intermediate(
             x=x,
@@ -171,7 +170,7 @@ def compute_bivariate(
             visual_type="two_cat_cols",
         )
     elif is_dtype(xtype, Continuous()) and is_dtype(ytype, Continuous()):
-        df = drop_null(df[[x, y]])
+        df = df[[x, y]].dropna()
 
         data: Dict[str, Any] = {}
         # scatter plot data

--- a/dataprep/eda/distribution/compute/common.py
+++ b/dataprep/eda/distribution/compute/common.py
@@ -9,6 +9,7 @@ import pandas as pd
 from scipy.stats import gaussian_kde as gaussian_kde_
 from scipy.stats import ks_2samp as ks_2samp_
 from scipy.stats import normaltest as normaltest_
+from scipy.stats import skewtest as skewtest_
 
 from ...dtypes import drop_null
 
@@ -233,5 +234,13 @@ def ks_2samp(data1: np.ndarray, data2: np.ndarray) -> Tuple[float, float]:
     name="scipy-gaussian_kde", pure=True, nout=2
 )
 def gaussian_kde(arr: np.ndarray) -> Tuple[float, float]:
-    """Delayed version of scipy ks_2samp."""
+    """Delayed version of scipy gaussian_kde."""
     return cast(Tuple[np.ndarray, np.ndarray], gaussian_kde_(arr))
+
+
+@dask.delayed(  # pylint: disable=no-value-for-parameter
+    name="scipy-skewtest", pure=True, nout=2
+)
+def skewtest(arr: np.ndarray) -> Tuple[float, float]:
+    """Delayed version of scipy skewtest."""
+    return cast(Tuple[float, float], skewtest_(arr))

--- a/dataprep/eda/distribution/compute/univariate.py
+++ b/dataprep/eda/distribution/compute/univariate.py
@@ -18,7 +18,6 @@ from ...dtypes import (
     DTypeDef,
     Nominal,
     detect_dtype,
-    drop_null,
     is_dtype,
 )
 from ...intermediate import Intermediate
@@ -177,7 +176,7 @@ def nom_comps(
     except TypeError:
         srs = srs.astype(str)
     # drop null values
-    srs = drop_null(srs)
+    srs = srs.dropna()
 
     ## if cfg.bar_enable or cfg.pie_enable
     # counts of unique values in the series
@@ -223,7 +222,7 @@ def cont_comps(srs: dd.Series, bins: int) -> Dict[str, Any]:
     ## if cfg.stats_enable or cfg.hist_enable or
     # calculate the total number of rows then drop the missing values
     data["nrows"] = srs.shape[0]
-    srs = drop_null(srs)
+    srs = srs.dropna()
     ## if cfg.stats_enable
     # number of not null (present) values
     data["npres"] = srs.shape[0]
@@ -236,7 +235,6 @@ def cont_comps(srs: dd.Series, bins: int) -> Dict[str, Any]:
     ## if cfg.hist_enable or cfg.qqplot_enable and cfg.ingsights_enable:
     data["hist"] = da.histogram(srs, bins=bins, range=[data["min"], data["max"]])
     ## if cfg.insights_enable and (cfg.qqplot_enable or cfg.hist_enable):
-    # NOTE normal test does a .compute() and I cannot fix it with delayed
     data["norm"] = normaltest(data["hist"][0])
     ## if cfg.qqplot_enable
     data["qntls"] = srs.quantile(np.linspace(0.01, 0.99, 99))

--- a/dataprep/eda/distribution/render.py
+++ b/dataprep/eda/distribution/render.py
@@ -1636,7 +1636,7 @@ def cont_insights(data: Dict[str, Any], col: str) -> Dict[str, List[str]]:
 
     ## if cfg.insight.normal_enable:
     if data["norm"][1] > 0.99:
-        ins["hist"].append(f"{col} is normally distributed")
+        ins["Histogram"].append(f"{col} is normally distributed")
 
     ## if cfg.insight.uniform_enable:
     if data["chisq"][1] > 0.999:  ## cfg.insight.uniform_threshold


### PR DESCRIPTION
# Description

Changed `drop_null()` to `.dropna()` to increase performance. Also, we can get a minor performance increase by using skewtest on the histogram frequencies rather than computing the skew on the entire column.

# How Has This Been Tested?

Some manual tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
