### PR TITLE
feat(connector): add functionality that lists supported websites

### DIFF
--- a/dataprep/connector/__init__.py
+++ b/dataprep/connector/__init__.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 
 from .connector import Connector
 from .generator import ConfigGenerator, ConfigGeneratorUI
-from .info import info
+from .info import info, websites
 
 __all__ = [
     "Connector",
@@ -12,6 +12,7 @@ __all__ = [
     "ConfigGeneratorUI",
     "connect",
     "info",
+    "websites",
 ]
 
 

--- a/dataprep/connector/info.py
+++ b/dataprep/connector/info.py
@@ -2,8 +2,9 @@
 from typing import Any, Dict, List
 
 import pandas as pd
+from IPython.display import display
 
-from ..utils import get_styled_schema
+from ..utils import get_styled_schema, is_notebook
 from .implicit_database import ImplicitDatabase
 from .info_ui import info_ui
 from .schema import ConfigDef
@@ -111,3 +112,35 @@ def get_schema(schema: Dict[str, Any]) -> pd.DataFrame:
         new_schema_dict["data_type"].append(schema[k].type)
 
     return pd.DataFrame.from_dict(new_schema_dict)
+
+
+def websites() -> None:
+    """Displays names of websites supported by data connector."""
+    websites = {
+        "business": ["yelp"],
+        "finance": ["finnhub"],
+        "geocoding": ["mapquest"],
+        "lifestyle": ["spoonacular"],
+        "music": ["musixmatch", "spotify"],
+        "news": ["guardian", "times"],
+        "science": ["dblp"],
+        "shopping": ["etsy"],
+        "social": ["twitch", "twitter"],
+        "video": ["youtube"],
+        "weather": ["openweathermap"],
+    }
+
+    supported_websites = pd.DataFrame.from_dict(websites, orient="index")
+    supported_websites = supported_websites.transpose()
+    supported_websites.columns = supported_websites.columns.str.upper()
+
+    # replace "None" values with empty string
+    mask = supported_websites.applymap(lambda x: x is None)
+    cols = supported_websites.columns[(mask).any()]
+    for col in supported_websites[cols]:
+        supported_websites.loc[mask[col], col] = ""
+
+    if is_notebook():
+        display(supported_websites)
+    else:
+        print(supported_websites.to_string(index=False))

--- a/dataprep/tests/connector/test_integration.py
+++ b/dataprep/tests/connector/test_integration.py
@@ -3,7 +3,7 @@ from os import environ
 import asyncio
 import pytest
 
-from ...connector import Connector
+from ...connector import Connector, websites
 from ...utils import display_dataframe
 from ...connector.utils import Request
 
@@ -18,6 +18,8 @@ def test_connector() -> None:
     df = asyncio.run(dc.query("businesses", term="ramen", location="vancouver"))
 
     assert len(df) > 0
+
+    websites()
 
     dc.info()
 


### PR DESCRIPTION
# Description

Created a websites function so users can see supported websites to use for info and connect functions.

# How Has This Been Tested?

Ran the following code in Jupyter and Eclipse to verify actual output is expected output for Jupyter and terminal.

from dataprep.connector import websites
websites()

# Snapshots:

![image](https://user-images.githubusercontent.com/35017006/106727728-9ef64d00-65c0-11eb-8a28-cf83eff41ed2.png)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already squashed the commits and make the commit message conform to the project standard.
- [ ] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
