### PR TITLE
refactor(eda.correlation): push numerical df into each subfunction

### DIFF
--- a/dataprep/eda/correlation/compute/__init__.py
+++ b/dataprep/eda/correlation/compute/__init__.py
@@ -5,11 +5,9 @@ from typing import Optional, Tuple, List, Dict, Union, Any
 
 from ...configs import Config
 from ...data_array import DataArray, DataFrame
-from ...dtypes import NUMERICAL_DTYPES
 from ...intermediate import Intermediate
-from ...utils import to_dask
 from .bivariate import _calc_bivariate
-from .nullivariate import _calc_nullivariate
+from .overview import _calc_overview
 from .univariate import _calc_univariate
 
 __all__ = ["compute_correlation"]
@@ -55,13 +53,9 @@ def compute_correlation(
         cfg = Config.from_dict(display, cfg)
     elif not cfg:
         cfg = Config()
-    if x is not None and y is not None:
-        df = to_dask(df.select_dtypes(NUMERICAL_DTYPES))
-    else:
-        df = DataArray(df).select_num_columns()
 
     if x is None and y is None:  # pylint: disable=no-else-return
-        return _calc_nullivariate(df, cfg, value_range=value_range, k=k)
+        return _calc_overview(df, cfg, value_range=value_range, k=k)
     elif x is not None and y is None:
         return _calc_univariate(df, x, cfg, value_range=value_range, k=k)
     elif x is None and y is not None:

--- a/dataprep/eda/create_report/formatter.py
+++ b/dataprep/eda/create_report/formatter.py
@@ -13,7 +13,7 @@ from bokeh.plotting import Figure
 
 from ..configs import Config
 from ..correlation import render_correlation
-from ..correlation.compute.nullivariate import correlation_nxn
+from ..correlation.compute.overview import correlation_nxn
 from ..data_array import DataArray
 from ..distribution import render
 from ..distribution.compute.common import _calc_line_dt

--- a/dataprep/tests/eda/test_plot_correlation.py
+++ b/dataprep/tests/eda/test_plot_correlation.py
@@ -18,7 +18,7 @@ from ...eda.correlation.compute.univariate import (
     _spearman_1xn,
     _corr_filter,
 )
-from ...eda.correlation.compute.nullivariate import (
+from ...eda.correlation.compute.overview import (
     _spearman_nxn,
     _pearson_nxn,
     _kendall_tau_nxn,


### PR DESCRIPTION
# Description
 This PR refactor `eda.correlation` by:
1. push numerical df into each subfunction, such that it is easier to support categorical correlation for each function.
2. rename nullivariate to overview, which follows the name convention from plot distribution.