### PR TITLE
fix(eda): fix the na values in plot_diff

### DIFF
--- a/dataprep/eda/diff/compute/__init__.py
+++ b/dataprep/eda/diff/compute/__init__.py
@@ -5,7 +5,7 @@ import dask.dataframe as dd
 import pandas as pd
 from ....errors import DataprepError
 from ...intermediate import Intermediate
-from ...utils import to_dask
+from ...utils import preprocess_dataframe
 from ...dtypes import DTypeDef, string_dtype_to_object
 from ...configs import Config
 from .multiple_df import compare_multiple_df  # type: ignore
@@ -65,10 +65,7 @@ def compute_diff(
         if cfg.diff.baseline > len(df) - 1:
             raise ValueError("Baseline is out of the boundary of the input.")
 
-        df_list = list(map(to_dask, df))
-        for i, _ in enumerate(df_list):
-            df_list[i].columns = df_list[i].columns.astype(str)
-        df_list = list(map(string_dtype_to_object, df_list))
+        df_list = list(map(preprocess_dataframe, df))
 
         if x:
             # return compare_multiple_on_column(df_list, x)

--- a/dataprep/eda/diff/compute/multiple_df.py
+++ b/dataprep/eda/diff/compute/multiple_df.py
@@ -174,7 +174,6 @@ def compare_multiple_df(
         if is_dtype(col_dtype, Continuous()) and cfg.hist.enable:
             data.append((col, Continuous(), _cont_calcs(srs.apply("dropna"), cfg), orig))
         elif is_dtype(col_dtype, Nominal()) and cfg.bar.enable:
-            srs = srs.apply("astype", "str")
             data.append((col, Nominal(), _nom_calcs(srs.apply("dropna"), cfg), orig))
         elif is_dtype(col_dtype, DateTime()) and cfg.line.enable:
             data.append(


### PR DESCRIPTION
# Description

Currently the NA values will first be transformed to string then displayed as categorical values. This PR avoid the transformation for na values.