### PR TITLE
fix(eda): supplement one datatype

### DIFF
--- a/dataprep/eda/dtypes.py
+++ b/dataprep/eda/dtypes.py
@@ -12,7 +12,7 @@ import dask.dataframe as dd
 from ..errors import UnreachableError
 
 CATEGORICAL_NUMPY_DTYPES = [np.bool, np.object]
-CATEGORICAL_PANDAS_DTYPES = [pd.CategoricalDtype, pd.PeriodDtype]
+CATEGORICAL_PANDAS_DTYPES = [pd.CategoricalDtype, pd.PeriodDtype, pd.StringDtype]
 CATEGORICAL_DTYPES = CATEGORICAL_NUMPY_DTYPES + CATEGORICAL_PANDAS_DTYPES
 
 NUMERICAL_NUMPY_DTYPES = [np.number]


### PR DESCRIPTION

This is yuzhen's first PR. I only changed one line: add a datatype to eda/dtype.py. This change is for solving issue#330, but this issue isn't be solved yet.