### PR TITLE
feat(connector):from_key parameter validation

### DIFF
--- a/dataprep/connector/config_manager.py
+++ b/dataprep/connector/config_manager.py
@@ -1,13 +1,14 @@
 """
 Functions for config downloading and maintaining
 """
+import json
 from json import dump as jdump
 from pathlib import Path
 from shutil import rmtree
 from tempfile import gettempdir
 from typing import cast
 
-import requests
+from .utils import Request
 
 META_URL = "https://raw.githubusercontent.com/sfu-db/DataConnectorConfigs/master/{}/_meta.json"
 TABLE_URL = "https://raw.githubusercontent.com/sfu-db/DataConnectorConfigs/master/{}/{}.json"
@@ -61,7 +62,10 @@ def get_git_master_hash() -> str:
     """
     Get current config files repo's hash
     """
-    refs = requests.get(GIT_REF_URL).json()
+    requests = Request(GIT_REF_URL)
+    response = requests.get()
+    refs = json.loads(response.read())
+
     (sha,) = [ref["object"]["sha"] for ref in refs if ref["ref"] == "refs/heads/master"]
     return cast(str, sha)
 
@@ -70,8 +74,9 @@ def download_config(impdb: str) -> None:
     """
     Download the config from Github into the temp directory.
     """
-    url = META_URL.format(impdb)
-    meta = requests.get(url).json()
+    requests = Request(META_URL.format(impdb))
+    response = requests.get()
+    meta = json.loads(response.read())
     tables = meta["tables"]
 
     sha = get_git_master_hash()
@@ -79,8 +84,9 @@ def download_config(impdb: str) -> None:
     while True:
         configs = {"_meta": meta}
         for table in tables:
-            url = TABLE_URL.format(impdb, table)
-            config = requests.get(url).json()
+            requests = Request(TABLE_URL.format(impdb, table))
+            response = requests.get()
+            config = json.loads(response.read())
             configs[table] = config
         sha_check = get_git_master_hash()
 
@@ -95,9 +101,9 @@ def download_config(impdb: str) -> None:
         rmtree(path / impdb)
 
     (path / impdb).mkdir(parents=True)
-    for fname, json in configs.items():
+    for fname, val in configs.items():
         with (path / impdb / f"{fname}.json").open("w") as f:
-            jdump(json, f)
+            jdump(val, f)
 
     with (path / impdb / "_hash").open("w") as f:
         f.write(sha)

--- a/dataprep/connector/connector.py
+++ b/dataprep/connector/connector.py
@@ -5,7 +5,7 @@ Every data fetching action should begin with instantiating this Connector class.
 import math
 import sys
 from asyncio import as_completed
-from typing import Any, Awaitable, Dict, Optional, Tuple, Union
+from typing import Any, Awaitable, Dict, Optional, Tuple, Union, Set
 from warnings import warn
 
 import pandas as pd
