### PR TITLE
fix(eda): fix the error of numerical cell in object column

### DIFF
--- a/dataprep/eda/create_report/formatter.py
+++ b/dataprep/eda/create_report/formatter.py
@@ -228,11 +228,9 @@ def basic_computations(df: dd.DataFrame, cfg: Config) -> Tuple[Dict[str, Any], D
         if is_dtype(detect_dtype(df.frame[col]), Continuous()):
             data[col] = cont_comps(df.frame[col], cfg)
         elif is_dtype(detect_dtype(df.frame[col]), Nominal()):
-            # cast the column as string type if it contains a mutable type
-            try:
-                first_rows[col].apply(hash)
-            except TypeError:
-                df.frame[col] = df.frame[col].astype(str)
+            # Since it will throw error if column is object while some cells are
+            # numerical, we transform column to string first.
+            df.frame[col] = df.frame[col].astype(str)
             data[col] = nom_comps(df.frame[col], first_rows[col], cfg)
         elif is_dtype(detect_dtype(df.frame[col]), DateTime()):
             data[col] = {}

--- a/dataprep/eda/distribution/compute/bivariate.py
+++ b/dataprep/eda/distribution/compute/bivariate.py
@@ -56,10 +56,9 @@ def compute_bivariate(
     ):
         x, y = (x, y) if is_dtype(xtype, Nominal()) else (y, x)
         df = df[[x, y]]
-        try:
-            df.head()[x].apply(hash)
-        except TypeError:
-            df[x] = df[x].astype(str)
+        # Since it will throw error if column is object while some cells are
+        # numerical, we transform column to string first.
+        df[x] = df[x].astype(str)
 
         (comps,) = dask.compute(_nom_cont_comps(df.dropna(), cfg))
 
@@ -155,15 +154,10 @@ def compute_bivariate(
         )
     elif is_dtype(xtype, Nominal()) and is_dtype(ytype, Nominal()):
         df = df[[x, y]]
-        head = df.head()
-        try:
-            head[x].apply(hash)
-        except TypeError:
-            df[x] = df[x].astype(str)
-        try:
-            head[y].apply(hash)
-        except TypeError:
-            df[y] = df[y].astype(str)
+        # Since it will throw error if column is object while some cells are
+        # numerical, we transform column to string first.
+        df[x] = df[x].astype(str)
+        df[y] = df[y].astype(str)
 
         (comps,) = dask.compute(df.dropna().groupby([x, y]).size())
         return Intermediate(

--- a/dataprep/eda/distribution/compute/overview.py
+++ b/dataprep/eda/distribution/compute/overview.py
@@ -53,11 +53,9 @@ def compute_overview(df: dd.DataFrame, cfg: Config, dtype: Optional[DTypeDef]) -
         if is_dtype(col_dtype, Continuous()) and (cfg.hist.enable or cfg.insight.enable):
             data.append((col, Continuous(), _cont_calcs(df[col].dropna(), cfg)))
         elif is_dtype(col_dtype, Nominal()) and (cfg.bar.enable or cfg.insight.enable):
-            # cast the column as string type if it contains a mutable type
-            try:
-                head[col].apply(hash)
-            except TypeError:
-                df[col] = df[col].astype(str)
+            # Since it will throw error if column is object while some cells are
+            # numerical, we transform column to string first.
+            df[col] = df[col].astype(str)
             data.append((col, Nominal(), _nom_calcs(df[col].dropna(), head[col], cfg)))
         elif is_dtype(col_dtype, DateTime()) and (cfg.line.enable or cfg.insight.enable):
             data.append((col, DateTime(), dask.delayed(_calc_line_dt)(df[[col]], cfg.line.unit)))

--- a/dataprep/eda/distribution/compute/univariate.py
+++ b/dataprep/eda/distribution/compute/univariate.py
@@ -47,12 +47,10 @@ def compute_univariate(
 
     if is_dtype(col_dtype, Nominal()):
         head = df[x].head()  # dd.Series.head() triggers a (small) data read
-        # cast the column as string type if it contains a mutable type
-        try:
-            head.apply(hash)
-        except TypeError:
-            df[x] = df[x].astype(str)
 
+        # Since it will throw error if column is object while some cells are
+        # numerical, we transform column to string first.
+        df[x] = df[x].astype(str)
         # all computations for plot(df, Nominal())
         (data,) = dask.compute(nom_comps(df[x], head, cfg))
 

--- a/dataprep/tests/eda/test_create_report.py
+++ b/dataprep/tests/eda/test_create_report.py
@@ -25,9 +25,10 @@ def simpledf() -> pd.DataFrame:
         ],
         axis=1,
     )
-    # df = pd.concat([df, pd.Series(np.zeros(1000))], axis=1)
     df.columns = ["a", "b", "c", "d", "e", "f"]
     df["g"] = pd.to_datetime(df["f"])
+    # test when column is object but some cells are numerical
+    df["h"] = pd.Series([0, "x"] * 500)
 
     idx = np.arange(1000)
     np.random.shuffle(idx)

--- a/dataprep/tests/eda/test_plot.py
+++ b/dataprep/tests/eda/test_plot.py
@@ -32,6 +32,8 @@ def simpledf() -> dd.DataFrame:
     df = pd.concat([df, pd.Series(np.zeros(1000))], axis=1)
     df.columns = ["a", "b", "c", "d", "e", "f"]
     df["e"] = pd.to_datetime(df["e"])
+    # test when column is object but some cells are numerical
+    df["g"] = pd.Series([0, "x"] * 500)
 
     idx = np.arange(1000)
     np.random.shuffle(idx)
@@ -42,28 +44,21 @@ def simpledf() -> dd.DataFrame:
     return ddf
 
 
-def test_sanity_compute_1(simpledf: dd.DataFrame) -> None:
+def test_sanity_compute_univariate(simpledf: dd.DataFrame) -> None:
     plot(simpledf, "a")
-
-
-def test_sanity_compute_2(simpledf: dd.DataFrame) -> None:
     plot(simpledf, "e")
+    plot(simpledf, "g")
 
 
-def test_sanity_compute_3(simpledf: dd.DataFrame) -> None:
+def test_sanity_compute_overview(simpledf: dd.DataFrame) -> None:
     plot(simpledf)
 
 
-def test_sanity_compute_4(simpledf: dd.DataFrame) -> None:
-    plot(simpledf, "d", "e")
-
-
-def test_sanity_compute_5(simpledf: dd.DataFrame) -> None:
+def test_sanity_compute_bivariate(simpledf: dd.DataFrame) -> None:
     plot(simpledf, "a", "e")
-
-
-# def test_sanity_compute_6(simpledf: dd.DataFrame) -> None:
-#     plot(simpledf, "f")
+    plot(simpledf, "d", "e")
+    plot(simpledf, "a", "g")
+    plot(simpledf, "d", "g")
 
 
 def test_specify_column_type(simpledf: dd.DataFrame) -> None:


### PR DESCRIPTION
# Description

An object column will be identified as a categorical variable. But its cell may still be numerical, which will cause problem in rendering. This PR fix this issue.