### PR TITLE
fix(eda): keep missing values when preprocessing dataframe

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,7 +3,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-whitelist=lxml
+extension-pkg-whitelist=lxml, pandas._libs.missing
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.

--- a/dataprep/eda/create_report/formatter.py
+++ b/dataprep/eda/create_report/formatter.py
@@ -267,9 +267,6 @@ def basic_computations(
                 df.frame[col] = df.frame[col].astype(str)
                 data[col] = nom_comps(df.frame[col], df.frame[col].head(), cfg)
             elif is_dtype(detect_dtype(df.frame[col]), Nominal()):
-                # Since it will throw error if column is object while some cells are
-                # numerical, we transform column to string first.
-                df.frame[col] = df.frame[col].astype(str)
                 data[col] = nom_comps(df.frame[col], first_rows[col], cfg)
             elif is_dtype(detect_dtype(df.frame[col]), Continuous()):
                 data[col] = cont_comps(df.frame[col], cfg)
@@ -289,9 +286,6 @@ def basic_computations(
                     (col, Continuous(), _cont_calcs(df.frame[col].dropna(), cfg))
                 )
             elif is_dtype(col_dtype, Nominal()):
-                # Since it will throw error if column is object while some cells are
-                # numerical, we transform column to string first.
-                df.frame[col] = df.frame[col].astype(str)
                 data["insights"].append(
                     (col, Nominal(), _nom_calcs(df.frame[col].dropna(), head[col], cfg))
                 )

--- a/dataprep/eda/distribution/compute/bivariate.py
+++ b/dataprep/eda/distribution/compute/bivariate.py
@@ -63,10 +63,6 @@ def compute_bivariate(
     ):
         x, y = (x, y) if is_dtype(xtype, Nominal()) else (y, x)
         df = df[[x, y]]
-        # Since it will throw error if column is object while some cells are
-        # numerical, we transform column to string first.
-        df[x] = df[x].astype(str)
-
         (comps,) = dask.compute(_nom_cont_comps(df.dropna(), cfg))
 
         return Intermediate(
@@ -112,7 +108,6 @@ def compute_bivariate(
     ):
         x, y = (x, y) if is_dtype(xtype, DateTime()) else (y, x)
         df = df[[x, y]].dropna()
-        df[y] = df[y].apply(str, meta=(y, str))
         dtcat: List[Any] = []
         if cfg.line.enable:
             # line chart
@@ -153,20 +148,15 @@ def compute_bivariate(
             stackdata=stackdata,
             visual_type="dt_and_cat_cols",
         )
+
     elif (is_dtype(xtype, GeoGraphy()) and is_dtype(ytype, Continuous())) or (
         is_dtype(xtype, Continuous()) and is_dtype(ytype, GeoGraphy())
     ):
         x, y = (x, y) if is_dtype(xtype, GeoGraphy()) else (y, x)
         df = df[[x, y]]
-        first_rows = df.head()
-        try:
-            first_rows[x].apply(hash)
-        except TypeError:
-            df[x] = df[x].astype(str)
-
         (comps,) = dask.compute(geo_cont_comps(df.dropna(), cfg))
-
         return Intermediate(x=x, y=y, data=comps, visual_type="geo_and_num_cols")
+
     elif (is_dtype(xtype, GeoPoint()) and is_dtype(ytype, Continuous())) or (
         is_dtype(xtype, Continuous()) and is_dtype(ytype, GeoPoint())
     ):
@@ -187,10 +177,6 @@ def compute_bivariate(
         is_dtype(ytype, Nominal()) or is_dtype(ytype, GeoGraphy()) or is_dtype(ytype, GeoPoint())
     ):
         df = df[[x, y]]
-        # Since it will throw error if column is object while some cells are
-        # numerical, we transform column to string first.
-        df[x] = df[x].astype(str)
-        df[y] = df[y].astype(str)
 
         if is_dtype(xtype, GeoPoint()):
             df[x] = df[x].astype(str)

--- a/dataprep/eda/distribution/compute/overview.py
+++ b/dataprep/eda/distribution/compute/overview.py
@@ -54,16 +54,8 @@ def compute_overview(df: dd.DataFrame, cfg: Config, dtype: Optional[DTypeDef]) -
         if is_dtype(col_dtype, Continuous()) and (cfg.hist.enable or cfg.insight.enable):
             data.append((col, Continuous(), _cont_calcs(df[col].dropna(), cfg)))
         elif is_dtype(col_dtype, Nominal()) and (cfg.bar.enable or cfg.insight.enable):
-            # Since it will throw error if column is object while some cells are
-            # numerical, we transform column to string first.
-            df[col] = df[col].astype(str)
             data.append((col, Nominal(), _nom_calcs(df[col].dropna(), head[col], cfg)))
         elif is_dtype(col_dtype, GeoGraphy()) and (cfg.bar.enable or cfg.insight.enable):
-            # cast the column as string type if it contains a mutable type
-            try:
-                head[col].apply(hash)
-            except TypeError:
-                df[col] = df[col].astype(str)
             data.append((col, GeoGraphy(), _nom_calcs(df[col].dropna(), head[col], cfg)))
         elif is_dtype(col_dtype, DateTime()) and (cfg.line.enable or cfg.insight.enable):
             data.append((col, DateTime(), dask.delayed(_calc_line_dt)(df[[col]], cfg.line.unit)))

--- a/dataprep/eda/distribution/compute/univariate.py
+++ b/dataprep/eda/distribution/compute/univariate.py
@@ -59,9 +59,6 @@ def compute_univariate(
         if is_dtype(col_dtype, GeoPoint()):
             df[x] = df[x].astype(str)
 
-        # Since it will throw error if column is object while some cells are
-        # numerical, we transform column to string first.
-        df[x] = df[x].astype(str)
         # all computations for plot(df, Nominal())
         (data,) = dask.compute(nom_comps(df[x], head, cfg))
 
@@ -92,10 +89,6 @@ def compute_univariate(
         )
     elif is_dtype(col_dtype, GeoGraphy()):
         head = df[x].head()  # dd.Series.head() triggers a (small) data read
-
-        # Since it will throw error if column is object while some cells are
-        # numerical, we transform column to string first.
-        df[x] = df[x].astype(str)
         # all computations for plot(df, Nominal())
         (data,) = dask.compute(nom_comps(df[x], head, cfg))
 

--- a/dataprep/eda/distribution/render.py
+++ b/dataprep/eda/distribution/render.py
@@ -1805,7 +1805,7 @@ def nom_insights(data: Dict[str, Any], col: str, cfg: Config) -> Dict[str, List[
     if cfg.bar.enable:
         if data["chisq"][1] > cfg.insight.uniform__threshold:
             ins["Bar Chart"].append(f"{col} is relatively evenly distributed")
-        factor = round(data["bar"][0] / data["bar"][1], 2) if len(data["bar"]) > 1 else 0
+        factor = round(data["bar"].iloc[0] / data["bar"].iloc[1], 2) if len(data["bar"]) > 1 else 0
         if factor > cfg.insight.outstanding_no1__threshold:
             val1, val2 = data["bar"].index[0], data["bar"].index[1]
             ins["Bar Chart"].append(
@@ -1814,7 +1814,7 @@ def nom_insights(data: Dict[str, Any], col: str, cfg: Config) -> Dict[str, List[
             )
     if cfg.pie.enable:
         if (
-            data["pie"][:2].sum() / data["nrows"] > cfg.insight.attribution__threshold
+            data["pie"].iloc[:2].sum() / data["nrows"] > cfg.insight.attribution__threshold
             and len(data["pie"]) >= 2
         ):
             vals = ", ".join(str(data["pie"].index[i]) for i in range(2))
@@ -1825,7 +1825,7 @@ def nom_insights(data: Dict[str, Any], col: str, cfg: Config) -> Dict[str, List[
             ins["Word Cloud"].append(f"{col} contains many words: {nwords} words")
     if cfg.wordfreq.enable:
         factor = (
-            round(data["word_cnts_freq"][0] / data["word_cnts_freq"][1], 2)
+            round(data["word_cnts_freq"].iloc[0] / data["word_cnts_freq"].iloc[1], 2)
             if len(data["word_cnts_freq"]) > 1
             else 0
         )


### PR DESCRIPTION
# Description
Previously each cell in obj column will transform to string including missing values. This will make missing values becomes a string 'nan' rather than missing. This PR fix this issue.