### PR TITLE
feat(clean): add clean_headers function

### DIFF
--- a/dataprep/clean/__init__.py
+++ b/dataprep/clean/__init__.py
@@ -15,6 +15,8 @@ from .clean_phone import clean_phone, validate_phone
 
 from .clean_ip import clean_ip, validate_ip
 
+from .clean_headers import clean_headers
+
 
 __all__ = [
     "clean_lat_long",
@@ -29,4 +31,5 @@ __all__ = [
     "validate_phone",
     "clean_ip",
     "validate_ip",
+    "clean_headers",
 ]

--- a/dataprep/clean/clean_headers.py
+++ b/dataprep/clean/clean_headers.py
@@ -1,0 +1,246 @@
+"""
+Clean and standardize column headers for a DataFrame.
+"""
+import re
+from typing import Any, Optional, Union, List, Dict
+from unicodedata import normalize
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+
+NULL_VALUES = {np.nan, "", None}
+
+CASE_STYLES = {
+    "snake",
+    "kebab",
+    "camel",
+    "pascal",
+    "const",
+    "sentence",
+    "title",
+    "lower",
+    "upper",
+}
+
+
+def clean_headers(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    case: str = "snake",
+    replace: Optional[Dict[str, str]] = None,
+    remove_accents: bool = True,
+    report: bool = True,
+) -> pd.DataFrame:
+    """
+    Function to clean column headers (column names).
+
+    Parameters
+    ----------
+    df
+        Dataframe from which column names are to be cleaned.
+
+    case
+        The desired case style of the column name.
+            - 'snake': 'column_name'
+            - 'kebab': 'column-name'
+            - 'camel': 'columnName'
+            - 'pascal': 'ColumnName'
+            - 'const': 'COLUMN_NAME'
+            - 'sentence': 'Column name'
+            - 'title': 'Column Name'
+            - 'lower': 'column name'
+            - 'upper': 'COLUMN NAME'
+
+        (default: 'snake')
+
+    replace
+        Values to replace in the column names.
+            - {"old_value": "new_value"}
+
+        (default: None)
+
+    remove_accents
+        If True, strip accents from the column names.
+
+        (default: True)
+
+    report
+        If True, output the summary report. Otherwise, no report is outputted.
+
+        (default: True)
+
+
+    Examples
+    --------
+    Clean column names by converting the names to camel case style, removing accents,
+    and correcting a mispelling.
+
+    >>> df = pd.DataFrame({"FirstNom":["Philip", "Turanga"], "lastName": ["Fry", "Leela"],
+                           "Téléphone":["555-234-5678", "(604) 111-2335"]})
+    >>> clean_headers(df, case='camel', replace={"Nom": "Name"})
+    Column Headers Cleaning Report:
+        2 values cleaned (66.67%)
+      firstName lastName       telephone
+    0    Philip      Fry    555-234-5678
+    1   Turanga    Leela  (604) 111-2335
+    """
+    if case not in CASE_STYLES:
+        raise ValueError(
+            f"case {case} is invalid, it needs to be one of {', '.join(c for c in CASE_STYLES)}"
+        )
+
+    # Store original column names for creating cleaning report
+    orig_columns = df.columns
+
+    if replace:
+        df = df.rename(columns=lambda col: _replace_values(col, replace))
+
+    if remove_accents:
+        df = df.rename(columns=_remove_accents)
+
+    df = df.rename(columns=lambda col: _convert_case(col, case))
+
+    df.columns = _rename_duplicates(df.columns, case)
+
+    # Count the number of changed column names
+    stats = {}
+    stats["cleaned"] = len(df.columns.astype(str).difference(orig_columns.astype(str)))
+
+    # Output a report describing the result of clean_headers
+    if report:
+        _create_report(stats, len(df.columns))
+
+    return df
+
+
+def _convert_case(name: Any, case: str) -> Any:
+    """
+    Convert case style of a column name.
+
+    Parameters
+    ----------
+    name
+        Column name.
+    case
+        The desired case style of the column name.
+    """
+    if name in NULL_VALUES:
+        name = "header"
+
+    if case in {"snake", "kebab", "camel", "pascal", "const"}:
+        words = _split_strip_string(str(name))
+    else:
+        words = _split_string(str(name))
+
+    if case == "snake":
+        name = "_".join(words).lower()
+    elif case == "kebab":
+        name = "-".join(words).lower()
+    elif case == "camel":
+        name = words[0].lower() + "".join(w.capitalize() for w in words[1:])
+    elif case == "pascal":
+        name = "".join(w.capitalize() for w in words)
+    elif case == "const":
+        name = "_".join(words).upper()
+    elif case == "sentence":
+        name = " ".join(words).capitalize()
+    elif case == "title":
+        name = " ".join(w.capitalize() for w in words)
+    elif case == "lower":
+        name = " ".join(words).lower()
+    elif case == "upper":
+        name = " ".join(words).upper()
+
+    return name
+
+
+def _split_strip_string(string: str) -> List[str]:
+    """
+    Split the string into separate words and strip punctuation
+    and special characters.
+    """
+    string = re.sub(r"[!()*+\,\-./:;<=>?[\]^_{|}~]", " ", string)
+    string = re.sub(r"[\'\"\`]", "", string)
+
+    return re.sub(r"([A-Z][a-z]+)", r" \1", re.sub(r"([A-Z]+|[0-9]+|\W+)", r" \1", string)).split()
+
+
+def _split_string(string: str) -> List[str]:
+    """
+    Split the string into separate words.
+    """
+    string = re.sub(r"[\-_]", " ", string)
+
+    return re.sub(r"([A-Z][a-z]+)", r" \1", re.sub(r"([A-Z]+)", r"\1", string)).split()
+
+
+def _replace_values(name: Any, mapping: Dict[str, str]) -> Any:
+    """
+    Replace string values in the column name.
+
+    Parameters
+    ----------
+    name
+        Column name.
+    mapping
+        Maps old values in the column name to the new values.
+    """
+    if name in NULL_VALUES:
+        return name
+
+    name = str(name)
+    for old_value, new_value in mapping.items():
+        # If the old value or the new value is not alphanumeric, add underscores to the
+        # beginning and end so the new value will be parsed correctly for _convert_case()
+        new_val = (
+            fr"{new_value}" if old_value.isalnum() and new_value.isalnum() else fr"_{new_value}_"
+        )
+        name = re.sub(fr"{old_value}", new_val, name, flags=re.IGNORECASE)
+
+    return name
+
+
+def _remove_accents(name: Any) -> Any:
+    """
+    Return the normal form for a Unicode string name using canonical
+    decomposition.
+    """
+    if not isinstance(name, str):
+        return name
+
+    return normalize("NFD", name).encode("ascii", "ignore").decode("ascii")
+
+
+def _rename_duplicates(names: pd.Index, case: str) -> Any:
+    """
+    Rename duplicated column names to append a number at the end.
+    """
+    if case in {"snake", "camel", "pascal", "const"}:
+        sep = "_"
+    elif case == "kebab":
+        sep = "-"
+    else:
+        sep = " "
+
+    names = list(names)
+    counts: Dict[str, int] = {}
+
+    for i, col in enumerate(names):
+        cur_count = counts.get(col, 0)
+        if cur_count > 0:
+            names[i] = f"{col}{sep}{cur_count}"
+        counts[col] = cur_count + 1
+
+    return names
+
+
+def _create_report(stats: Dict[str, int], ncols: int) -> None:
+    """
+    Describe what was done in the cleaning process.
+    """
+    print("Column Headers Cleaning Report:")
+    if stats["cleaned"] > 0:
+        nclnd = stats["cleaned"]
+        pclnd = round(nclnd / ncols * 100, 2)
+        print(f"\t{nclnd} values cleaned ({pclnd}%)")

--- a/docs/source/api_reference/dataprep.clean.rst
+++ b/docs/source/api_reference/dataprep.clean.rst
@@ -50,3 +50,11 @@ URLs
    :members:
    :undoc-members:
    :show-inheritance:
+   
+Column Headers
+--------------------------------------
+
+.. automodule:: dataprep.clean.clean_headers
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
# Description

Implements the `clean_headers()` function to clean column names. Design details are set out in #447.

# How Has This Been Tested?

See snapshots below.

# Snapshots:

## Functionality

<img width="565" alt="clean_headers" src="https://user-images.githubusercontent.com/55072906/106370604-6892a680-6310-11eb-8a02-535563333b87.png">

## Specify case style

Users can specify the case style using the `case` parameter:

<img width="546" alt="styles_1" src="https://user-images.githubusercontent.com/55072906/106370614-7a744980-6310-11eb-8d95-2a4a6f731917.png">

<img width="602" alt="styles_2" src="https://user-images.githubusercontent.com/55072906/106370616-7cd6a380-6310-11eb-95c0-d3405324ba7c.png">

<img width="604" alt="styles_3" src="https://user-images.githubusercontent.com/55072906/106370617-7f38fd80-6310-11eb-8127-4ee77088b752.png">

## Replace values

Users can specify values to replace in the column names by passing in a dictionary to the `replace` parameter:

<img width="578" alt="replace" src="https://user-images.githubusercontent.com/55072906/106370635-abed1500-6310-11eb-9843-654a6b7b1af1.png">

## Remove accents

Accents are automatically removed from column names:

<img width="518" alt="accents_1" src="https://user-images.githubusercontent.com/55072906/106370627-9a0b7200-6310-11eb-8d7f-305d90beaff3.png">

Removal of accents can be suppressed by setting `remove_accents=False`:

<img width="518" alt="accents_2" src="https://user-images.githubusercontent.com/55072906/106370629-9d9ef900-6310-11eb-94b2-1306a04567ed.png">

## Rename duplicated column names

Column names duplicated by calling `clean_headers()` are automatically renamed by appending a number to the end of the duplicated column name(s):

<img width="518" alt="duplicate_1" src="https://user-images.githubusercontent.com/55072906/106370649-ce7f2e00-6310-11eb-8e60-e220c2fe54e0.png">

The suffix used to append the number is inferred from the `case` type:

<img width="519" alt="duplicate_2" src="https://user-images.githubusercontent.com/55072906/106370652-da6af000-6310-11eb-8803-8929e5d89aa0.png">

## Real World Data

An example of `clean_headers()` called on the [FIFA 21 messy, raw dataset for cleaning/ exploring](https://www.kaggle.com/yagunnersya/fifa-21-messy-raw-dataset-for-cleaning-exploring) dataset:

<img width="802" alt="real_world_1" src="https://user-images.githubusercontent.com/55072906/106370678-43526800-6311-11eb-895e-c30e86999c15.png">

<img width="803" alt="real_world_2" src="https://user-images.githubusercontent.com/55072906/106370681-48afb280-6311-11eb-926d-9ce443120ada.png">

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have already squashed the commits and made the commit message conform to the project standard.
- [ ] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules