### PR TITLE
fix(eda): set encoding to utf-8 when file is opened

### DIFF
--- a/dataprep/eda/container.py
+++ b/dataprep/eda/container.py
@@ -67,7 +67,7 @@ class Container:
         """
         save function
         """
-        with open(filename, "w") as f:
+        with open(filename, "w", encoding="utf-8") as f:
             f.write(self.template_base.render(context=self.context))
 
     def _repr_html_(self) -> str:
@@ -107,7 +107,7 @@ class Container:
         # set delete = False to avoid early delete when user open multiple plots.
         with NamedTemporaryFile(suffix=".html", delete=False) as tmpf:
             pass
-        with open(tmpf.name, "w") as file:
+        with open(tmpf.name, "w", encoding="utf-8") as file:
             file.write(self.template_base.render(context=self.context))
         webbrowser.open_new_tab(f"file://{tmpf.name}")
 

--- a/dataprep/eda/create_report/report.py
+++ b/dataprep/eda/create_report/report.py
@@ -63,7 +63,7 @@ class Report:
         if not path.is_dir():
             raise ValueError("The second parameter is not a valid path.")
 
-        with open(path / f"{filename}.html", "w") as file:
+        with open(path / f"{filename}.html", "w", encoding="utf-8") as file:
             file.write(self.report)
         print(f"Report has been saved to {path}/{filename}.html!")
 


### PR DESCRIPTION
# Description

Set encoding="utf-8" in all instances that we open a file in dataprep.eda.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
