### PR TITLE
fix(clean): lat_long regex not match a date format

### DIFF
--- a/dataprep/clean/clean_lat_long.py
+++ b/dataprep/clean/clean_lat_long.py
@@ -15,7 +15,7 @@ from .utils import NULL_VALUES, create_report_new, to_dask
 
 LAT_LONG_PATTERN = re.compile(
     r"""
-    .*?[(]?
+    [^/]*?[(]?
       (?P<dir_front>[NS])?[ ]*
         (?P<deg>-?%(FLOAT)s)(?:[%(DEGREE)sD\*\u00B0\s][ ]*
         (?:(?P<min>%(FLOAT)s)[%(PRIME)s'm]?[ ]*)?


### PR DESCRIPTION
# Description

With a string like "1999/20/11", the `clean_lat_long()` regex would match "1999/" as irrelevant characters at the beginning of the string, then "20" as the latitude degrees and "11" as the longitude degrees. This PR inhibits this match.

# How Has This Been Tested?

CI

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
