### PR TITLE
feat(clean): add report parameter for clean_lat_long

### DIFF
--- a/dataprep/clean/clean_lat_long.py
+++ b/dataprep/clean/clean_lat_long.py
@@ -10,7 +10,7 @@ import dask
 import numpy as np
 import pandas as pd
 
-from .utils import NULL_VALUES, report, to_dask
+from .utils import NULL_VALUES, create_report, to_dask
 
 LAT_LONG_PATTERN = re.compile(
     r"""
@@ -87,6 +87,7 @@ def clean_lat_long(
     output_format: str = "dd",
     split: bool = False,
     inplace: bool = False,
+    report: bool = True,
     errors: str = "coerce",
 ) -> pd.DataFrame:
     """
@@ -114,6 +115,8 @@ def clean_lat_long(
     inplace
         If True, delete the given column with dirty data, else, create a new
         column with cleaned data.
+    report
+        If True, output the summary report. Otherwise, no report is outputted.
     errors {‘ignore’, ‘raise’, ‘coerce’}, default 'coerce'
         * If ‘raise’, then invalid parsing will raise an exception.
         * If ‘coerce’, then invalid parsing will be set as NaT.
@@ -192,7 +195,8 @@ def clean_lat_long(
     df, nrows = dask.compute(df, df.shape[0])
 
     # output the report describing the changes to the column
-    report(STATS, nrows)
+    if report:
+        create_report(STATS, nrows)
 
     return df
 

--- a/dataprep/clean/utils.py
+++ b/dataprep/clean/utils.py
@@ -40,7 +40,7 @@ def to_dask(df: Union[pd.DataFrame, dd.DataFrame]) -> dd.DataFrame:
     return dd.from_pandas(df, npartitions=npartitions)
 
 
-def report(stats: Dict[str, int], nrows: int) -> None:
+def create_report(stats: Dict[str, int], nrows: int) -> None:
     """
     Describe what was done in the cleaning process
     """


### PR DESCRIPTION
# Description

Adds a `report` parameter to `clean_lat_long()` that, if True, generates a summary report. Otherwise, no report is outputted. By default, the parameter is set to True.

Closes #348.

# How Has This Been Tested?

Manual testing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules