### PR TITLE
feat(connector): Improve info

### DIFF
--- a/dataprep/connector/__init__.py
+++ b/dataprep/connector/__init__.py
@@ -4,8 +4,15 @@ from typing import Any, Dict, Optional
 
 from .connector import Connector
 from .generator import ConfigGenerator, ConfigGeneratorUI
+from .info import info
 
-__all__ = ["Connector", "ConfigGenerator", "ConfigGeneratorUI", "connect"]
+__all__ = [
+    "Connector",
+    "ConfigGenerator",
+    "ConfigGeneratorUI",
+    "connect",
+    "info",
+]
 
 
 def connect(

--- a/dataprep/connector/assets/info.html
+++ b/dataprep/connector/assets/info.html
@@ -1,0 +1,114 @@
+<html>
+    <head>
+        <title> DataPrep.Connector Info </title>
+        <script>
+            function switchTab637(e) {
+                const selectedAreaSuffix = e.parentElement.parentElement.className.split('-')[1];
+                const selectedTabId = e.id.split('-')[2];
+                const selectedTabContent = document.querySelector(`.contents-${selectedAreaSuffix}>div:nth-of-type(${selectedTabId})`);
+                const contentArray = document.getElementsByClassName('info-637')
+                for (let i of contentArray) {
+                    i.style.display = 'none';
+                }
+                selectedTabContent.style.display = 'block';
+            }
+        </script>
+        <style>
+            .container-637 {
+            }
+            .container-637 input[type=radio] {
+            display: none;
+            }
+            .tabs-637 {
+            font-family: -apple-system, 'Helvetica Neue', 'Helvetica', 'Arial', 'Lucida Grande', sans-serif;
+            -webkit-font-smoothing: antialiased;
+            display: grid;
+            flex-wrap: wrap;
+            gap: 5px;
+            grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+            justify-content: wrap;
+            }
+            .tabs-637 label {
+            word-wrap: break-word;
+            text-align: center;
+            font-size: 12px;
+            border-bottom: 2px solid #9edae5;
+            transition: border 0.3s ease;
+            }
+            .tabs-637 label:hover {
+            background: rgba(0, 0, 0, 0.1);
+            }
+            .tabs-637 input:checked+label {
+            border-bottom: 2px solid #1f77b4;
+            }
+            .contents-637>div:nth-of-type(n+2) {
+            display: none;
+            }
+            h4 {
+            font-size: 14px;
+            font-family: Arial;
+            }
+            p {
+            font-size: 13px;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="container-637">
+            <div class="tabs-637">
+                <input type="radio" name="select" id='tab-637-1' checked onclick="switchTab637(this)">
+                <label for="tab-637-1">{{ tbs | first }}</label>
+                {% for tb in tbs %}
+                {% set tab_id = 'tab-637-' + loop.index|string %}
+                {% if loop.index != 1 %}          
+                <input type="radio" name="select" id={{ tab_id }}  onclick="switchTab637(this)">
+                <label for={{ tab_id }}>{{ tb }}</label>
+                {% endif %}
+                {% endfor %}    		
+            </div>
+            <div class="contents-637">
+                {% for tb in tbs %}
+                <div class="info-637">
+                    <div>
+                        <h4><u>Parameters</u></h4>
+                        {% if tbs[tb].required_params%}
+                        {% for required_param in tbs[tb].required_params %}
+                        <p style="display:wrap"><code>{{ required_param }} (required)</code></p>
+                        {% endfor %}
+                        {% endif %}
+                        {% if tbs[tb].optional_params%}
+                        {% for optional_param in tbs[tb].optional_params %}
+                        <p style="display:wrap"><code>{{ optional_param }}</code></p>
+                        {% endfor %}
+                        {% endif %}
+                        {% if not (tbs[tb].required_params or tbs[tb].optional_params)%}
+                        <p>None</p>
+                        {% endif %}
+                    </div>
+                    <div>
+                        <h4><u>Example</u></h4>
+                        {% set connect_example = "dc = connect('" + dbname + "'" %}
+                        {% if tbs[tb].joined_auth_params %}
+                        {% set connect_example = connect_example + ", _auth={'" + tbs[tb].joined_auth_params[0] + "}, _concurrency=3)" %}
+                        {% else %}
+                        {% set connect_example = connect_example + ")" %}
+                        {% endif %}
+                        {% set query_example = "df = await dc.query('" + tb + "'" %}
+                        {% if tbs[tb].joined_query_fields%}
+                        {% set query_example = query_example + ", " + tbs[tb].joined_query_fields[0] %}
+                        {% endif %}
+                        {% if tbs[tb].count == True %}
+                        {% set query_example = query_example + ", _count=20" %}
+                        {% endif %}
+                        {% set query_example = query_example + ")" %}
+                        <p><code>{{ connect_example }}<br>{{ query_example }}</code></p>
+                    </div>
+                    <div>
+                    	<h4><u>Schema</u></h4>
+                    	{{ tbs[tb].schemas }}
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </body>

--- a/dataprep/connector/connector.py
+++ b/dataprep/connector/connector.py
@@ -5,22 +5,19 @@ Every data fetching action should begin with instantiating this Connector class.
 import math
 import sys
 from asyncio import as_completed
-from pathlib import Path
-from typing import Any, Awaitable, Dict, List, Optional, Tuple, Union
+from typing import Any, Awaitable, Dict, Optional, Tuple, Union
 from warnings import warn
 
 import pandas as pd
 from aiohttp import ClientSession
 from aiohttp.client_reqrep import ClientResponse
-from jinja2 import Environment, StrictUndefined, Template, UndefinedError
+from jinja2 import Environment, StrictUndefined, UndefinedError
 from jsonpath_ng import parse as jparse
 
-from .config_manager import config_directory, ensure_config
 from .errors import InvalidParameterError, RequestError, UniversalParameterOverridden
 from .implicit_database import ImplicitDatabase, ImplicitTable
 from .ref import Ref
 from .schema import (
-    ConfigDef,
     FieldDefUnion,
     OffsetPaginationDef,
     PagePaginationDef,
@@ -29,26 +26,10 @@ from .schema import (
     TokenPaginationDef,
 )
 from .throttler import OrderedThrottler, ThrottleSession
-
-INFO_TEMPLATE = Template(
-    """{% for tb in tbs.keys() %}
-Table {{dbname}}.{{tb}}
-
-Parameters
-----------
-{% if tbs[tb].required_params %}{{", ".join(tbs[tb].required_params)}} required {% endif %}
-{% if tbs[tb].optional_params %}{{", ".join(tbs[tb].optional_params)}} optional {% endif %}
-
-Examples
---------
->>> dc.query({{", ".join(["\\\"{}\\\"".format(tb)] + tbs[tb].joined_query_fields)}})
->>> dc.show_schema("{{tb}}")
-{% endfor %}
-"""
-)
+from .info import info, initialize_path
 
 
-class Connector:
+class Connector:  # pylint: disable=too-many-instance-attributes
     """This is the main class of the connector component.
     Initialize Connector class as the example code.
 
@@ -79,6 +60,7 @@ class Connector:
     # storage for authorization
     _storage: Dict[str, Any]
     _concurrency: int
+    _update: bool
     _jenv: Environment
 
     def __init__(
@@ -90,16 +72,7 @@ class Connector:
         _concurrency: int = 1,
         **kwargs: Any,
     ) -> None:
-        if (
-            config_path.startswith(".")
-            or config_path.startswith("/")
-            or config_path.startswith("~")
-        ):
-            path = Path(config_path).resolve()
-        else:
-            # From Github!
-            ensure_config(config_path, update)
-            path = config_directory() / config_path
+        path = initialize_path(config_path, update)
 
         self._impdb = ImplicitDatabase(path)
 
@@ -107,6 +80,7 @@ class Connector:
         self._auth = _auth or {}
         self._storage = {}
         self._concurrency = _concurrency
+        self._update = update
         self._jenv = Environment(undefined=StrictUndefined)
         self._throttler = OrderedThrottler(_concurrency)
 
@@ -145,74 +119,10 @@ class Connector:
 
         return await self._query_imp(table, where, _auth=_auth, _q=_q, _count=_count)
 
-    @property
-    def table_names(self) -> List[str]:
-        """
-        Return all the names of the available tables in a list.
-
-        Note
-        ----
-        We abstract each website as a database containing several tables.
-        For example in Spotify, we have artist and album table.
-        """
-        return list(self._impdb.tables.keys())
-
     def info(self) -> None:
         """Show the basic information and provide guidance for users
         to issue queries."""
-
-        # get info
-        tbs: Dict[str, Any] = {}
-        for cur_table in self._impdb.tables:
-            table_config_content: ConfigDef = self._impdb.tables[cur_table].config
-            params_required = []
-            params_optional = []
-            example_query_fields = []
-            count = 1
-            for k, val in table_config_content.request.params.items():
-                if isinstance(val, bool) and val:
-                    params_required.append(k)
-                    example_query_fields.append(f"""{k}="word{count}\"""")
-                    count += 1
-                elif isinstance(val, bool):
-                    params_optional.append(k)
-            tbs[cur_table] = {}
-            tbs[cur_table]["required_params"] = params_required
-            tbs[cur_table]["optional_params"] = params_optional
-            tbs[cur_table]["joined_query_fields"] = example_query_fields
-
-        # show table info
-        print(INFO_TEMPLATE.render(ntables=len(self.table_names), dbname=self._impdb.name, tbs=tbs))
-
-    def show_schema(self, table_name: str) -> pd.DataFrame:
-        """This method shows the schema of the table that will be returned,
-        so that the user knows what information to expect.
-
-        Parameters
-        ----------
-        table_name
-            The table name.
-
-        Returns
-        -------
-        pd.DataFrame
-            The returned data's schema.
-
-        Note
-        ----
-        The schema is defined in the configuration file.
-        The user can either use the default one or change it by editing the configuration file.
-        """
-        print(f"table: {table_name}")
-        table_config_content: ConfigDef = self._impdb.tables[table_name].config
-        schema = table_config_content.response.schema_
-        new_schema_dict: Dict[str, List[Any]] = {}
-        new_schema_dict["column_name"] = []
-        new_schema_dict["data_type"] = []
-        for k in schema.keys():
-            new_schema_dict["column_name"].append(k)
-            new_schema_dict["data_type"].append(schema[k].type)
-        return pd.DataFrame.from_dict(new_schema_dict)
+        info(self._impdb.name)
 
     async def _query_imp(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         self,

--- a/dataprep/connector/info.py
+++ b/dataprep/connector/info.py
@@ -1,0 +1,126 @@
+"""This module contains back end functions helping developers use data connector."""
+from pathlib import Path
+from typing import Any, Dict, List
+import pandas as pd
+from .implicit_database import ImplicitDatabase
+from .schema import ConfigDef
+from .config_manager import config_directory, ensure_config
+from .info_ui import info_ui
+from ..utils import get_styled_schema
+
+GIT_REF_URL = "https://api.github.com/repos/sfu-db/DataConnectorConfigs/contents"
+
+
+def info(config_path: str, update: bool = False) -> None:  # pylint: disable=too-many-locals
+    """Show the basic information and provide guidance for users
+    to issue queries.
+
+    Parameters
+    ----------
+    config_path
+        The path to the config. It can be hosted, e.g. "yelp", or from
+        local filesystem, e.g. "./yelp"
+    update
+        Force update the config file even if the local version exists.
+    """
+
+    path = initialize_path(config_path, update)
+    impdb = ImplicitDatabase(path)
+
+    # get info
+    tbs: Dict[str, Any] = {}
+    for cur_table in impdb.tables:
+        table_config_content: ConfigDef = impdb.tables[cur_table].config
+
+        joined_auth_params = []
+        required_params = []
+        optional_params = []
+        examples = []
+        example_query_fields = []
+        count = False
+        required_param_count = 1
+        auth = table_config_content.request.authorization
+        config_examples = table_config_content.examples
+
+        if auth is None:
+            pass
+        elif auth.type == "OAuth2":
+            joined_auth_params.append(
+                "client_id':'QNf0IeGSeMq3K*********NIU9mfHFMfX3cYe'"
+                + " , "
+                + "'client_secret':'eeNspLqiRoVfX*********3V2ntIiXKui9A6X'"
+            )
+        else:
+            joined_auth_params.append("access_token':'cCMHU4M4t7rdt*********vp3whGzFjgIKIm0'")
+
+        for k, val in table_config_content.request.params.items():
+            if isinstance(val, bool) and val:
+                required_params.append(k)
+                if config_examples:
+                    examples.append(k + "=" + config_examples[k])
+                required_param_count += 1
+            elif isinstance(val, bool):
+                optional_params.append(k)
+
+        separator = ", "
+
+        if examples:
+            example_query_fields.append(separator.join(examples))
+
+        if table_config_content.request.pagination is not None:
+            count = True
+
+        schema = get_schema(table_config_content.response.schema_)
+        styled_schema = get_styled_schema(schema)
+
+        tbs[cur_table] = {}
+        tbs[cur_table]["joined_auth_params"] = joined_auth_params
+        tbs[cur_table]["required_params"] = required_params
+        tbs[cur_table]["optional_params"] = optional_params
+        tbs[cur_table]["joined_query_fields"] = example_query_fields
+        tbs[cur_table]["count"] = count
+        tbs[cur_table]["schemas"] = styled_schema
+
+    # show table info
+    info_ui(impdb.name, tbs)
+
+
+def initialize_path(config_path: str, update: bool) -> Path:
+    """Determines if the given config_path is local or in GitHub.
+    Fetches the full path."""
+    if config_path.startswith(".") or config_path.startswith("/") or config_path.startswith("~"):
+        path = Path(config_path).resolve()
+    else:
+        # From GitHub!
+        ensure_config(config_path, update)
+        path = config_directory() / config_path
+    return path
+
+
+def get_schema(schema: Dict[str, Any]) -> pd.DataFrame:
+    """This method returns the schema of the table that will be returned,
+    so that the user knows what information to expect.
+
+    Parameters
+    ----------
+    schema
+        The schema for the table from the config file.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The returned data's schema.
+
+    Note
+    ----
+    The schema is defined in the configuration file.
+    The user can either use the default one or change it by editing the configuration file.
+    """
+    new_schema_dict: Dict[str, List[Any]] = {}
+    new_schema_dict["column_name"] = []
+    new_schema_dict["data_type"] = []
+    for k in schema.keys():
+        new_schema_dict["column_name"].append(k)
+        new_schema_dict["data_type"].append(schema[k].type)
+
+    return pd.DataFrame.from_dict(new_schema_dict)

--- a/dataprep/connector/info_ui.py
+++ b/dataprep/connector/info_ui.py
@@ -1,0 +1,26 @@
+"""This module handles displaying information on how to connect and query."""
+from typing import Any, Dict
+from jinja2 import Environment, PackageLoader, select_autoescape
+from ..utils import display_html
+
+LOADER = PackageLoader("dataprep", "connector/assets")
+ENV_LOADER = Environment(loader=LOADER, autoescape=select_autoescape("html"))
+
+
+def info_ui(dbname: str, tbs: Dict[str, Any]) -> None:
+    """Fills out info.txt template file. Renders the template to an html file.
+
+    Parameters
+    ----------
+    dbname
+        Name of the website
+    tbs
+        Table containing info to be displayed.
+    """
+    template = ENV_LOADER.get_template("info.html")
+
+    jinja_vars = {"dbname": dbname, "tbs": tbs}
+
+    html_content = template.render(jinja_vars)
+
+    display_html(html_content)

--- a/dataprep/connector/schema/defs.py
+++ b/dataprep/connector/schema/defs.py
@@ -400,4 +400,5 @@ class ResponseDef(BaseDef):
 class ConfigDef(BaseDef):
     version: int = Field(1, const=True)
     request: RequestDef
+    examples: Optional[Dict[str, str]]
     response: ResponseDef

--- a/dataprep/tests/connector/test_integration.py
+++ b/dataprep/tests/connector/test_integration.py
@@ -19,10 +19,6 @@ def test_connector() -> None:
 
     dc.info()
 
-    schema = dc.show_schema("businesses")
-
-    assert len(schema) > 0
-
     df = asyncio.run(dc.query("businesses", _count=120, term="ramen", location="vancouver"))
 
     assert len(df) == 120

--- a/dataprep/utils.py
+++ b/dataprep/utils.py
@@ -1,5 +1,9 @@
 """Utility functions used by the whole library."""
 from typing import Any
+import webbrowser
+from tempfile import NamedTemporaryFile
+from IPython.core.display import display, HTML
+import pandas as pd
 
 
 def is_notebook() -> Any:
@@ -18,3 +22,44 @@ def is_notebook() -> Any:
         return False
     except (NameError, ImportError):
         return False
+
+
+def display_html(html_content: str) -> None:
+    """Writes HTML content to a file and displays in browser."""
+    if is_notebook():
+        display(HTML(html_content))
+    else:
+        with NamedTemporaryFile(suffix=".html", mode="w", delete=False) as tmpf:
+            tmpf.write(html_content)
+            tmpf.flush()
+            webbrowser.open_new_tab("file://" + tmpf.name)
+
+
+def get_styled_schema(df: pd.DataFrame) -> Any:
+    """Adds CSS styling to dataframe."""
+    styled_df = df.style.set_table_styles(
+        [
+            {
+                "selector": "th",
+                "props": [
+                    ("background", "white"),
+                    ("font-weight", "bold"),
+                    ("text-align", "right"),
+                    ("font-family", "arial"),
+                    ("font-size", "13"),
+                ],
+            },
+            {"selector": "td", "props": [("font-family", "arial")]},
+            {
+                "selector": "tr:nth-of-type(odd)",
+                "props": [("background", "#f5f5f5"), ("font-size", "13"), ("text-align", "right")],
+            },
+            {
+                "selector": "tr:nth-of-type(even)",
+                "props": [("background", "#white"), ("font-size", "13"), ("text-align", "right")],
+            },
+            {"selector": "tr:hover", "props": [("background-color", "e0f1ff")]},
+        ]
+    )
+
+    return styled_df.render()


### PR DESCRIPTION
# Description

Changes

- Added two ways to call info function:
    1. Dependent on Connector object
    2. Independent from Connector object
- Created function to style and display a dataframe in a browser

Issue: #386 

Motivation: Provide guidance for Jupyter and console users to call connect and query functions.

No new dependencies are required.

# How Has This Been Tested?

Ran info for each supported website config paths (local and remote) to make sure it works.
Only does not work for Spoonacular but this isn't an info function related issue. Spoonacular also doesn't work for connect.

How to call the functions:
- info('{website_name}', update = False)
- After creating a Connector object: dc.info()
- display_dataframe(df)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
