### PR TITLE
eda: fix NA and int viz issue in plot_diff

### DIFF
--- a/dataprep/eda/diff/compute/__init__.py
+++ b/dataprep/eda/diff/compute/__init__.py
@@ -6,7 +6,7 @@ import pandas as pd
 from ....errors import DataprepError
 from ...intermediate import Intermediate
 from ...utils import to_dask
-from ...dtypes import DTypeDef, string_dtype_to_object
+from ...dtypes import DTypeDef
 from ...configs import Config
 from .multiple_df import compare_multiple_df  # type: ignore
 
@@ -68,7 +68,6 @@ def compute_diff(
         df_list = list(map(to_dask, df))
         for i, _ in enumerate(df_list):
             df_list[i].columns = df_list[i].columns.astype(str)
-        df_list = list(map(string_dtype_to_object, df_list))
 
         if x:
             # return compare_multiple_on_column(df_list, x)

--- a/dataprep/eda/distribution/__init__.py
+++ b/dataprep/eda/distribution/__init__.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from ..configs import Config
 from ..container import Container
-from ..dtypes import DTypeDef
+from ..dtypes import DTypeDef, LatLong
 from ...progress_bar import ProgressBar
 from .compute import compute
 from .render import render
@@ -19,8 +19,8 @@ __all__ = ["plot", "compute", "render"]
 
 def plot(
     df: Union[pd.DataFrame, dd.DataFrame],
-    x: Optional[str] = None,
-    y: Optional[str] = None,
+    x: Optional[Union[str, LatLong]] = None,
+    y: Optional[Union[str, LatLong]] = None,
     z: Optional[str] = None,
     *,
     config: Optional[Dict[str, Any]] = None,

--- a/dataprep/eda/distribution/compute/__init__.py
+++ b/dataprep/eda/distribution/compute/__init__.py
@@ -9,7 +9,7 @@ import dask.dataframe as dd
 import pandas as pd
 
 from ...configs import Config
-from ...dtypes import DTypeDef, string_dtype_to_object, is_dtype, GeoPoint
+from ...dtypes import DTypeDef, string_dtype_to_object, is_dtype, GeoPoint, LatLong
 from ...intermediate import Intermediate
 from ...utils import preprocess_dataframe
 from .bivariate import compute_bivariate
@@ -22,8 +22,8 @@ __all__ = ["compute"]
 
 def compute(
     df: Union[pd.DataFrame, dd.DataFrame],
-    x: Optional[str] = None,
-    y: Optional[str] = None,
+    x: Optional[Union[str, LatLong]] = None,
+    y: Optional[Union[str, LatLong]] = None,
     z: Optional[str] = None,
     *,
     cfg: Union[Config, Dict[str, Any], None] = None,
@@ -111,10 +111,10 @@ def concat_latlong(df: Union[pd.DataFrame, dd.DataFrame], x: Any) -> Tuple[str, 
 
 def process_latlong(
     df: pd.DataFrame,
-    x: Optional[str] = None,
-    y: Optional[str] = None,
+    x: Optional[Union[str, LatLong]] = None,
+    y: Optional[Union[str, LatLong]] = None,
     z: Optional[str] = None,
-) -> Tuple[List[Optional[str]], List[str], pd.DataFrame]:
+) -> Tuple[List[Optional[Union[str, LatLong]]], List[str], pd.DataFrame]:
     """
     Process Latlong data tpye.
     """

--- a/dataprep/eda/distribution/compute/__init__.py
+++ b/dataprep/eda/distribution/compute/__init__.py
@@ -9,7 +9,7 @@ import dask.dataframe as dd
 import pandas as pd
 
 from ...configs import Config
-from ...dtypes import DTypeDef, string_dtype_to_object, is_dtype, GeoPoint, LatLong
+from ...dtypes import DTypeDef, is_dtype, GeoPoint, LatLong
 from ...intermediate import Intermediate
 from ...utils import preprocess_dataframe
 from .bivariate import compute_bivariate

--- a/dataprep/eda/distribution/compute/bivariate.py
+++ b/dataprep/eda/distribution/compute/bivariate.py
@@ -17,6 +17,7 @@ from ...dtypes import (
     GeoPoint,
     detect_dtype,
     is_dtype,
+    LatLong,
 )
 from ...intermediate import Intermediate
 from ...utils import (
@@ -31,8 +32,8 @@ from ...utils import (
 
 def compute_bivariate(
     df: dd.DataFrame,
-    x: str,
-    y: str,
+    x: Union[str, LatLong],
+    y: Union[str, LatLong],
     cfg: Config,
     dtype: Optional[DTypeDef],
 ) -> Intermediate:

--- a/dataprep/eda/distribution/compute/trivariate.py
+++ b/dataprep/eda/distribution/compute/trivariate.py
@@ -12,9 +12,11 @@ from ...dtypes import (
     DTypeDef,
     Nominal,
     GeoGraphy,
+    Union,
     detect_dtype,
     drop_null,
     is_dtype,
+    LatLong,
 )
 from ...intermediate import Intermediate
 from ...utils import _calc_line_dt
@@ -22,9 +24,9 @@ from ...utils import _calc_line_dt
 
 def compute_trivariate(
     df: dd.DataFrame,
-    x: str,
-    y: str,
-    z: str,
+    x: Union[str, LatLong],
+    y: Union[str, LatLong],
+    z: Union[str, LatLong],
     cfg: Config,
     dtype: Optional[DTypeDef] = None,
 ) -> Intermediate:

--- a/dataprep/eda/distribution/compute/univariate.py
+++ b/dataprep/eda/distribution/compute/univariate.py
@@ -2,7 +2,7 @@
 Computations for plot(df, x)
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import math
 import dask
@@ -25,6 +25,7 @@ from ...dtypes import (
     GeoPoint,
     detect_dtype,
     is_dtype,
+    LatLong,
 )
 from ...intermediate import Intermediate
 from ...utils import _calc_line_dt, gaussian_kde, normaltest
@@ -32,7 +33,7 @@ from ...utils import _calc_line_dt, gaussian_kde, normaltest
 
 def compute_univariate(
     df: dd.DataFrame,
-    x: Optional[str],
+    x: Optional[Union[str, LatLong]],
     cfg: Config,
     dtype: Optional[DTypeDef],
 ) -> Intermediate:

--- a/dataprep/eda/dtypes.py
+++ b/dataprep/eda/dtypes.py
@@ -318,17 +318,6 @@ def is_pandas_categorical(dtype: Any) -> bool:
     return any(isinstance(dtype, c) for c in CATEGORICAL_PANDAS_DTYPES)
 
 
-def string_dtype_to_object(df: dd.DataFrame) -> dd.DataFrame:
-    """
-    Convert string dtype to object dtype
-    """
-    for col in df.columns:
-        if any(isinstance(df[col].dtype, c) for c in STRING_DTYPES):
-            df[col] = df[col].astype(object)
-
-    return df
-
-
 def drop_null(
     var: Union[dd.Series, pd.DataFrame, dd.DataFrame]
 ) -> Union[pd.Series, dd.Series, pd.DataFrame, dd.DataFrame]:

--- a/dataprep/tests/eda/test_plot.py
+++ b/dataprep/tests/eda/test_plot.py
@@ -10,7 +10,7 @@ import pytest
 from ...datasets import load_dataset
 
 from ...eda import plot
-from ...eda.dtypes import Nominal
+from ...eda.dtypes import Nominal, LatLong
 from ...eda.utils import to_dask
 from .random_data_generator import random_df
 
@@ -92,6 +92,8 @@ def test_specify_color(simpledf: dd.DataFrame) -> None:
 def test_geo(geodf: dd.DataFrame) -> None:
     plot(geodf, "Country")
     plot(geodf, "Country", "Population")
+    covid = load_dataset("covid19")
+    plot(covid, LatLong("Lat", "Long"), "2/16/2020")
 
 
 def test_random_df(random_df: pd.DataFrame) -> None:

--- a/dataprep/tests/eda/test_plot_diff.py
+++ b/dataprep/tests/eda/test_plot_diff.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 from ...eda import plot_diff
+from ...datasets import load_dataset
 from ...eda.dtypes import Nominal
 from ...eda.utils import to_dask
 
@@ -64,3 +65,10 @@ def test_specify_label(simpledf: dd.DataFrame) -> None:
 
 def test_specify_baseline(simpledf: dd.DataFrame) -> None:
     plot_diff([simpledf, simpledf], config={"diff.baseline": 1})
+
+
+def test_dataset() -> None:
+    df = load_dataset("titanic")
+    df1 = df[df["Survived"] == 0]
+    df2 = df[df["Survived"] == 1]
+    plot_diff([df1, df2])


### PR DESCRIPTION
# Description

1. Currently the NA values will first be transformed to string then displayed as categorical values. This PR avoid the transformation for na values.
2. Currently the int column may change to float when concat dfs. This PR fixs the float display for int column.