@@ -18,6 +18,8 @@ from .errors import InvalidParameterError, RequestError, UniversalParameterOverr
 from .implicit_database import ImplicitDatabase, ImplicitTable
 from .ref import Ref
 from .schema import (
+    ConfigDef,
+    FieldDef,
     FieldDefUnion,
     OffsetPaginationDef,
     PagePaginationDef,
@@ -112,7 +114,19 @@ class Connector:  # pylint: disable=too-many-instance-attributes
         **where
             The additional parameters required for the query.
         """
-        allowed_params = self._impdb.tables[table].config.request.params
+        allowed_params: Set[str] = set()
+
+        for key, val in self._impdb.tables[table].config.request.params.items():
+            if isinstance(val, FieldDef):
+                if isinstance(val.from_key, list):
+                    allowed_params.update(val.from_key)
+                elif isinstance(val.from_key, str):
+                    allowed_params.add(val.from_key)
+                else:
+                    allowed_params.add(key)
+            else:
+                allowed_params.add(key)
+
         for key in where:
             if key not in allowed_params:
                 raise InvalidParameterError(key)
@@ -399,20 +413,19 @@ def validate_fields(fields: Dict[str, FieldDefUnion], data: Dict[str, Any]) -> N
     """Check required fields are provided."""
 
     for key, def_ in fields.items():
-        from_key, to_key = key, key
+        to_key = key
 
         if isinstance(def_, bool):
             required = def_
             if required and to_key not in data:
-                raise KeyError(f"'{from_key}' is required but not provided")
+                raise KeyError(f"'{to_key}' is required but not provided")
         elif isinstance(def_, str):
             pass
         else:
             to_key = def_.to_key or to_key
-            from_key = def_.from_key or from_key
             required = def_.required
             if required and to_key not in data:
-                raise KeyError(f"'{from_key}' is required but not provided")
+                raise KeyError(f"'{to_key}' is required but not provided")
 
 
 def populate_field(  # pylint: disable=too-many-branches
@@ -438,7 +451,8 @@ def populate_field(  # pylint: disable=too-many-branches
             template = def_.template
             remove_if_empty = def_.remove_if_empty
             to_key = def_.to_key or to_key
-            from_key = def_.from_key or from_key
+            if not isinstance(def_.from_key, list):
+                from_key = def_.from_key or from_key
 
             if template is None:
                 value = params.get(from_key)

--- a/dataprep/connector/connector.py
+++ b/dataprep/connector/connector.py
@@ -5,7 +5,7 @@ Every data fetching action should begin with instantiating this Connector class.
 import math
 import sys
 from asyncio import as_completed
-from typing import Any, Awaitable, Dict, Optional, Tuple, Union, Set
+from typing import Any, Awaitable, Dict, Optional, Set, Tuple, Union
 from warnings import warn
 
 import pandas as pd
@@ -16,9 +16,9 @@ from jsonpath_ng import parse as jparse
 
 from .errors import InvalidParameterError, RequestError, UniversalParameterOverridden
 from .implicit_database import ImplicitDatabase, ImplicitTable
+from .info import info, initialize_path
 from .ref import Ref
 from .schema import (
-    ConfigDef,
     FieldDef,
     FieldDefUnion,
     OffsetPaginationDef,
@@ -28,7 +28,6 @@ from .schema import (
     TokenPaginationDef,
 )
 from .throttler import OrderedThrottler, ThrottleSession
-from .info import info, initialize_path
 
 
 class Connector:  # pylint: disable=too-many-instance-attributes
@@ -437,10 +436,10 @@ def populate_field(  # pylint: disable=too-many-branches
     ret: Dict[str, str] = {}
 
     for key, def_ in fields.items():
-        from_key, to_key = key, key
+        to_key = key
 
         if isinstance(def_, bool):
-            value = params.get(from_key)
+            value = params.get(to_key)
             remove_if_empty = False
         elif isinstance(def_, str):
             # is a template
@@ -451,11 +450,9 @@ def populate_field(  # pylint: disable=too-many-branches
             template = def_.template
             remove_if_empty = def_.remove_if_empty
             to_key = def_.to_key or to_key
-            if not isinstance(def_.from_key, list):
-                from_key = def_.from_key or from_key
 
             if template is None:
-                value = params.get(from_key)
+                value = params.get(to_key)
             else:
                 tmplt = jenv.from_string(template)
                 try:

--- a/dataprep/connector/utils.py
+++ b/dataprep/connector/utils.py
@@ -1,0 +1,95 @@
+"""
+This module contains common utilities used by the connector
+"""
+from typing import Any, Dict, Optional
+import http.client
+import urllib.parse
+
+
+class Request:
+    """
+    Provides a wrapper for the python http.client,
+    to be used similar to the requests library.
+
+    Parameters
+    ----------
+    _url: The requesting end-point URL.
+    """
+
+    def __init__(self, _url: str) -> None:
+        self.url: urllib.parse.ParseResult = urllib.parse.urlparse(_url)
+        self.hostname: str = self.url.hostname or ""
+        self.path: str = self.url.path or ""
+        self.headers: Dict[str, Any] = dict({"user-agent": "dataprep"})
+
+    def get(self, _headers: Optional[Dict[str, Any]] = None) -> http.client.HTTPResponse:
+        """
+        GET request to the specified end-point.
+
+        Parameters
+        ----------
+        _headers: Any additional headers to be passed
+        """
+        if _headers:
+            self.headers.update(_headers)
+
+        conn = http.client.HTTPSConnection(self.hostname)
+
+        conn.request(method="GET", url=self.path, headers=self.headers)
+        response = conn.getresponse()
+
+        return response
+
+    def post(
+        self, _headers: Optional[Dict[str, Any]] = None, _data: Optional[Dict[str, Any]] = None
+    ) -> http.client.HTTPResponse:
+        """
+        POST request to the specified end-point.
+
+        Parameters
+        ----------
+        _headers: Any additional headers to be passed
+        _data: Body of the request
+        """
+        if _headers:
+            self.headers.update(_headers)
+        conn = http.client.HTTPSConnection(self.hostname)
+        if _data is not None:
+            conn.request(
+                method="POST",
+                url=self.path,
+                headers=self.headers,
+                body=urllib.parse.urlencode(_data),
+            )
+        else:
+            conn.request(method="POST", url=self.path, headers=self.headers)
+        response = conn.getresponse()
+
+        return response
+
+    def put(
+        self, _headers: Optional[Dict[str, Any]] = None, _data: Optional[Dict[str, Any]] = None
+    ) -> http.client.HTTPResponse:
+        """
+        PUT request to the specified end-point.
+
+        Parameters
+        ----------
+        _headers: Any additional headers to be passed
+        _data: Body of the request
+        """
+        if _headers:
+            self.headers.update(_headers)
+        conn = http.client.HTTPSConnection(self.hostname)
+        if _data is not None:
+            conn.request(
+                method="PUT",
+                url=self.path,
+                headers=self.headers,
+                body=urllib.parse.urlencode(_data),
+            )
+        else:
+            conn.request(method="PUT", url=self.path, headers=self.headers)
+        response = conn.getresponse()
+
+        return response

--- a/dataprep/tests/connector/test_integration.py
+++ b/dataprep/tests/connector/test_integration.py
@@ -5,6 +5,7 @@ import pytest
 
 from ...connector import Connector
 from ...utils import display_dataframe
+from ...connector.utils import Request
 
 
 @pytest.mark.skipif(
@@ -43,3 +44,24 @@ def test_query_params() -> None:
     df = asyncio.run(dc.query("videos", q="covid", part="snippet"))
 
     assert len(df) != 0
+
+
+def test_requests() -> None:
+    # GET request
+    req1 = Request("https://www.python.org/")
+    get_resp = req1.get()
+    assert get_resp.status == 200
+
+    # POST request
+    params = {"@number": 12524, "@type": "issue", "@action": "show"}
+    headers = {"Content-type": "application/x-www-form-urlencoded", "Accept": "text/plain"}
+    req2 = Request("https://bugs.python.org/")
+    post_resp = req2.post(_data=params, _headers=headers)
+    assert post_resp.status == 302
+
+    # PUT request
+    params = {"@number": 12524, "@type": "issue", "@action": "show"}
+    headers = {"Content-type": "application/x-www-form-urlencoded", "Accept": "text/plain"}
+    req3 = Request("https://bugs.python.org/")
+    put_resp = req3.put(_data=params, _headers=headers)
+    assert put_resp.status == 302


### PR DESCRIPTION
The PR is addressing two issues:

### **1. Parameter validation for template params:**
Parameter checking happens in dataprep `connector.py` where we check for keys in `allowed_params`. This check had to include the `from_key` to accommodate for the template params.

_Also Fixed_: Finnhub config files had the template keys mentioned differently (the `fromKey` was being passed as part of the query). This has been fixed now on the DataConnector repo along with the corresponding changes in the DBLP config files. [Needs merge of the [corresponding PR in the Data Connector repo](https://github.com/sfu-db/DataConnectorConfigs/pull/50).]

**Testing**:
`fromKey` tested in both DBLP and Finnhub.
The following was throwing an error because `first_name` and `last_name` are not directly specified as params in the config file.
`df = await dc.query("publication", first_name="Jian", last_name="Pei")`

![Selection_050](https://user-images.githubusercontent.com/17384838/95693418-20286f00-0be1-11eb-9e98-f7fa61f2bad5.png)

**Consequence**:
In the config files, the `fromKey` in the template param `FieldDef` is now to be specified as a `List` instead of `string` containing all the params the template needs.
Ex:
`
"fromKey": ["first_name", "last_name"]
`
Note: Single parameter for template should have the key specified an array of one element.

---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
### **2. Reducing Dependency on Requests Library** [#396]:
Replacing the python requests library with our own implementation serving as a wrapper around the standard `http.client` library

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
