### PR TITLE
fix(clean): escape apostrophes in code exported by clean_dupl

### DIFF
--- a/dataprep/clean/clean_duplication_utils.py
+++ b/dataprep/clean/clean_duplication_utils.py
@@ -219,9 +219,13 @@ class Clusterer:
         df_name, col = self._df_name, f"'{self._col}'"
         replace_calls = []
         for idx, cluster in enumerate(cluster_page):
-            cluster_repr = f"'{new_values[idx]}'"
             if do_merge[idx]:
-                cluster_vals = [f"'{val}'" for val, _ in cluster if f"'{val}'" != cluster_repr]
+                # create the string that all the values in the cluster will be set to
+                cluster_repr = new_values[idx].replace("'", "\\'")
+                cluster_repr = f"'{cluster_repr}'"
+                # create the strings to be replaced
+                cluster_vals = [val.replace("'", "\\'") for val, _ in cluster]
+                cluster_vals = [f"'{val}'" for val in cluster_vals if f"'{val}'" != cluster_repr]
                 code = (
                     f"{df_name}[{col}] = {df_name}[{col}].replace"
                     f"([{', '.join(cluster_vals)}], {cluster_repr})"


### PR DESCRIPTION
# Description

When using the export code functionality of clean_duplication() apostrophes aren't escaped in exported code.

# How Has This Been Tested?

Unit tests

# Snapshots:


![Screen Shot 2021-04-23 at 8 43 17 PM](https://user-images.githubusercontent.com/47376068/115946211-95b8a600-a474-11eb-88e8-2b9df6e381e5.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [ ] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
