### PR TITLE
feat(clean): tuple of input formats for clean_country()

### DIFF
--- a/dataprep/tests/clean/test_clean_country.py
+++ b/dataprep/tests/clean/test_clean_country.py
@@ -196,6 +196,34 @@ def test_clean_input_format(df_countries: pd.DataFrame) -> None:
     assert df_clean_numeric.equals(df_check_numeric)
 
 
+def test_clean_input_format_tuple(df_countries: pd.DataFrame) -> None:
+    df_clean = clean_country(df_countries, "messy_country", input_format=("name", "alpha-2"))
+    df_check = df_countries.copy()
+    df_check["messy_country_clean"] = [
+        "Canada",
+        "Canada",
+        np.nan,
+        np.nan,
+        "Ireland",
+        "DR Congo",
+        "Congo Republic",
+        np.nan,
+        np.nan,
+        np.nan,
+        "American Samoa",
+        "Turkey",
+        "Belize",
+        np.nan,
+        np.nan,
+        np.nan,
+        np.nan,
+        np.nan,
+        np.nan,
+    ]
+
+    assert df_clean.equals(df_check)
+
+
 def test_clean_output_format(df_countries: pd.DataFrame) -> None:
     df_clean_official = clean_country(df_countries, "messy_country", output_format="official")
     df_clean_alpha2 = clean_country(df_countries, "messy_country", output_format="alpha-2")
@@ -682,6 +710,35 @@ def test_validate_series_input_format(df_countries: pd.DataFrame) -> None:
     )
     assert srs_check_name.equals(srs_valid_name)
     assert srs_check_alpha2.equals(srs_valid_alpha2)
+
+
+def test_validate_series_input_format_tuple(df_countries: pd.DataFrame) -> None:
+    srs_valid = validate_country(df_countries["messy_country"], input_format=("name", "alpha-2"))
+    srs_check = pd.Series(
+        [
+            True,
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            True,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+        ],
+        name="messy_country",
+    )
+    assert srs_check.equals(srs_valid)
 
 
 def test_validate_series_strict(df_countries: pd.DataFrame) -> None:

--- a/docs/source/user_guide/clean/clean_country.ipynb
+++ b/docs/source/user_guide/clean/clean_country.ipynb
@@ -30,8 +30,8 @@
     "* ISO 3166-1 alpha-2 (alpha-2): \"US\"\n",
     "* ISO 3166-1 alpha-3 (alpha-3): \"USA\"\n",
     "* ISO 3166-1 numeric (numeric): \"840\"\n",
-    "\n",
-    "``input_format`` can also be set to \"auto\" which automatically infers the input format.\n",
+    " \n",
+    "``input_format`` can be set to \"auto\" which automatically infers the input format. A tuple of input formats may also be used to indicate that the input may be any of the given input formats. \n",
     "\n",
     "The ``strict`` parameter allows for control over the type of matching used for the \"name\" and \"official\" input formats.\n",
     "\n",
@@ -207,6 +207,24 @@
    "outputs": [],
    "source": [
     "clean_country(df, \"country\", input_format=\"numeric\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### (name, alpha-2)\n",
+    "\n",
+    "A tuple containing any combination of input formats may be used to clean any of the given input formats."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_country(df, \"country\", input_format=(\"name\", \"alpha-2\"))"
    ]
   },
   {
@@ -500,7 +518,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Description

Adds support for cleaning multiple input formats at once by passing a tuple of input formats to the clean_country() and validate_country() functions.

closes #567

# How Has This Been Tested?

Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [ ] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
