### PR TITLE
feat(clean) : add errors parameter, enhance report for clean_url

### DIFF
--- a/dataprep/clean/clean_url.py
+++ b/dataprep/clean/clean_url.py
@@ -1,13 +1,14 @@
-# pylint: disable=too-many-arguments, trailing-whitespace, global-statement, line-too-long
+# pylint: disable=too-many-arguments, global-statement, line-too-long, too-many-locals
 """
 implement clean_url functionality
 """
 
 import re
-from typing import Any, Union, Dict, List
+from typing import Any, Union, List
 from urllib.parse import unquote, urlparse
 
 import pandas as pd
+import numpy as np
 import dask
 import dask.dataframe as dd
 
@@ -41,7 +42,12 @@ AUTH_VALUES = {
 UNIFIED_AUTH_LIST = set()
 
 # STATs count
-STATS = {"cleaned": 0, "rows": 0, "correct_format": 0, "incorrect_format": 0}
+# cleaned=number of queries removed,
+# rows=number of rows from which querries were removed
+# correct_format=number of rows in correct format
+# incorrect_format=number of rows in incorrect format
+# first_val is to indicate whether what format is the first values in (more details in `check_first` doc-string), 100 for correct format, 200 for incorrect format
+STATS = {"cleaned": 0, "rows": 0, "correct_format": 0, "incorrect_format": 0, "first_val": 0}
 
 
 def clean_url(
@@ -51,6 +57,7 @@ def clean_url(
     split: bool = False,
     remove_auth: Union[bool, List[str]] = False,
     report: bool = True,
+    errors: str = "coerce",
 ) -> Union[pd.DataFrame, dd.DataFrame]:
 
     """
@@ -71,8 +78,14 @@ def clean_url(
     remove_auth
         can be a bool, or list of string representing the names of Auth queries
         to be removed. By default it is set to False
-    report:
+    report
         Displays how many queries were removed from rows
+    errors
+        Specify ways to deal with broken value
+        {'ignore', 'coerce', 'raise'}, default 'coerce'
+        'raise': raise an exception when there is broken value
+        'coerce': set invalid value to NaN
+        'ignore': just return the initial input
     """
 
     # reset stats and convert to dask
@@ -81,12 +94,6 @@ def clean_url(
 
     # unified list of auth removal params
     if not isinstance(remove_auth, bool):
-
-        if not isinstance(remove_auth, list):
-            raise TypeError(
-                "Parameter `remove_auth` should either be boolean value or list of strings"
-            )
-
         global UNIFIED_AUTH_LIST
         UNIFIED_AUTH_LIST = {*AUTH_VALUES, *set(remove_auth)}
 
@@ -94,16 +101,13 @@ def clean_url(
     meta = df.dtypes.to_dict()
 
     if split:
-        meta.update(zip(("scheme", "host", "cleaned_url", "queries"), (str, str, str, str, str)))
+        meta.update(
+            zip(("scheme", "host", f"{column}_clean", "queries"), (str, str, str, str, str))
+        )
     else:
-        meta.update(zip(("url_details",), (str,)))
+        meta[f"{column}_details"] = str
 
-    df = df.apply(
-        format_url,
-        args=(column, split, remove_auth),
-        axis=1,
-        meta=meta,
-    )
+    df = df.apply(format_url, args=(column, split, remove_auth, errors), axis=1, meta=meta)
 
     df, nrows = dask.compute(df, df.shape[0])
 
@@ -111,47 +115,44 @@ def clean_url(
         df = df.drop(columns=[column])
 
     if report:
-        report_url(STATS, nrows)
+        report_url(nrows=nrows, errors=errors, split=split, column=column)
 
     return df
 
 
 def format_url(
-    row: pd.Series, column: str, split: bool, remove_auth: Union[bool, List[str]]
+    row: pd.Series, column: str, split: bool, remove_auth: Union[bool, List[str]], errors: str
 ) -> pd.Series:
     """
     This function formats each row of a pd.Series containing the url column
     """
-
     if split:
-
-        if row[column] in NULL_VALUES:
-            row["scheme"], row["host"], row["cleaned_url"], row["queries"] = None, None, None, None
-
-        else:
-            row["scheme"], row["host"], row["cleaned_url"], row["queries"] = get_url_params(
-                row[column], split=split, remove_auth=remove_auth
-            )
-
+        row["scheme"], row["host"], row[f"{column}_clean"], row["queries"] = get_url_params(
+            row[column], split=split, remove_auth=remove_auth, column=column, errors=errors
+        )
     else:
-        if row[column] in NULL_VALUES:
-            row["url_details"] = None
-        else:
-            val_dict = get_url_params(row[column], split=split, remove_auth=remove_auth)
-            row["url_details"] = val_dict
+        val_dict = get_url_params(
+            row[column], split=split, remove_auth=remove_auth, column=column, errors=errors
+        )
+        row[f"{column}_details"] = val_dict
+
     return row
 
 
-def get_url_params(url: str, split: bool, remove_auth: Union[bool, List[str]]) -> Any:
+def get_url_params(
+    url: str, column: str, split: bool, remove_auth: Union[bool, List[str]], errors: str
+) -> Any:
     """
     This function extracts all the params from a given url string
     """
-
-    if not validate_url(url, report=False):
+    if not validate_url(url):
+        # values based on errors
         if split:
-            return None, None, None, None
+            return np.nan, np.nan, np.nan, np.nan
         else:
-            return {"scheme": None, "host": None, "cleaned_url": None, "queries": None}
+            if errors == "raise":
+                raise ValueError(f"Unable to parse value {url}")
+            return url if errors == "ignore" else np.nan
 
     # regex for finding the query / params and values
     re_queries = re.findall(QUERY_REGEX, url)
@@ -185,10 +186,10 @@ def get_url_params(url: str, split: bool, remove_auth: Union[bool, List[str]]) -
     if split:
         return scheme, host, cleaned_url, queries
     else:
-        return {"scheme": scheme, "host": host, "cleaned_url": cleaned_url, "queries": queries}
+        return {"scheme": scheme, "host": host, f"{column}_clean": cleaned_url, "queries": queries}
 
 
-def validate_url(x: Union[str, pd.Series], report: bool = True) -> Union[bool, pd.Series]:
+def validate_url(x: Union[str, pd.Series]) -> Union[bool, pd.Series]:
     """
     This function validates url
     Parameters
@@ -197,10 +198,7 @@ def validate_url(x: Union[str, pd.Series], report: bool = True) -> Union[bool, p
         pandas Series of urls or url instance
     """
     if isinstance(x, pd.Series):
-        reset_stats()
         verfied_series = x.apply(check_url)
-        if report:
-            report_url(stats=STATS, nrows=x.size, validate=True)
         return verfied_series
     else:
         return check_url(x)
@@ -211,43 +209,83 @@ def check_url(val: Union[str, Any]) -> Any:
     Function to check whether a value is a valid url
     """
     # check if the url is parsable
-    if not isinstance(val, str):
-
-        # check for null values
+    try:
         if val in NULL_VALUES:
+            if check_first():
+                # set first_val = 200, here 200 means incorrect_format
+                STATS["first_val"] = 200
             STATS["incorrect_format"] += 1
             return False
         # for non-string datatypes
         else:
             val = str(val)
 
-    val = unquote(val).replace(" ", "")
+        val = unquote(val).replace(" ", "")
 
-    if re.match(VALID_URL_REGEX, val):
-        STATS["correct_format"] += 1
-        return True
-    else:
+        if re.match(VALID_URL_REGEX, val):
+            if check_first():
+                # set first_val = 100, here 100 means incorrect_format
+                STATS["first_val"] = 100
+            STATS["correct_format"] += 1
+            return True
+        else:
+            if check_first():
+                # set first_val = 200, here 200 means incorrect_format
+                STATS["first_val"] = 200
+            STATS["incorrect_format"] += 1
+            return False
+    except TypeError:
+        if check_first():
+            # set first_val = 200, here 200 means incorrect_format
+            STATS["first_val"] = 200
         STATS["incorrect_format"] += 1
         return False
 
 
-def report_url(stats: Dict[str, int], nrows: int, validate: bool = False) -> None:
+def report_url(nrows: int, errors: str, split: bool, column: str) -> None:
     """
     This function displays the stats report
     """
-    if validate:
-        correct_format = stats["correct_format"]
-        incorrect_format = stats["incorrect_format"]
-        print(
-            f"{correct_format} rows ({((correct_format / nrows) * 100) : .2f} %) in correct format"
-        )
-        print(
-            f"{incorrect_format} rows ({((incorrect_format / nrows) * 100): .2f} %)  in incorrect format"
+    correct_format = (
+        STATS["correct_format"] - 1 if (STATS["first_val"] == 100) else STATS["correct_format"]
+    )
+    correct_format_percentage = (correct_format / nrows) * 100
+
+    incorrect_format = (
+        STATS["incorrect_format"] - 1 if (STATS["first_val"] == 200) else STATS["incorrect_format"]
+    )
+    incorrect_format_percentage = (incorrect_format / nrows) * 100
+
+    cleaned_queries = STATS["cleaned"]
+    rows = STATS["rows"]
+
+    rows_string = (
+        f"\nRemoved {cleaned_queries} auth queries from {rows} rows" if STATS["rows"] > 0 else ""
+    )
+    set_to = "NaN" if (errors == "coerce" or split) else "their original values"
+    result_null = "null values" if (errors == "coerce" or split) else "null / not parsable values"
+
+    if split:
+        result = (
+            f"Result contains parsed values for {correct_format}"
+            f"({(correct_format / nrows) * 100 :.2f} %) rows and {incorrect_format} {result_null}"
+            f"({(incorrect_format / nrows) * 100:.2f} %)."
         )
     else:
-        cleaned_queries = stats["cleaned"]
-        rows = stats["rows"]
-        print(f"Removed {cleaned_queries} auth queries from {rows} rows")
+        result = (
+            f"Result contains parsed key-value pairs for {correct_format} "
+            f"({(correct_format / nrows) * 100 :.2f} %) rows (stored in column `{column}_details`) and {incorrect_format} {result_null}"
+            f"({(incorrect_format / nrows) * 100:.2f} %)."
+        )
+
+    print(
+        f"""
+Url Cleaning report:
+        {correct_format} values parsed ({correct_format_percentage:.2f} %)
+        {incorrect_format} values unable to be parsed ({incorrect_format_percentage:.2f} %), set to {set_to} {rows_string}
+{result}
+        """
+    )
 
 
 def reset_stats() -> None:
@@ -258,3 +296,17 @@ def reset_stats() -> None:
     STATS["rows"] = 0
     STATS["correct_format"] = 0
     STATS["incorrect_format"] = 0
+    STATS["first_val"] = 0
+
+
+def check_first() -> bool:
+    """
+    Dask runs 2 times for the first value (hence the first value is counted twice),
+    this function checks whether the value we are parsing is the first value,
+    after we find the first value we check whether it is in the correct form or incorrect form
+    we then set STATS["first_val"] according to the following convention
+    100 is the code for correct form and 200 is the code for the incorrect form
+    we will use this value (STATS["first_val"] == 100 or STATS["first_val"] == 200) in our stats
+    report to compensate for the overcounting of the first value by reducing the value.
+    """
+    return STATS["correct_format"] == 0 and STATS["incorrect_format"] == 0


### PR DESCRIPTION
# Description

Fix issue #402.

Add `errors` parameter to the `clean_url` function and enhance the report based upon the errors parameter.
When `errors == ignore` we keep the original values and when `errors==coerce` we replace the values with `np.nan`. In the screenshot below we can see the changes in the wording of the report based on the `errors` parameter (**underlined in red**).

![Screen Shot 2020-10-28 at 11 04 07 PM](https://user-images.githubusercontent.com/59293179/97532946-9ca6a600-1974-11eb-9897-0a7578f3ee42.png)


# How Has This Been Tested?
This function was tested on the following dataset, which also includes non-parable / non-hashable values.

![Screen Shot 2020-10-28 at 11 23 59 PM](https://user-images.githubusercontent.com/59293179/97532983-a9c39500-1974-11eb-885f-fcf8efcfc839.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
