### PR TITLE
feat(clean): add clean_text function

### DIFF
--- a/dataprep/assets/english_stopwords.py
+++ b/dataprep/assets/english_stopwords.py
@@ -1,4 +1,4 @@
-english_stopwords = [
+english_stopwords = {
     "i",
     "me",
     "my",
@@ -178,4 +178,4 @@ english_stopwords = [
     "won't",
     "wouldn",
     "wouldn't",
-]
+}

--- a/dataprep/clean/__init__.py
+++ b/dataprep/clean/__init__.py
@@ -27,6 +27,8 @@ from .clean_currency import clean_currency, validate_currency
 
 from .clean_df import clean_df
 
+from .clean_text import clean_text, default_text_pipeline
+
 
 __all__ = [
     "clean_lat_long",
@@ -50,4 +52,6 @@ __all__ = [
     "clean_currency",
     "validate_currency",
     "clean_df",
+    "clean_text",
+    "default_text_pipeline",
 ]

--- a/dataprep/clean/clean_text.py
+++ b/dataprep/clean/clean_text.py
@@ -1,0 +1,440 @@
+"""
+Clean a DataFrame column containing text data.
+"""
+import re
+import string
+from functools import partial, update_wrapper
+from typing import Any, Callable, Dict, List, Optional, Set, Union
+from unicodedata import normalize
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from ..assets.english_stopwords import english_stopwords
+from .utils import NULL_VALUES, to_dask
+
+REGEX_BRACKETS = {
+    "angle": re.compile(r"(\<)[^<>]*(\>)"),
+    "curly": re.compile(r"(\{)[^{}]*(\})"),
+    "round": re.compile(r"(\()[^()]*(\))"),
+    "square": re.compile(r"(\[)[^\[\]]*(\])"),
+}
+REGEX_DIGITS = re.compile(r"\d+")
+REGEX_DIGITS_BLOCK = re.compile(r"\b\d+\b")
+REGEX_HTML = re.compile(r"<[A-Za-z/][^>]*>|&(?:[a-z0-9]+|#[0-9]{1,6}|#x[0-9a-f]{1,6});")
+REGEX_PUNCTUATION = re.compile(fr"[{re.escape(string.punctuation)}]")
+REGEX_URL = re.compile(r"(?:https?://|www\.)\S+")
+REGEX_WHITESPACE = re.compile(r"[\n\t]|[ ]{2,}")
+
+
+def clean_text(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    pipeline: Optional[List[Dict[str, Any]]] = None,
+    stopwords: Optional[Set[str]] = None,
+) -> pd.DataFrame:
+    """
+    Clean text data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        column
+            The name of the column containing text data.
+        pipeline
+            A list of cleaning functions to be applied to the column. If None,
+            use the default pipeline.
+
+            (default: None)
+        stopwords
+            A set of words to be removed from the column. If None, use NLTK's
+            stopwords.
+
+            (default: None)
+
+    Examples
+    --------
+    Clean a column of text data using the default pipeline.
+
+    >>> df = pd.DataFrame({"text": ["This show was an amazing, fresh & innovative idea in the \
+70's when it first aired."]})
+    >>> clean_text(df, 'text')
+                                                 text
+    0  show amazing fresh innovative idea first aired
+    """
+    df = to_dask(df)
+
+    pipe = _get_default_pipeline(stopwords) if not pipeline else _get_custom_pipeline(pipeline)
+
+    for func in pipe:
+        df[column] = df[column].apply(func, meta=object)
+
+    df = df.compute()
+
+    return df
+
+
+def default_text_pipeline() -> List[Dict[str, Any]]:
+    """
+    Return a list of dictionaries representing the functions in the default pipeline.
+    Use as a template for creating a custom pipeline.
+
+    Examples
+    --------
+    >>> default_text_pipeline()
+    [{'operator': 'fillna'}, {'operator': 'lowercase'}, {'operator': 'remove_digits'},
+    {'operator': 'remove_html'}, {'operator': 'remove_urls'}, {'operator': 'remove_punctuation'},
+    {'operator': 'remove_accents'}, {'operator': 'remove_stopwords', 'parameters':
+    {'stopwords': None}}, {'operator': 'remove_whitespace'}]
+    """
+    return [
+        {"operator": "fillna"},
+        {"operator": "lowercase"},
+        {"operator": "remove_digits"},
+        {"operator": "remove_html"},
+        {"operator": "remove_urls"},
+        {"operator": "remove_punctuation"},
+        {"operator": "remove_accents"},
+        {"operator": "remove_stopwords", "parameters": {"stopwords": None}},
+        {"operator": "remove_whitespace"},
+    ]
+
+
+def _get_default_pipeline(
+    stopwords: Optional[Set[str]] = None,
+) -> List[Callable[..., Any]]:
+    """
+    Return a list of functions defining the default pipeline.
+    """
+    return [
+        _fillna,
+        _lowercase,
+        _remove_digits,
+        _remove_html,
+        _remove_urls,
+        _remove_punctuation,
+        _remove_accents,
+        lambda x: _remove_stopwords(x, stopwords),
+        _remove_whitespace,
+    ]
+
+
+def _get_custom_pipeline(pipeline: List[Dict[str, Any]]) -> List[Callable[..., Any]]:
+    """
+    Return a list of functions defining a custom pipeline.
+    """
+    func_dict = _get_func_dict()
+    custom_pipeline: List[Callable[..., Any]] = []
+
+    for component in pipeline:
+        # Check whether function is built in or user defined
+        operator = (
+            func_dict[component["operator"]]
+            if isinstance(component["operator"], str)
+            else component["operator"]
+        )
+        # Append the function to the pipeline
+        # If parameters are specified, create a partial function to lock in
+        # the values and prevent them from being overwritten in subsequent loops
+        if "parameters" in component:
+            custom_pipeline.append(_wrapped_partial(operator, component["parameters"]))
+        else:
+            custom_pipeline.append(operator)
+
+    return custom_pipeline
+
+
+def _get_func_dict() -> Dict[str, Callable[..., Any]]:
+    """
+    Return a mapping of strings to function names.
+    """
+    return {
+        "fillna": _fillna,
+        "lowercase": _lowercase,
+        "sentence_case": _sentence_case,
+        "title_case": _title_case,
+        "uppercase": _uppercase,
+        "remove_accents": _remove_accents,
+        "remove_bracketed": _remove_bracketed,
+        "remove_digits": _remove_digits,
+        "remove_html": _remove_html,
+        "remove_prefixed": _remove_prefixed,
+        "remove_punctuation": _remove_punctuation,
+        "remove_stopwords": _remove_stopwords,
+        "remove_urls": _remove_urls,
+        "remove_whitespace": _remove_whitespace,
+        "replace_bracketed": _replace_bracketed,
+        "replace_digits": _replace_digits,
+        "replace_prefixed": _replace_prefixed,
+        "replace_punctuation": _replace_punctuation,
+        "replace_stopwords": _replace_stopwords,
+        "replace_text": _replace_text,
+        "replace_urls": _replace_urls,
+    }
+
+
+def _fillna(text: Any, value: Any = np.nan) -> Any:
+    """
+    Replace all null values with NaN (default) or the supplied value.
+    """
+    return value if text in NULL_VALUES else str(text)
+
+
+def _lowercase(text: Any) -> Any:
+    """
+    Convert all characters to lowercase.
+    """
+    return str(text).lower() if pd.notna(text) else text
+
+
+def _sentence_case(text: Any) -> Any:
+    """
+    Convert first character to uppercase and remaining to lowercase.
+    """
+    return str(text).capitalize() if pd.notna(text) else text
+
+
+def _title_case(text: Any) -> Any:
+    """
+    Convert first character of each word to uppercase and remaining to lowercase.
+    """
+    return str(text).title() if pd.notna(text) else text
+
+
+def _uppercase(text: Any) -> Any:
+    """
+    Convert all characters to uppercase.
+    """
+    return str(text).upper() if pd.notna(text) else text
+
+
+def _remove_accents(text: Any) -> Any:
+    """
+    Remove accents (diacritic marks).
+    """
+    return (
+        normalize("NFD", str(text)).encode("ascii", "ignore").decode("ascii")
+        if pd.notna(text)
+        else text
+    )
+
+
+def _remove_bracketed(text: Any, brackets: Union[str, Set[str]], inclusive: bool = True) -> Any:
+    """
+    Remove text between brackets.
+
+    Parameters
+    ----------
+    brackets
+        The bracket style.
+            - "angle": <>
+            - "curly": {}
+            - "round": ()
+            - "square": []
+
+    inclusive
+        If True (default), remove the brackets along with the text in between.
+        Otherwise, keep the brackets.
+    """
+    if pd.isna(text):
+        return text
+
+    text = str(text)
+    value = "" if inclusive else r"\g<1>\g<2>"
+    if isinstance(brackets, set):
+        for bracket in brackets:
+            text = re.sub(REGEX_BRACKETS[bracket], value, text)
+    else:
+        text = re.sub(REGEX_BRACKETS[brackets], value, text)
+
+    return text
+
+
+def _remove_digits(text: Any) -> Any:
+    """
+    Remove all digits.
+    """
+    return re.sub(REGEX_DIGITS, "", str(text)) if pd.notna(text) else text
+
+
+def _remove_html(text: Any) -> Any:
+    """
+    Remove HTML tags.
+    """
+    return re.sub(REGEX_HTML, "", str(text)) if pd.notna(text) else text
+
+
+def _remove_prefixed(text: Any, prefix: Union[str, Set[str]]) -> Any:
+    """
+    Remove substrings that start with the prefix(es).
+    """
+    if pd.isna(text):
+        return text
+
+    text = str(text)
+    if isinstance(prefix, set):
+        for pre in prefix:
+            text = re.sub(fr"{pre}\S+", "", text)
+    else:
+        text = re.sub(fr"{prefix}\S+", "", text)
+
+    return text
+
+
+def _remove_punctuation(text: Any) -> Any:
+    """
+    Remove punctuation marks.
+    """
+    return re.sub(REGEX_PUNCTUATION, " ", str(text)) if pd.notna(text) else text
+
+
+def _remove_stopwords(text: Any, stopwords: Optional[Set[str]] = None) -> Any:
+    """
+    Remove a set of words from the text.
+    If `stopwords` is None (default), use NLTK's stopwords.
+    """
+    if pd.isna(text):
+        return text
+
+    stopwords = english_stopwords if not stopwords else stopwords
+    return " ".join(word for word in str(text).split() if word.lower() not in stopwords)
+
+
+def _remove_urls(text: Any) -> Any:
+    """
+    Remove URLS.
+    """
+    return re.sub(REGEX_URL, "", str(text)) if pd.notna(text) else text
+
+
+def _remove_whitespace(text: Any) -> Any:
+    """
+    Remove extra spaces along with tabs and newlines.
+    """
+    return re.sub(REGEX_WHITESPACE, " ", str(text)).strip() if pd.notna(text) else text
+
+
+def _replace_bracketed(
+    text: Any, brackets: Union[str, Set[str]], value: str, inclusive: bool = True
+) -> Any:
+    """
+    Replace text between brackets with the value.
+
+    Parameters
+    ----------
+    brackets
+        The bracket style.
+            - "angle": <>
+            - "curly": {}
+            - "round": ()
+            - "square": []
+
+    value
+        The value to replace the text between the brackets.
+
+    inclusive
+        If True (default), replace the brackets with the new text as well.
+        Otherwise, keep the brackets.
+    """
+    if pd.isna(text):
+        return text
+
+    text = str(text)
+    value = value if inclusive else fr"\g<1>{value}\g<2>"
+    if isinstance(brackets, set):
+        for bracket in brackets:
+            text = re.sub(REGEX_BRACKETS[bracket], value, text)
+    else:
+        text = re.sub(REGEX_BRACKETS[brackets], value, text)
+
+    return text
+
+
+def _replace_digits(text: Any, value: str, block: Optional[bool] = True) -> Any:
+    """
+    Replace all digits with the value. If `block` is True (default),
+    only replace blocks of digits.
+    """
+    if pd.isna(text):
+        return text
+
+    return (
+        re.sub(REGEX_DIGITS_BLOCK, value, str(text))
+        if block
+        else re.sub(REGEX_DIGITS, value, str(text))
+    )
+
+
+def _replace_prefixed(text: Any, prefix: Union[str, Set[str]], value: str) -> Any:
+    """
+    Replace all substrings starting with the prefix(es) with the value.
+    """
+    if pd.isna(text):
+        return text
+
+    text = str(text)
+    if isinstance(prefix, set):
+        for pre in prefix:
+            text = re.sub(fr"{pre}\S+", value, text)
+    else:
+        text = re.sub(fr"{prefix}\S+", value, text)
+
+    return text
+
+
+def _replace_punctuation(text: Any, value: str) -> Any:
+    """
+    Replace all punctuation marks with the value.
+    """
+    return re.sub(REGEX_PUNCTUATION, value, str(text)) if pd.notna(text) else text
+
+
+def _replace_stopwords(text: Any, value: str, stopwords: Optional[Set[str]] = None) -> Any:
+    """
+    Replace a set of words in the text with the value.
+    If `stopwords` is None (default), use NLTK's stopwords.
+    """
+    if pd.isna(text):
+        return text
+
+    stopwords = english_stopwords if not stopwords else stopwords
+    return " ".join(word if word.lower() not in stopwords else value for word in str(text).split())
+
+
+def _replace_text(text: Any, value: Dict[str, str], block: Optional[bool] = True) -> Any:
+    """
+    Replace a sequence of characters with another according to the value mapping.
+    If `block` is True (default), only replace standalone blocks of the sequence.
+    """
+    if pd.isna(text):
+        return text
+
+    text = str(text)
+    for old_value, new_value in value.items():
+        text = (
+            re.sub(fr"\b{old_value}\b", new_value, text, flags=re.IGNORECASE)
+            if block
+            else re.sub(fr"{old_value}", new_value, text, flags=re.IGNORECASE)
+        )
+
+    return text
+
+
+def _replace_urls(text: Any, value: str) -> Any:
+    """
+    Replace all URLs with the value.
+    """
+    return re.sub(REGEX_URL, value, str(text)) if pd.notna(text) else text
+
+
+def _wrapped_partial(
+    func: Callable[..., Callable[..., Any]], params: Dict[str, Any]
+) -> Callable[..., Callable[..., Any]]:
+    """
+    Return a partial function with a name and a doc attribute.
+    """
+    partial_func = partial(func, **params)
+    update_wrapper(partial_func, func)
+    return partial_func

--- a/dataprep/tests/clean/test_clean_text.py
+++ b/dataprep/tests/clean/test_clean_text.py
@@ -1,0 +1,791 @@
+"""
+module for testing the functions clean_text() and default_text_pipeline()
+"""
+import re
+import logging
+from typing import Any, Dict, List
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ...clean import clean_text, default_text_pipeline
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")  # type: ignore
+def df_text() -> pd.DataFrame:
+    df = pd.DataFrame(
+        {
+            "text": [
+                "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+                "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+                "Simon of the Desert (Simón del desierto) is a 1965 film directed by Luis Buñuel.",
+                "[SPOILERS]\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+                "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968:\tA video essay</a>",
+                "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+                "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer.  But does it deserve to be?",
+                "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+                123,
+                np.nan,
+                "NULL",
+            ]
+        }
+    )
+    return df
+
+
+def test_clean_default(df_text: pd.DataFrame) -> None:
+    df_clean = clean_text(df_text, "text")
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "zzzzz imdb would allow one word reviews mine would",
+        "cast played shakespeare shakespeare lost",
+        "simon desert simon del desierto film directed luis bunuel",
+        "spoilers think seen film bad acting script effects etc",
+        "cannes video essay",
+        "recap thread rottentomatoes excellent panel hosted erikdavis filmfatale nyc ashcrossan",
+        "gameofthrones season rotten tomatometer deserve",
+        "come join share thoughts week episode",
+        "",
+        np.nan,
+        np.nan,
+    ]
+    assert df_check.equals(df_clean)
+
+
+def test_clean_custom(df_text: pd.DataFrame) -> None:
+    pipeline: List[Dict[str, Any]] = [
+        {"operator": "lowercase"},
+        {"operator": "remove_html"},
+        {
+            "operator": "replace_bracketed",
+            "parameters": {"brackets": "square", "value": "**spoilers**"},
+        },
+        {
+            "operator": "replace_bracketed",
+            "parameters": {"brackets": "curly", "value": "in every aspect"},
+        },
+        {"operator": "remove_whitespace"},
+    ]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'zzzzz!' if imdb would allow one-word reviews, that's what mine would be.",
+        "the cast played shakespeare.shakespeare lost.",
+        "simon of the desert (simón del desierto) is a 1965 film directed by luis buñuel.",
+        "**spoilers** i don't think i've seen a film this bad before in every aspect",
+        "cannes 1968: a video essay",
+        "recap thread for @rottentomatoes excellent panel, hosted by @erikdavis with @filmfatale_nyc and @ashcrossan.",
+        "#gameofthrones: season 8 is #rotten at 54% on the #tomatometer. but does it deserve to be?",
+        "come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeurl",
+        "123",
+        np.nan,
+        "null",
+    ]
+    assert df_check.equals(df_clean)
+
+
+def test_clean_user(df_text: pd.DataFrame) -> None:
+    def swapcase(text: str) -> str:
+        return str(text).swapcase()
+
+    def replace_z(text: str, value: str) -> str:
+        return re.sub(r"[zZ]", value, text)
+
+    pipeline: List[Dict[str, Any]] = [
+        {"operator": "fillna", "parameters": {"value": ""}},
+        {"operator": swapcase},
+        {"operator": replace_z, "parameters": {"value": "#"}},
+        {"operator": "remove_digits"},
+    ]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'#####!' iF imdB WOULD ALLOW ONE-WORD REVIEWS, THAT'S WHAT MINE WOULD BE.",
+        "tHE CAST PLAYED sHAKESPEARE.<BR /><BR />sHAKESPEARE LOST.",
+        "sIMON OF THE dESERT (sIMÓN DEL DESIERTO) IS A  FILM DIRECTED BY lUIS bUÑUEL.",
+        "[spoilers]\ni DON'T THINK i'VE SEEN A FILM THIS BAD BEFORE {ACTING, SCRIPT, EFFECTS (!), ETC...}",
+        "<A HREF='/FESTIVALS/CANNES--A-VIDEO-ESSAY'>cANNES :\ta VIDEO ESSAY</A>",
+        "rECAP THREAD FOR @rOTTENtOMATOES EXCELLENT PANEL, HOSTED BY @eRIKdAVIS WITH @fILMfATALE_nyc AND @aSHcROSSAN.",
+        "#gAMEoFtHRONES: sEASON  IS #rOTTEN AT % ON THE #tOMATOMETER.  bUT DOES IT DESERVE TO BE?",
+        "cOME JOIN AND SHARE YOUR THOUGHTS ON THIS WEEK'S EPISODE: HTTPS://TWITTER.COM/I/SPACES/FAKEurl",
+        "",
+        "",
+        "",
+    ]
+    assert df_check.equals(df_clean)
+
+
+def test_clean_fillna(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "fillna"}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 film directed by Luis Buñuel.",
+        "[SPOILERS]\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968:\tA video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        np.nan,
+    ]
+    pipeline_value = [{"operator": "fillna", "parameters": {"value": "<NAN>"}}]
+    df_clean_value = clean_text(df_text, "text", pipeline=pipeline_value)
+    df_check_value = df_text.copy()
+    df_check_value["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 film directed by Luis Buñuel.",
+        "[SPOILERS]\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968:\tA video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        "<NAN>",
+        "<NAN>",
+    ]
+    assert df_check.equals(df_clean)
+    assert df_check_value.equals(df_clean_value)
+
+
+def test_clean_lowercase(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "lowercase"}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'zzzzz!' if imdb would allow one-word reviews, that's what mine would be.",
+        "the cast played shakespeare.<br /><br />shakespeare lost.",
+        "simon of the desert (simón del desierto) is a 1965 film directed by luis buñuel.",
+        "[spoilers]\ni don't think i've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>cannes 1968:\ta video essay</a>",
+        "recap thread for @rottentomatoes excellent panel, hosted by @erikdavis with @filmfatale_nyc and @ashcrossan.",
+        "#gameofthrones: season 8 is #rotten at 54% on the #tomatometer.  but does it deserve to be?",
+        "come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeurl",
+        "123",
+        np.nan,
+        "null",
+    ]
+    assert df_check.equals(df_clean)
+
+
+def test_clean_sentence_case(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "sentence_case"}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'zzzzz!' if imdb would allow one-word reviews, that's what mine would be.",
+        "The cast played shakespeare.<br /><br />shakespeare lost.",
+        "Simon of the desert (simón del desierto) is a 1965 film directed by luis buñuel.",
+        "[spoilers]\ni don't think i've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>cannes 1968:\ta video essay</a>",
+        "Recap thread for @rottentomatoes excellent panel, hosted by @erikdavis with @filmfatale_nyc and @ashcrossan.",
+        "#gameofthrones: season 8 is #rotten at 54% on the #tomatometer.  but does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeurl",
+        "123",
+        np.nan,
+        "Null",
+    ]
+    assert df_check.equals(df_clean)
+
+
+def test_clean_title_case(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "title_case"}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'Zzzzz!' If Imdb Would Allow One-Word Reviews, That'S What Mine Would Be.",
+        "The Cast Played Shakespeare.<Br /><Br />Shakespeare Lost.",
+        "Simon Of The Desert (Simón Del Desierto) Is A 1965 Film Directed By Luis Buñuel.",
+        "[Spoilers]\nI Don'T Think I'Ve Seen A Film This Bad Before {Acting, Script, Effects (!), Etc...}",
+        "<A Href='/Festivals/Cannes-1968-A-Video-Essay'>Cannes 1968:\tA Video Essay</A>",
+        "Recap Thread For @Rottentomatoes Excellent Panel, Hosted By @Erikdavis With @Filmfatale_Nyc And @Ashcrossan.",
+        "#Gameofthrones: Season 8 Is #Rotten At 54% On The #Tomatometer.  But Does It Deserve To Be?",
+        "Come Join And Share Your Thoughts On This Week'S Episode: Https://Twitter.Com/I/Spaces/1Fakeurl",
+        "123",
+        np.nan,
+        "Null",
+    ]
+    assert df_check.equals(df_clean)
+
+
+def test_clean_uppercase(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "uppercase"}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'ZZZZZ!' IF IMDB WOULD ALLOW ONE-WORD REVIEWS, THAT'S WHAT MINE WOULD BE.",
+        "THE CAST PLAYED SHAKESPEARE.<BR /><BR />SHAKESPEARE LOST.",
+        "SIMON OF THE DESERT (SIMÓN DEL DESIERTO) IS A 1965 FILM DIRECTED BY LUIS BUÑUEL.",
+        "[SPOILERS]\nI DON'T THINK I'VE SEEN A FILM THIS BAD BEFORE {ACTING, SCRIPT, EFFECTS (!), ETC...}",
+        "<A HREF='/FESTIVALS/CANNES-1968-A-VIDEO-ESSAY'>CANNES 1968:\tA VIDEO ESSAY</A>",
+        "RECAP THREAD FOR @ROTTENTOMATOES EXCELLENT PANEL, HOSTED BY @ERIKDAVIS WITH @FILMFATALE_NYC AND @ASHCROSSAN.",
+        "#GAMEOFTHRONES: SEASON 8 IS #ROTTEN AT 54% ON THE #TOMATOMETER.  BUT DOES IT DESERVE TO BE?",
+        "COME JOIN AND SHARE YOUR THOUGHTS ON THIS WEEK'S EPISODE: HTTPS://TWITTER.COM/I/SPACES/1FAKEURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check.equals(df_clean)
+
+
+def test_clean_remove_accents(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "remove_accents"}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simon del desierto) is a 1965 film directed by Luis Bunuel.",
+        "[SPOILERS]\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968:\tA video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check.equals(df_clean)
+
+
+def test_clean_remove_bracketed(df_text: pd.DataFrame) -> None:
+    pipeline_all = [
+        {
+            "operator": "remove_bracketed",
+            "parameters": {"brackets": {"angle", "curly", "round", "square"}},
+        }
+    ]
+    df_clean_all = clean_text(df_text, "text", pipeline=pipeline_all)
+    df_check_all = df_text.copy()
+    df_check_all["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.Shakespeare lost.",
+        "Simon of the Desert  is a 1965 film directed by Luis Buñuel.",
+        "\nI don't think I've seen a film this bad before ",
+        "Cannes 1968:\tA video essay",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    pipeline_all_excl = [
+        {
+            "operator": "remove_bracketed",
+            "parameters": {"brackets": {"angle", "curly", "round", "square"}, "inclusive": False},
+        }
+    ]
+    df_clean_all_excl = clean_text(df_text, "text", pipeline=pipeline_all_excl)
+    df_check_all_excl = df_text.copy()
+    df_check_all_excl["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<><>Shakespeare lost.",
+        "Simon of the Desert () is a 1965 film directed by Luis Buñuel.",
+        "[]\nI don't think I've seen a film this bad before {}",
+        "<>Cannes 1968:\tA video essay<>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    pipeline_square = [{"operator": "remove_bracketed", "parameters": {"brackets": "square"}}]
+    df_clean_square = clean_text(df_text, "text", pipeline=pipeline_square)
+    df_check_square = df_text.copy()
+    df_check_square["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 film directed by Luis Buñuel.",
+        "\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968:\tA video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check_all.equals(df_clean_all)
+    assert df_check_all_excl.equals(df_clean_all_excl)
+    assert df_check_square.equals(df_clean_square)
+
+
+def test_clean_remove_digits(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "remove_digits"}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a  film directed by Luis Buñuel.",
+        "[SPOILERS]\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes--a-video-essay'>Cannes :\tA video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season  is #Rotten at % on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/fakeURL",
+        "",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check.equals(df_clean)
+
+
+def test_clean_remove_html(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "remove_html"}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 film directed by Luis Buñuel.",
+        "[SPOILERS]\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "Cannes 1968:\tA video essay",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check.equals(df_clean)
+
+
+def test_clean_remove_prefixed(df_text: pd.DataFrame) -> None:
+    pipeline_hashtag = [{"operator": "remove_prefixed", "parameters": {"prefix": "#"}}]
+    df_clean_hashtag = clean_text(df_text, "text", pipeline=pipeline_hashtag)
+    df_check_hashtag = df_text.copy()
+    df_check_hashtag["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 film directed by Luis Buñuel.",
+        "[SPOILERS]\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968:\tA video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        " Season 8 is  at 54% on the   But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    pipeline_hashtag_mention = [
+        {"operator": "remove_prefixed", "parameters": {"prefix": {"#", "@"}}}
+    ]
+    df_clean_hashtag_mention = clean_text(df_text, "text", pipeline=pipeline_hashtag_mention)
+    df_check_hashtag_mention = df_text.copy()
+    df_check_hashtag_mention["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 film directed by Luis Buñuel.",
+        "[SPOILERS]\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968:\tA video essay</a>",
+        "Recap thread for  excellent panel, hosted by  with  and ",
+        " Season 8 is  at 54% on the   But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check_hashtag.equals(df_clean_hashtag)
+    assert df_check_hashtag_mention.equals(df_clean_hashtag_mention)
+
+
+def test_clean_remove_punctuation(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "remove_punctuation"}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        " ZZZZZ   If IMDb would allow one word reviews  that s what mine would be ",
+        "The cast played Shakespeare  br    br   Shakespeare lost ",
+        "Simon of the Desert  Simón del desierto  is a 1965 film directed by Luis Buñuel ",
+        " SPOILERS \nI don t think I ve seen a film this bad before  acting  script  effects      etc    ",
+        " a href   festivals cannes 1968 a video essay  Cannes 1968 \tA video essay  a ",
+        "Recap thread for  RottenTomatoes excellent panel  hosted by  ErikDavis with  FilmFatale NYC and  AshCrossan ",
+        " GameOfThrones  Season 8 is  Rotten at 54  on the  Tomatometer   But does it deserve to be ",
+        "Come join and share your thoughts on this week s episode  https   twitter com i spaces 1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check.equals(df_clean)
+
+
+def test_clean_remove_stopwords(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "remove_stopwords"}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'ZZZZZ!' IMDb would allow one-word reviews, that's mine would be.",
+        "cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon Desert (Simón del desierto) 1965 film directed Luis Buñuel.",
+        "[SPOILERS] think I've seen film bad {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968: video essay</a>",
+        "Recap thread @RottenTomatoes excellent panel, hosted @ErikDavis @FilmFatale_NYC @AshCrossan.",
+        "#GameOfThrones: Season 8 #Rotten 54% #Tomatometer. deserve be?",
+        "Come join share thoughts week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    pipeline_custom = [
+        {"operator": "remove_stopwords", "parameters": {"stopwords": {"imdb", "film"}}}
+    ]
+    df_clean_custom = clean_text(df_text, "text", pipeline=pipeline_custom)
+    df_check_custom = df_text.copy()
+    df_check_custom["text"] = [
+        "'ZZZZZ!' If would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 directed by Luis Buñuel.",
+        "[SPOILERS] I don't think I've seen a this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968: A video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer. But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check.equals(df_clean)
+    assert df_check_custom.equals(df_clean_custom)
+
+
+def test_clean_remove_urls(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "remove_urls"}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 film directed by Luis Buñuel.",
+        "[SPOILERS]\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968:\tA video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: ",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check.equals(df_clean)
+
+
+def test_clean_remove_whitespace(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "remove_whitespace"}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 film directed by Luis Buñuel.",
+        "[SPOILERS] I don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968: A video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer. But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check.equals(df_clean)
+
+
+def test_clean_replace_bracketed(df_text: pd.DataFrame) -> None:
+    pipeline_all = [
+        {
+            "operator": "replace_bracketed",
+            "parameters": {
+                "brackets": {"angle", "curly", "round", "square"},
+                "value": "<REDACTED>",
+            },
+        }
+    ]
+    df_clean_all = clean_text(df_text, "text", pipeline=pipeline_all)
+    df_check_all = df_text.copy()
+    df_check_all["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<REDACTED><REDACTED>Shakespeare lost.",
+        "Simon of the Desert <REDACTED> is a 1965 film directed by Luis Buñuel.",
+        "<REDACTED>\nI don't think I've seen a film this bad before <REDACTED>",
+        "<REDACTED>Cannes 1968:\tA video essay<REDACTED>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    pipeline_square = [
+        {
+            "operator": "replace_bracketed",
+            "parameters": {"brackets": "square", "value": "**SPOILERS**"},
+        }
+    ]
+    df_clean_square = clean_text(df_text, "text", pipeline=pipeline_square)
+    df_check_square = df_text.copy()
+    df_check_square["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 film directed by Luis Buñuel.",
+        "**SPOILERS**\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968:\tA video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    pipeline_square_excl = [
+        {
+            "operator": "replace_bracketed",
+            "parameters": {"brackets": "square", "value": "SPOILER WARNING", "inclusive": False},
+        }
+    ]
+    df_clean_square_excl = clean_text(df_text, "text", pipeline=pipeline_square_excl)
+    df_check_square_excl = df_text.copy()
+    df_check_square_excl["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 film directed by Luis Buñuel.",
+        "[SPOILER WARNING]\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968:\tA video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check_all.equals(df_clean_all)
+    assert df_check_square.equals(df_clean_square)
+    assert df_check_square_excl.equals(df_clean_square_excl)
+
+
+def test_clean_replace_digits(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "replace_digits", "parameters": {"value": "X"}}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a X film directed by Luis Buñuel.",
+        "[SPOILERS]\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-X-a-video-essay'>Cannes X:\tA video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season X is #Rotten at X% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "X",
+        np.nan,
+        "NULL",
+    ]
+    pipeline_no_block = [
+        {"operator": "replace_digits", "parameters": {"value": "X", "block": False}}
+    ]
+    df_clean_no_block = clean_text(df_text, "text", pipeline=pipeline_no_block)
+    df_check_no_block = df_text.copy()
+    df_check_no_block["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a X film directed by Luis Buñuel.",
+        "[SPOILERS]\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-X-a-video-essay'>Cannes X:\tA video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season X is #Rotten at X% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/XfakeURL",
+        "X",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check.equals(df_clean)
+    assert df_check_no_block.equals(df_clean_no_block)
+
+
+def test_clean_replace_prefixed(df_text: pd.DataFrame) -> None:
+    pipeline_hashtag = [
+        {"operator": "replace_prefixed", "parameters": {"prefix": "#", "value": "<HASHTAG>"}}
+    ]
+    df_clean_hashtag = clean_text(df_text, "text", pipeline=pipeline_hashtag)
+    df_check_hashtag = df_text.copy()
+    df_check_hashtag["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 film directed by Luis Buñuel.",
+        "[SPOILERS]\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968:\tA video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "<HASHTAG> Season 8 is <HASHTAG> at 54% on the <HASHTAG>  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    pipeline_hashtag_mention = [
+        {"operator": "replace_prefixed", "parameters": {"prefix": {"#", "@"}, "value": "<TAG>"}}
+    ]
+    df_clean_hashtag_mention = clean_text(df_text, "text", pipeline=pipeline_hashtag_mention)
+    df_check_hashtag_mention = df_text.copy()
+    df_check_hashtag_mention["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 film directed by Luis Buñuel.",
+        "[SPOILERS]\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968:\tA video essay</a>",
+        "Recap thread for <TAG> excellent panel, hosted by <TAG> with <TAG> and <TAG>",
+        "<TAG> Season 8 is <TAG> at 54% on the <TAG>  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check_hashtag.equals(df_clean_hashtag)
+    assert df_check_hashtag_mention.equals(df_clean_hashtag_mention)
+
+
+def test_clean_replace_punctuation(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "replace_punctuation", "parameters": {"value": "*"}}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "*ZZZZZ** If IMDb would allow one*word reviews* that*s what mine would be*",
+        "The cast played Shakespeare**br ***br **Shakespeare lost*",
+        "Simon of the Desert *Simón del desierto* is a 1965 film directed by Luis Buñuel*",
+        "*SPOILERS*\nI don*t think I*ve seen a film this bad before *acting* script* effects **** etc****",
+        "*a href***festivals*cannes*1968*a*video*essay**Cannes 1968*\tA video essay**a*",
+        "Recap thread for *RottenTomatoes excellent panel* hosted by *ErikDavis with *FilmFatale*NYC and *AshCrossan*",
+        "*GameOfThrones* Season 8 is *Rotten at 54* on the *Tomatometer*  But does it deserve to be*",
+        "Come join and share your thoughts on this week*s episode* https***twitter*com*i*spaces*1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check.equals(df_clean)
+
+
+def test_clean_replace_stopwords(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "replace_stopwords", "parameters": {"value": "<S>"}}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'ZZZZZ!' <S> IMDb would allow one-word reviews, that's <S> mine would be.",
+        "<S> cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon <S> <S> Desert (Simón del desierto) <S> <S> 1965 film directed <S> Luis Buñuel.",
+        "[SPOILERS] <S> <S> think I've seen <S> film <S> bad <S> {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968: <S> video essay</a>",
+        "Recap thread <S> @RottenTomatoes excellent panel, hosted <S> @ErikDavis <S> @FilmFatale_NYC <S> @AshCrossan.",
+        "#GameOfThrones: Season 8 <S> #Rotten <S> 54% <S> <S> #Tomatometer. <S> <S> <S> deserve <S> be?",
+        "Come join <S> share <S> thoughts <S> <S> week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    pipeline_custom = [
+        {
+            "operator": "replace_stopwords",
+            "parameters": {"stopwords": {"imdb", "film"}, "value": "<S>"},
+        }
+    ]
+    df_clean_custom = clean_text(df_text, "text", pipeline=pipeline_custom)
+    df_check_custom = df_text.copy()
+    df_check_custom["text"] = [
+        "'ZZZZZ!' If <S> would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 <S> directed by Luis Buñuel.",
+        "[SPOILERS] I don't think I've seen a <S> this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968: A video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer. But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check.equals(df_clean)
+    assert df_check_custom.equals(df_clean_custom)
+
+
+def test_clean_replace_text(df_text: pd.DataFrame) -> None:
+    pipeline = [
+        {"operator": "replace_text", "parameters": {"value": {"imdb": "Netflix", "film": "movie"}}}
+    ]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'ZZZZZ!' If Netflix would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 movie directed by Luis Buñuel.",
+        "[SPOILERS]\nI don't think I've seen a movie this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968:\tA video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    pipeline_no_block = [
+        {
+            "operator": "replace_text",
+            "parameters": {"value": {"imdb": "Netflix", "film": "movie"}, "block": False},
+        }
+    ]
+    df_clean_no_block = clean_text(df_text, "text", pipeline=pipeline_no_block)
+    df_check_no_block = df_text.copy()
+    df_check_no_block["text"] = [
+        "'ZZZZZ!' If Netflix would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 movie directed by Luis Buñuel.",
+        "[SPOILERS]\nI don't think I've seen a movie this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968:\tA video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @movieFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: https://twitter.com/i/spaces/1fakeURL",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check.equals(df_clean)
+    assert df_check_no_block.equals(df_clean_no_block)
+
+
+def test_clean_replace_urls(df_text: pd.DataFrame) -> None:
+    pipeline = [{"operator": "replace_urls", "parameters": {"value": "<URL>"}}]
+    df_clean = clean_text(df_text, "text", pipeline=pipeline)
+    df_check = df_text.copy()
+    df_check["text"] = [
+        "'ZZZZZ!' If IMDb would allow one-word reviews, that's what mine would be.",
+        "The cast played Shakespeare.<br /><br />Shakespeare lost.",
+        "Simon of the Desert (Simón del desierto) is a 1965 film directed by Luis Buñuel.",
+        "[SPOILERS]\nI don't think I've seen a film this bad before {acting, script, effects (!), etc...}",
+        "<a href='/festivals/cannes-1968-a-video-essay'>Cannes 1968:\tA video essay</a>",
+        "Recap thread for @RottenTomatoes excellent panel, hosted by @ErikDavis with @FilmFatale_NYC and @AshCrossan.",
+        "#GameOfThrones: Season 8 is #Rotten at 54% on the #Tomatometer.  But does it deserve to be?",
+        "Come join and share your thoughts on this week's episode: <URL>",
+        "123",
+        np.nan,
+        "NULL",
+    ]
+    assert df_check.equals(df_clean)
+
+
+def test_default_text_pipeline() -> None:
+    pipeline_default = [
+        {"operator": "fillna"},
+        {"operator": "lowercase"},
+        {"operator": "remove_digits"},
+        {"operator": "remove_html"},
+        {"operator": "remove_urls"},
+        {"operator": "remove_punctuation"},
+        {"operator": "remove_accents"},
+        {"operator": "remove_stopwords", "parameters": {"stopwords": None}},
+        {"operator": "remove_whitespace"},
+    ]
+    pipeline_check = default_text_pipeline()
+    assert pipeline_check == pipeline_default

--- a/docs/source/api_reference/dataprep.clean.rst
+++ b/docs/source/api_reference/dataprep.clean.rst
@@ -67,6 +67,14 @@ Phone Numbers
    :undoc-members:
    :show-inheritance:
 
+Text
+----
+
+.. automodule:: dataprep.clean.clean_text
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 URLs
 ----
 


### PR DESCRIPTION
# Description

Implements the `clean_text()` function to clean text data in a DataFrame column. Design details are set out in #571 (updated).

# How Has This Been Tested?

Unit tests.

# Snapshots:

## Functionality

<img width="505" alt="clean_text_1" src="https://user-images.githubusercontent.com/55072906/115311668-e2267d80-a124-11eb-9665-1043e7d58c63.png">

<img width="380" alt="clean_text_2" src="https://user-images.githubusercontent.com/55072906/115311689-e9e62200-a124-11eb-8828-0f0ecd978e13.png">

## Custom Pipeline

<img width="486" alt="clean_text_3" src="https://user-images.githubusercontent.com/55072906/115311692-eeaad600-a124-11eb-9a9b-5527dadf5066.png">

## User-defined Functions

<img width="611" alt="clean_text_4" src="https://user-images.githubusercontent.com/55072906/115311705-f4082080-a124-11eb-8479-7d5046d588b4.png">

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have already squashed the commits and made the commit message conform to the project standard
- [ ] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules