### PR TITLE
fix(eda): supplement one datatype

### DIFF
--- a/dataprep/eda/distribution/compute/__init__.py
+++ b/dataprep/eda/distribution/compute/__init__.py
@@ -93,6 +93,10 @@ def compute(
         dtype = {"a": Continuous(), "b": "nominal"}
         or dtype = Continuous() or dtype = "Continuous" or dtype = Continuous()
     """  # pylint: disable=too-many-locals
+	
+	for col in df:
+        if df[col].dtype=='string':
+            df[col] = df[col].astype('object') 
 
     df = to_dask(df)
     df.columns = df.columns.astype(str)

--- a/dataprep/eda/dtypes.py
+++ b/dataprep/eda/dtypes.py
@@ -12,7 +12,7 @@ import dask.dataframe as dd
 from ..errors import UnreachableError
 
 CATEGORICAL_NUMPY_DTYPES = [np.bool, np.object]
-CATEGORICAL_PANDAS_DTYPES = [pd.CategoricalDtype, pd.PeriodDtype]
+CATEGORICAL_PANDAS_DTYPES = [pd.CategoricalDtype, pd.PeriodDtype, pd.StringDtype]
 CATEGORICAL_DTYPES = CATEGORICAL_NUMPY_DTYPES + CATEGORICAL_PANDAS_DTYPES
 
 NUMERICAL_NUMPY_DTYPES = [np.number]


### PR DESCRIPTION
# Description
yuzhen's second pull request try. Only add one datatype: "pd.StringDtype" in CATEGORICAL_PANDAS_DTYPES

# How Has This Been Tested?

manually

# Snapshots:

No Snapshot

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
