### PR TITLE
feat(clean): support conversion into packed binary format in clean_ip

### DIFF
--- a/dataprep/clean/clean_ip.py
+++ b/dataprep/clean/clean_ip.py
@@ -49,6 +49,7 @@ def clean_ip(
             - 'binary': binary representation ('00001100000000110000010000000101')
             - 'hexa': hexadecimal representation ('0xc030405')
             - 'integer': integer representation (201524229)
+            - 'packed': packed binary representation (big-endian, a bytes object)
 
         (default: 'compressed')
     inplace
@@ -98,10 +99,10 @@ def clean_ip(
             f'input_format {input_format} is invalid, it needs to be "ipv4", "ipv6" or "auto"'
         )
 
-    if output_format not in {"compressed", "full", "binary", "hexa", "integer"}:
+    if output_format not in {"compressed", "full", "binary", "hexa", "integer", "packed"}:
         raise ValueError(
             f'output_format {output_format} is invalid, it needs to be "compressed", "full", '
-            '"binary", "hexa" or "integer"'
+            '"binary", "hexa", "integer" or "packed"'
         )
 
     if not isinstance(inplace, bool):
@@ -192,6 +193,7 @@ def _format_ip(val: Any, input_format: str, output_format: str, errors: str) -> 
         2 := the value is cleaned and the cleaned value is DIFFERENT than the input value
         3 := the value is cleaned and is THE SAME as the input value (no transformation)
     """
+    # pylint: disable=too-many-branches
     address, status = _check_ip(val, input_format, True)
 
     if status == "null":
@@ -220,6 +222,10 @@ def _format_ip(val: Any, input_format: str, output_format: str, errors: str) -> 
     # converts to integer format
     elif output_format == "integer":
         result = int(address)
+
+    # converts to packed binary format (big-endian)
+    elif output_format == "packed":
+        result = address.packed
 
     # convert to full representation
     else:

--- a/dataprep/tests/clean/test_clean_ip.py
+++ b/dataprep/tests/clean/test_clean_ip.py
@@ -123,6 +123,21 @@ def test_clean_output_binary(df_ips: pd.DataFrame) -> None:
     assert df_check.equals(df_clean)
 
 
+def test_clean_output_packed(df_ips: pd.DataFrame) -> None:
+    df_clean = clean_ip(df_ips, column="messy_ip", output_format="packed")
+    df_check = df_ips.copy()
+    df_check["messy_ip_clean"] = [
+        b' \x01\r\xb8\x85\xa3\x00\x00\x00\x00\x8a.\x03ps4',
+        b'\x0c\x03\x04\x05',
+        b'\xe9\x05\x06\x00',
+        np.nan,
+        np.nan,
+        b'\xb1\xc3\x94t',
+        b'\xfd\xf8\xf5;\x82\xe4\x00\x00\x00\x00\x00\x00\x00\x00\x00S',
+    ]
+    assert df_check.equals(df_clean)
+
+
 def test_validate_value() -> None:
     assert validate_ip("2001:0db8:85a3:0000:0000:8a2e:0370:7334") == True
     assert validate_ip("") == False

--- a/docs/source/user_guide/clean/clean_ip.ipynb
+++ b/docs/source/user_guide/clean/clean_ip.ipynb
@@ -35,7 +35,8 @@
     "* `full`: provides full version of the ip address,\n",
     "* `binary`: provides binary representation of the ip address,\n",
     "* `hexa`: provides hexadecimal representation of the ip address,\n",
-    "* `integer`: provides integer representation of the ip address.\n",
+    "* `integer`: provides integer representation of the ip address,\n",
+    "* `packed`: provides packed binary representation of the ip address.\n",
     "\n",
     "The default output format is `compressed`.\n",
     "\n",
@@ -69,7 +70,7 @@
     "df = pd.DataFrame({\n",
     "    \"ips\": [\n",
     "        \"00.000.0.0\", \"455.0.0.0\", None, 876234, {}, \"00.12.021.255\",\n",
-    "        \"684D:1111:222:3333:4444:5555:6:77\"\n",
+    "        \"684D:1111:222:3333:4444:5555:6:77\", b'\\xc9\\xdb\\x10\\x00'\n",
     "    ]\n",
     "})\n",
     "df"
@@ -268,6 +269,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### `packed`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ip(df, \"ips\", output_format=\"packed\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 3. `errors` parameter"
    ]
   },
@@ -367,7 +384,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Description

Add an option "packed" in parameter `output_format` in `clean_ip`, which is mentioned in issue #631 . This will make it support conversion into packed binary format (a bit-endian byte object).
Since `clean_ip` can accept this format as input, and `validate_ip` can recognize the format as well, now the whole set of functions related to ip support the format.

# How Has This Been Tested?
Using example in the document.
```python3
from dataprep.clean import clean_ip
import pandas as pd
df = pd.DataFrame({
    "ips": [
        "00.000.0.0", "455.0.0.0", None, 876234, {}, "00.12.021.255",
        "684D:1111:222:3333:4444:5555:6:77"
    ]
})
clean_ip(df, "ips", output_format = "packed")
```

# Snapshots:

![image](https://user-images.githubusercontent.com/66409637/119612002-f3526080-be2d-11eb-98f8-11948d2671e0.png)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already squashed the commits and make the commit message conform to the project standard.
- [ ] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
