### PR TITLE
fix(eda.create_report): handle unhashable dtypes

### DIFF
--- a/dataprep/eda/distribution/compute/overview.py
+++ b/dataprep/eda/distribution/compute/overview.py
@@ -241,10 +241,8 @@ def calc_stats(df: dd.DataFrame, dtype: Optional[DTypeDef]) -> Dict[str, Any]:
     ----------
     df
         a DataFrame
-    dtype_cnts
-        a dictionary that contains the count for each type
-    num_cols:
-        numerical columns in the dataset
+    dtype
+        str or DType or dict of str or dict of DType
     """
 
     stats = {"nrows": df.shape[0]}

--- a/dataprep/eda/distribution/compute/univariate.py
+++ b/dataprep/eda/distribution/compute/univariate.py
@@ -88,6 +88,11 @@ def compute_univariate(
     col_dtype = detect_dtype(df[x], dtype)
     if is_dtype(col_dtype, Nominal()):
         first_rows = df[x].head()  # dd.Series.head() triggers a (small) data read
+        # cast the column as string type if it contains a mutable type
+        try:
+            first_rows.apply(hash)
+        except TypeError:
+            df[x] = df[x].astype(str)
         # all computations for plot(df, Nominal())
         data = nom_comps(
             df[x],
@@ -170,11 +175,6 @@ def nom_comps(
 
     # total rows
     data["nrows"] = srs.shape[0]
-    # cast the column as string type if it contains a mutable type
-    try:
-        first_rows.apply(hash)
-    except TypeError:
-        srs = srs.astype(str)
     # drop null values
     srs = srs.dropna()
 

--- a/dataprep/tests/eda/test_create_report.py
+++ b/dataprep/tests/eda/test_create_report.py
@@ -17,6 +17,7 @@ def simpledf() -> pd.DataFrame:
     df = pd.concat(
         [df, pd.Series(np.random.choice(["a", "b", "c"], 1000, replace=True))], axis=1
     )
+    df = pd.concat([df, pd.Series([["foo"] * 1000])], axis=1)
     df = pd.concat(
         [
             df,
@@ -29,7 +30,7 @@ def simpledf() -> pd.DataFrame:
         axis=1,
     )
     # df = pd.concat([df, pd.Series(np.zeros(1000))], axis=1)
-    df.columns = ["a", "b", "c", "d", "e"]
+    df.columns = ["a", "b", "c", "d", "e", "f"]
     # df["e"] = pd.to_datetime(df["e"])
 
     idx = np.arange(1000)


### PR DESCRIPTION
# Description

Make `create_report` able to handle columns containing unhashable types.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
