### PR TITLE
fix(clean): remove unneeded replace in clean_dupl

### DIFF
--- a/dataprep/clean/clean_duplication_utils.py
+++ b/dataprep/clean/clean_duplication_utils.py
@@ -221,7 +221,7 @@ class Clusterer:
         for idx, cluster in enumerate(cluster_page):
             cluster_repr = f"'{new_values[idx]}'"
             if do_merge[idx]:
-                cluster_vals = [f"'{cluster_val}'" for cluster_val, _ in cluster]
+                cluster_vals = [f"'{val}'" for val, _ in cluster if f"'{val}'" != cluster_repr]
                 code = (
                     f"{df_name}[{col}] = {df_name}[{col}].replace"
                     f"([{', '.join(cluster_vals)}], {cluster_repr})"


### PR DESCRIPTION
# Description

Change the output code from `clean_duplication` from
``` python
df['col'] = df['col'].replace(['Hello', 'HELLO'], 'Hello')
```
to
``` python
df['col'] = df['col'].replace(['HELLO'], 'Hello')
```
I.e., remove the unnecessary value  from the replace list.
# How Has This Been Tested?

Unit

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
