### PR TITLE
fix(eda.report):encoding and show issue

### DIFF
--- a/dataprep/eda/create_report/report.py
+++ b/dataprep/eda/create_report/report.py
@@ -1,10 +1,12 @@
 """
     This module implements the Report class.
 """
+import sys
 import webbrowser
 from typing import Optional
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from ...utils import is_notebook
 
 
 CELL_HEIGHT_OVERRIDE = """<style>
@@ -72,6 +74,27 @@ class Report:
 
         with NamedTemporaryFile(suffix=".html", delete=False) as tmpf:
             pass
-        with open(tmpf.name, "w") as file:
+        with open(tmpf.name, "w", encoding="utf-8") as file:
             file.write(self.report)
         webbrowser.open(f"file://{tmpf.name}", new=2)
+
+    def show(self) -> None:
+        """
+        Render the report. This is useful when calling plot in a for loop.
+        """
+        # if not called from notebook environment, ref to show_browser function.
+        if not is_notebook():
+            print(
+                "The plot will not show in a notebook environment, "
+                "please try 'show_browser' if you want to open it in browser",
+                file=sys.stderr,
+            )
+        try:
+            from IPython.display import (  # pylint: disable=import-outside-toplevel
+                HTML,
+                display,
+            )
+
+            display(HTML(self._repr_html_()))
+        except ImportError:
+            pass

--- a/dataprep/tests/eda/test_create_report.py
+++ b/dataprep/tests/eda/test_create_report.py
@@ -44,3 +44,14 @@ def test_report(simpledf: pd.DataFrame) -> None:
 
         matplotlib.use("PS")
     create_report(simpledf, mode="basic")
+
+
+def test_report_show(simpledf: pd.DataFrame) -> None:
+    from sys import platform
+
+    if platform == "darwin":
+        import matplotlib
+
+        matplotlib.use("PS")
+    report = create_report(simpledf, mode="basic")
+    report.show()


### PR DESCRIPTION
# Description

Fixes encoding issue for report.show_browser() and add report.show() function
I also add corresponding test for report.show()

# How Has This Been Tested?

manually

# Snapshots:
![image](https://user-images.githubusercontent.com/57878927/100498410-eca7a100-319c-11eb-92dc-697339071a07.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules