### PR TITLE
feat(clean): add multiple clean functions for number types

### DIFF
--- a/dataprep/clean/__init__.py
+++ b/dataprep/clean/__init__.py
@@ -2,7 +2,6 @@
 dataprep.clean
 ==============
 """
-
 from .clean_lat_long import clean_lat_long, validate_lat_long
 
 from .clean_email import clean_email, validate_email
@@ -29,6 +28,278 @@ from .clean_df import clean_df
 
 from .clean_text import clean_text, default_text_pipeline
 
+from .clean_au_abn import clean_au_abn, validate_au_abn
+
+from .clean_au_acn import clean_au_acn, validate_au_acn
+
+from .clean_au_tfn import clean_au_tfn, validate_au_tfn
+
+from .clean_be_iban import clean_be_iban, validate_be_iban
+
+from .clean_be_vat import clean_be_vat, validate_be_vat
+
+from .clean_bg_egn import clean_bg_egn, validate_bg_egn
+
+from .clean_bg_pnf import clean_bg_pnf, validate_bg_pnf
+
+from .clean_bg_vat import clean_bg_vat, validate_bg_vat
+
+from .clean_br_cnpj import clean_br_cnpj, validate_br_cnpj
+
+from .clean_br_cpf import clean_br_cpf, validate_br_cpf
+
+from .clean_by_unp import clean_by_unp, validate_by_unp
+
+from .clean_ca_bn import clean_ca_bn, validate_ca_bn
+
+from .clean_ca_sin import clean_ca_sin, validate_ca_sin
+
+from .clean_ch_esr import clean_ch_esr, validate_ch_esr
+
+from .clean_ch_ssn import clean_ch_ssn, validate_ch_ssn
+
+from .clean_ch_uid import clean_ch_uid, validate_ch_uid
+
+from .clean_ch_vat import clean_ch_vat, validate_ch_vat
+
+from .clean_cl_rut import clean_cl_rut, validate_cl_rut
+
+from .clean_cn_ric import clean_cn_ric, validate_cn_ric
+
+from .clean_cn_uscc import clean_cn_uscc, validate_cn_uscc
+
+from .clean_co_nit import clean_co_nit, validate_co_nit
+
+from .clean_cr_cpf import clean_cr_cpf, validate_cr_cpf
+
+from .clean_cr_cpj import clean_cr_cpj, validate_cr_cpj
+
+from .clean_cr_cr import clean_cr_cr, validate_cr_cr
+
+from .clean_cu_ni import clean_cu_ni, validate_cu_ni
+
+from .clean_cy_vat import clean_cy_vat, validate_cy_vat
+
+from .clean_cz_dic import clean_cz_dic, validate_cz_dic
+
+from .clean_cz_rc import clean_cz_rc, validate_cz_rc
+
+from .clean_de_handelsregisternummer import (
+    clean_de_handelsregisternummer,
+    validate_de_handelsregisternummer,
+)
+
+from .clean_de_idnr import clean_de_idnr, validate_de_idnr
+
+from .clean_de_stnr import clean_de_stnr, validate_de_stnr
+
+from .clean_de_vat import clean_de_vat, validate_de_vat
+
+from .clean_de_wkn import clean_de_wkn, validate_de_wkn
+
+from .clean_dk_cpr import clean_dk_cpr, validate_dk_cpr
+
+from .clean_dk_cvr import clean_dk_cvr, validate_dk_cvr
+
+from .clean_do_cedula import clean_do_cedula, validate_do_cedula
+
+from .clean_do_ncf import clean_do_ncf, validate_do_ncf
+
+from .clean_do_rnc import clean_do_rnc, validate_do_rnc
+
+from .clean_ec_ci import clean_ec_ci, validate_ec_ci
+
+from .clean_ec_ruc import clean_ec_ruc, validate_ec_ruc
+
+from .clean_ee_ik import clean_ee_ik, validate_ee_ik
+
+from .clean_ee_kmkr import clean_ee_kmkr, validate_ee_kmkr
+
+from .clean_ee_registrikood import clean_ee_registrikood, validate_ee_registrikood
+
+from .clean_es_ccc import clean_es_ccc, validate_es_ccc
+
+from .clean_es_cif import clean_es_cif, validate_es_cif
+
+from .clean_es_cups import clean_es_cups, validate_es_cups
+
+from .clean_es_dni import clean_es_dni, validate_es_dni
+
+from .clean_es_iban import clean_es_iban, validate_es_iban
+
+from .clean_es_nie import clean_es_nie, validate_es_nie
+
+from .clean_es_nif import clean_es_nif, validate_es_nif
+
+from .clean_es_referenciacatastral import (
+    clean_es_referenciacatastral,
+    validate_es_referenciacatastral,
+)
+
+from .clean_eu_at_02 import clean_eu_at_02, validate_eu_at_02
+
+from .clean_eu_banknote import clean_eu_banknote, validate_eu_banknote
+
+from .clean_eu_eic import clean_eu_eic, validate_eu_eic
+
+from .clean_eu_nace import clean_eu_nace, validate_eu_nace
+
+from .clean_eu_vat import clean_eu_vat, validate_eu_vat
+
+from .clean_fi_alv import clean_fi_alv, validate_fi_alv
+
+from .clean_fi_associationid import (
+    clean_fi_associationid,
+    validate_fi_associationid,
+)
+
+from .clean_fi_hetu import clean_fi_hetu, validate_fi_hetu
+
+from .clean_fi_veronumero import (
+    clean_fi_veronumero,
+    validate_fi_veronumero,
+)
+
+from .clean_fi_ytunnus import clean_fi_ytunnus, validate_fi_ytunnus
+
+from .clean_fr_nif import clean_fr_nif, validate_fr_nif
+
+from .clean_fr_nir import clean_fr_nir, validate_fr_nir
+
+from .clean_fr_siren import clean_fr_siren, validate_fr_siren
+
+from .clean_fr_siret import clean_fr_siret, validate_fr_siret
+
+from .clean_fr_tva import clean_fr_tva, validate_fr_tva
+
+from .clean_gb_nhs import clean_gb_nhs, validate_gb_nhs
+
+from .clean_gb_sedol import clean_gb_sedol, validate_gb_sedol
+
+from .clean_gb_upn import clean_gb_upn, validate_gb_upn
+
+from .clean_gb_utr import clean_gb_utr, validate_gb_utr
+
+from .clean_gb_vat import clean_gb_vat, validate_gb_vat
+
+from .clean_gr_amka import clean_gr_amka, validate_gr_amka
+
+from .clean_gr_vat import clean_gr_vat, validate_gr_vat
+
+from .clean_gt_nit import clean_gt_nit, validate_gt_nit
+
+from .clean_hr_oib import clean_hr_oib, validate_hr_oib
+
+from .clean_hu_anum import clean_hu_anum, validate_hu_anum
+
+from .clean_id_npwp import clean_id_npwp, validate_id_npwp
+
+from .clean_ie_pps import clean_ie_pps, validate_ie_pps
+
+from .clean_ie_vat import clean_ie_vat, validate_ie_vat
+
+from .clean_il_hp import clean_il_hp, validate_il_hp
+
+from .clean_il_idnr import clean_il_idnr, validate_il_idnr
+
+from .clean_in_aadhaar import clean_in_aadhaar, validate_in_aadhaar
+
+from .clean_in_pan import clean_in_pan, validate_in_pan
+
+from .clean_is_kennitala import clean_is_kennitala, validate_is_kennitala
+
+from .clean_is_vsk import clean_is_vsk, validate_is_vsk
+
+from .clean_it_aic import clean_it_aic, validate_it_aic
+
+from .clean_it_codicefiscale import clean_it_codicefiscale, validate_it_codicefiscale
+
+from .clean_it_iva import clean_it_iva, validate_it_iva
+
+from .clean_jp_cn import clean_jp_cn, validate_jp_cn
+
+from .clean_kr_brn import clean_kr_brn, validate_kr_brn
+
+from .clean_kr_rrn import clean_kr_rrn, validate_kr_rrn
+
+from .clean_li_peid import clean_li_peid, validate_li_peid
+
+from .clean_lt_asmens import clean_lt_asmens, validate_lt_asmens
+
+from .clean_lt_pvm import clean_lt_pvm, validate_lt_pvm
+
+from .clean_lu_tva import clean_lu_tva, validate_lu_tva
+
+from .clean_lv_pvn import clean_lv_pvn, validate_lv_pvn
+
+from .clean_mc_tva import clean_mc_tva, validate_mc_tva
+
+from .clean_md_idno import clean_md_idno, validate_md_idno
+
+from .clean_me_iban import clean_me_iban, validate_me_iban
+
+from .clean_mt_vat import clean_mt_vat, validate_mt_vat
+
+from .clean_mu_nid import clean_mu_nid, validate_mu_nid
+
+from .clean_mx_curp import clean_mx_curp, validate_mx_curp
+
+from .clean_mx_rfc import clean_mx_rfc, validate_mx_rfc
+
+from .clean_my_nric import clean_my_nric, validate_my_nric
+
+from .clean_nl_brin import clean_nl_brin, validate_nl_brin
+
+from .clean_nl_bsn import clean_nl_bsn, validate_nl_bsn
+
+from .clean_nl_btw import clean_nl_btw, validate_nl_btw
+
+from .clean_nl_onderwijsnummer import (
+    clean_nl_onderwijsnummer,
+    validate_nl_onderwijsnummer,
+)
+
+from .clean_nl_postcode import clean_nl_postcode, validate_nl_postcode
+
+from .clean_no_fodselsnummer import (
+    clean_no_fodselsnummer,
+    validate_no_fodselsnummer,
+)
+
+from .clean_no_iban import clean_no_iban, validate_no_iban
+
+from .clean_no_kontonr import clean_no_kontonr, validate_no_kontonr
+
+from .clean_no_mva import clean_no_mva, validate_no_mva
+
+from .clean_no_orgnr import clean_no_orgnr, validate_no_orgnr
+
+from .clean_nz_bankaccount import clean_nz_bankaccount, validate_nz_bankaccount
+
+from .clean_nz_ird import clean_nz_ird, validate_nz_ird
+
+from .clean_pe_cui import clean_pe_cui, validate_pe_cui
+
+from .clean_pe_ruc import clean_pe_ruc, validate_pe_ruc
+
+from .clean_pl_nip import clean_pl_nip, validate_pl_nip
+
+from .clean_pl_pesel import clean_pl_pesel, validate_pl_pesel
+
+from .clean_pl_regon import clean_pl_regon, validate_pl_regon
+
+from .clean_pt_nif import clean_pt_nif, validate_pt_nif
+
+from .clean_py_ruc import clean_py_ruc, validate_py_ruc
+
+from .clean_ro_cf import clean_ro_cf, validate_ro_cf
+
+from .clean_ro_cnp import clean_ro_cnp, validate_ro_cnp
+
+from .clean_ro_cui import clean_ro_cui, validate_ro_cui
+
+from .clean_ro_onrc import clean_ro_onrc, validate_ro_onrc
+
 
 __all__ = [
     "clean_lat_long",
@@ -54,4 +325,258 @@ __all__ = [
     "clean_df",
     "clean_text",
     "default_text_pipeline",
+    "clean_au_abn",
+    "validate_au_abn",
+    "clean_au_acn",
+    "validate_au_acn",
+    "clean_au_tfn",
+    "validate_au_tfn",
+    "clean_be_iban",
+    "validate_be_iban",
+    "clean_be_vat",
+    "validate_be_vat",
+    "clean_bg_egn",
+    "validate_bg_egn",
+    "clean_bg_pnf",
+    "validate_bg_pnf",
+    "clean_bg_vat",
+    "validate_bg_vat",
+    "clean_br_cnpj",
+    "validate_br_cnpj",
+    "clean_br_cpf",
+    "validate_br_cpf",
+    "clean_by_unp",
+    "validate_by_unp",
+    "clean_ca_bn",
+    "validate_ca_bn",
+    "clean_ca_sin",
+    "validate_ca_sin",
+    "clean_ch_esr",
+    "validate_ch_esr",
+    "clean_ch_ssn",
+    "validate_ch_ssn",
+    "clean_ch_uid",
+    "validate_ch_uid",
+    "clean_ch_vat",
+    "validate_ch_vat",
+    "clean_cl_rut",
+    "validate_cl_rut",
+    "clean_cn_ric",
+    "validate_cn_ric",
+    "clean_cn_uscc",
+    "validate_cn_uscc",
+    "clean_co_nit",
+    "validate_co_nit",
+    "clean_cr_cpf",
+    "validate_cr_cpf",
+    "clean_cr_cpj",
+    "validate_cr_cpj",
+    "clean_cr_cr",
+    "validate_cr_cr",
+    "clean_cu_ni",
+    "validate_cu_ni",
+    "clean_cy_vat",
+    "validate_cy_vat",
+    "clean_cz_dic",
+    "validate_cz_dic",
+    "clean_cz_rc",
+    "validate_cz_rc",
+    "clean_de_handelsregisternummer",
+    "validate_de_handelsregisternummer",
+    "clean_de_idnr",
+    "validate_de_idnr",
+    "clean_de_stnr",
+    "validate_de_stnr",
+    "clean_de_vat",
+    "validate_de_vat",
+    "clean_de_wkn",
+    "validate_de_wkn",
+    "clean_dk_cpr",
+    "validate_dk_cpr",
+    "clean_dk_cvr",
+    "validate_dk_cvr",
+    "clean_do_cedula",
+    "validate_do_cedula",
+    "clean_do_ncf",
+    "validate_do_ncf",
+    "clean_do_rnc",
+    "validate_do_rnc",
+    "clean_ec_ci",
+    "validate_ec_ci",
+    "clean_ec_ruc",
+    "validate_ec_ruc",
+    "clean_ee_ik",
+    "validate_ee_ik",
+    "clean_ee_kmkr",
+    "validate_ee_kmkr",
+    "clean_ee_registrikood",
+    "validate_ee_registrikood",
+    "clean_es_ccc",
+    "validate_es_ccc",
+    "clean_es_cif",
+    "validate_es_cif",
+    "clean_es_cups",
+    "validate_es_cups",
+    "clean_es_dni",
+    "validate_es_dni",
+    "clean_es_iban",
+    "validate_es_iban",
+    "clean_es_nie",
+    "validate_es_nie",
+    "clean_es_nif",
+    "validate_es_nif",
+    "clean_es_referenciacatastral",
+    "validate_es_referenciacatastral",
+    "clean_eu_at_02",
+    "validate_eu_at_02",
+    "clean_eu_banknote",
+    "validate_eu_banknote",
+    "clean_eu_eic",
+    "validate_eu_eic",
+    "clean_eu_nace",
+    "validate_eu_nace",
+    "clean_eu_vat",
+    "validate_eu_vat",
+    "clean_fi_alv",
+    "validate_fi_alv",
+    "clean_fi_associationid",
+    "validate_fi_associationid",
+    "clean_fi_hetu",
+    "validate_fi_hetu",
+    "clean_fi_veronumero",
+    "validate_fi_veronumero",
+    "clean_fi_ytunnus",
+    "validate_fi_ytunnus",
+    "clean_fr_nif",
+    "validate_fr_nif",
+    "clean_fr_nir",
+    "validate_fr_nir",
+    "clean_fr_siren",
+    "validate_fr_siren",
+    "clean_fr_siret",
+    "validate_fr_siret",
+    "clean_fr_tva",
+    "validate_fr_tva",
+    "clean_gb_nhs",
+    "validate_gb_nhs",
+    "clean_gb_sedol",
+    "validate_gb_sedol",
+    "clean_gb_upn",
+    "validate_gb_upn",
+    "clean_gb_utr",
+    "validate_gb_utr",
+    "clean_gb_vat",
+    "validate_gb_vat",
+    "clean_gr_amka",
+    "validate_gr_amka",
+    "clean_gr_vat",
+    "validate_gr_vat",
+    "clean_gt_nit",
+    "validate_gt_nit",
+    "clean_hr_oib",
+    "validate_hr_oib",
+    "clean_hu_anum",
+    "validate_hu_anum",
+    "clean_id_npwp",
+    "validate_id_npwp",
+    "clean_ie_pps",
+    "validate_ie_pps",
+    "clean_ie_vat",
+    "validate_ie_vat",
+    "clean_il_hp",
+    "validate_il_hp",
+    "clean_il_idnr",
+    "validate_il_idnr",
+    "clean_in_aadhaar",
+    "validate_in_aadhaar",
+    "clean_in_pan",
+    "validate_in_pan",
+    "clean_is_kennitala",
+    "validate_is_kennitala",
+    "clean_is_vsk",
+    "validate_is_vsk",
+    "clean_it_aic",
+    "validate_it_aic",
+    "clean_it_codicefiscale",
+    "validate_it_codicefiscale",
+    "clean_it_iva",
+    "validate_it_iva",
+    "clean_jp_cn",
+    "validate_jp_cn",
+    "clean_kr_brn",
+    "validate_kr_brn",
+    "clean_kr_rrn",
+    "validate_kr_rrn",
+    "clean_li_peid",
+    "validate_li_peid",
+    "clean_lt_asmens",
+    "validate_lt_asmens",
+    "clean_lt_pvm",
+    "validate_lt_pvm",
+    "clean_lu_tva",
+    "validate_lu_tva",
+    "clean_lv_pvn",
+    "validate_lv_pvn",
+    "clean_mc_tva",
+    "validate_mc_tva",
+    "clean_md_idno",
+    "validate_md_idno",
+    "clean_me_iban",
+    "validate_me_iban",
+    "clean_mt_vat",
+    "validate_mt_vat",
+    "clean_mu_nid",
+    "validate_mu_nid",
+    "clean_mx_curp",
+    "validate_mx_curp",
+    "clean_mx_rfc",
+    "validate_mx_rfc",
+    "clean_my_nric",
+    "validate_my_nric",
+    "clean_nl_brin",
+    "validate_nl_brin",
+    "clean_nl_bsn",
+    "validate_nl_bsn",
+    "clean_nl_btw",
+    "validate_nl_btw",
+    "clean_nl_onderwijsnummer",
+    "validate_nl_onderwijsnummer",
+    "clean_nl_postcode",
+    "validate_nl_postcode",
+    "clean_no_fodselsnummer",
+    "validate_no_fodselsnummer",
+    "clean_no_iban",
+    "validate_no_iban",
+    "clean_no_kontonr",
+    "validate_no_kontonr",
+    "clean_no_mva",
+    "validate_no_mva",
+    "clean_no_orgnr",
+    "validate_no_orgnr",
+    "clean_nz_bankaccount",
+    "validate_nz_bankaccount",
+    "clean_nz_ird",
+    "validate_nz_ird",
+    "clean_pe_cui",
+    "validate_pe_cui",
+    "clean_pe_ruc",
+    "validate_pe_ruc",
+    "clean_pl_nip",
+    "validate_pl_nip",
+    "clean_pl_pesel",
+    "validate_pl_pesel",
+    "clean_pl_regon",
+    "validate_pl_regon",
+    "clean_pt_nif",
+    "validate_pt_nif",
+    "clean_py_ruc",
+    "validate_py_ruc",
+    "clean_ro_cf",
+    "validate_ro_cf",
+    "clean_ro_cnp",
+    "validate_ro_cnp",
+    "clean_ro_cui",
+    "validate_ro_cui",
+    "clean_ro_onrc",
+    "validate_ro_onrc",
 ]

--- a/dataprep/clean/clean_au_abn.py
+++ b/dataprep/clean/clean_au_abn.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Australian Business Numbers (ABNs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.au import abn
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_au_abn(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Australian Business Numbers (ABNs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of ABN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of ABN data.
+
+    >>> df = pd.DataFrame({{
+            "abn": [
+            "51824753556",
+            "99999999999",]
+            })
+    >>> clean_au_abn(df, 'abn')
+            abn                 abn_clean
+    0       51824753556         51 824 753 556
+    1       99999999999         NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_au_abn(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is ABN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(abn.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(abn.is_valid)
+        else:
+            return df.applymap(abn.is_valid)
+    return abn.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_au_abn(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [abn.compact(val)] + result
+    elif output_format == "standard":
+        result = [abn.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_au_acn.py
+++ b/dataprep/clean/clean_au_acn.py
@@ -1,0 +1,165 @@
+"""
+Clean and validate a DataFrame column containing Australian Company Numbers (ACNs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.au import acn
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_au_acn(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Australian Company Numbers (ACNs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of ACN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'abn', convert the number to an Australian Business Number (ABN).
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of ACN data.
+
+    >>> df = pd.DataFrame({{
+            "acn": [
+            "004085616",
+            "999 999 999"]
+            })
+    >>> clean_au_acn(df, 'acn')
+            acn             acn_clean
+    0       004085616       004 085 616
+    1       999 999 999     NaN
+    """
+
+    if output_format not in {"compact", "standard", "abn"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "abn".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_au_acn(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is ACN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(acn.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(acn.is_valid)
+        else:
+            return df.applymap(acn.is_valid)
+    return acn.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'abn', convert the number to an Australian Business Number (ABN).
+    """
+    val = str(val)
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_au_acn(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [acn.compact(val)]
+    elif output_format == "standard":
+        result = [acn.format(val)]
+    elif output_format == "abn":
+        result = [acn.to_abn(val)]
+
+    return result

--- a/dataprep/clean/clean_au_tfn.py
+++ b/dataprep/clean/clean_au_tfn.py
@@ -1,0 +1,160 @@
+"""
+Clean and validate a DataFrame column containing Australian Tax File Numbers (TFNs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.au import tfn
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_au_tfn(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Australian Tax File Numbers (TFNs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of TFN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of TFN data.
+
+    >>> df = pd.DataFrame({
+            "tfn": [
+            "123456782",
+            "999 999 999"]
+            })
+    >>> clean_au_tfn(df, 'tfn')
+            tfn             tfn_clean
+    0       123456782       123 456 782
+    1       999 999 999     NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_au_tfn(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is TFN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(tfn.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(tfn.is_valid)
+        else:
+            return df.applymap(tfn.is_valid)
+    return tfn.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_au_tfn(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [tfn.compact(val)]
+    elif output_format == "standard":
+        result = [tfn.format(val)]
+
+    return result

--- a/dataprep/clean/clean_be_iban.py
+++ b/dataprep/clean/clean_be_iban.py
@@ -1,0 +1,166 @@
+"""
+Clean and validate a DataFrame column containing Belgian IBANs.
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.be import iban
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_be_iban(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Belgian IBAN (International Bank Account Number) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of Belgian IBAN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'bic', return the BIC for the bank that this number refers to.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of Belgian IBANs data.
+
+    >>> df = pd.DataFrame({{
+            "be_iban": [
+            "BE32 123-4567890-02",
+            "BE41091811735141"]
+            })
+    >>> clean_be_iban(df, 'be_iban')
+            be_iban                 be_iban_clean
+    0       BE32 123-4567890-02     BE32123456789002
+    1       BE41091811735141        NaN
+    """
+
+    if output_format not in {"compact", "standard", "bic"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "bic".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_be_iban(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is Belgian IBAN in a DataFrame column.
+    For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(iban.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(iban.is_valid)
+        else:
+            return df.applymap(iban.is_valid)
+    return iban.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'bic', return the BIC for the bank that this number refers to.
+    """
+    val = str(val)
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_be_iban(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [iban.compact(val)]
+    elif output_format == "standard":
+        result = [iban.format(val)]
+    elif output_format == "bic":
+        result = [iban.to_bic(val)]
+
+    return result

--- a/dataprep/clean/clean_be_vat.py
+++ b/dataprep/clean/clean_be_vat.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Belgian VAT numbers (VATs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.be import vat
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_be_vat(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Belgian VAT numbers (VATs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of VAT type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of VAT, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of VAT data.
+
+    >>> df = pd.DataFrame({{
+            "vat": [
+            'BE403019261',
+            'BE431150351',]
+            })
+    >>> clean_be_vat(df, 'vat')
+            vat             vat_clean
+    0       BE403019261     0403019261
+    1       BE431150351     NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_be_vat(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is VAT in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(vat.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(vat.is_valid)
+        else:
+            return df.applymap(vat.is_valid)
+    return vat.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of VAT, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_be_vat(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [vat.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_bg_egn.py
+++ b/dataprep/clean/clean_bg_egn.py
@@ -1,0 +1,165 @@
+"""
+Clean and validate a DataFrame column containing Bulgarian national identification numbers (EGNs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.bg import egn
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_bg_egn(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Bulgarian national identification numbers (EGNs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of EGN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', return the birth date attained from the number.
+            Note: in the case of EGN, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of EGN data.
+
+    >>> df = pd.DataFrame({{
+            "egn": [
+            '752316 926 3',
+            '7552A10004']
+            })
+    >>> clean_bg_egn(df, 'egn')
+            egn             egn_clean
+    0       752316 926 3    7523169263
+    1       7552A10004      NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "birthdate.'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_bg_egn(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is EGN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(egn.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(egn.is_valid)
+        else:
+            return df.applymap(egn.is_valid)
+    return egn.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', return the birth date attained from the number.
+           Note: in the case of EGN, the compact format is the same as the standard one.
+    """
+    val = str(val)
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_bg_egn(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [egn.compact(val)]
+    elif output_format == "birthdate":
+        result = [egn.get_birth_date(val)]  # DateTime type
+
+    return result

--- a/dataprep/clean/clean_bg_pnf.py
+++ b/dataprep/clean/clean_bg_pnf.py
@@ -1,0 +1,160 @@
+"""
+Clean and validate a DataFrame column containing Bulgarian personal number of a foreigner.
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.bg import pnf
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_bg_pnf(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Bulgarian personal number of a foreigner type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of PNF type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of PNF, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of PNF data.
+
+    >>> df = pd.DataFrame({{
+            "pnf": [
+            '7111 042 925',
+            '7111042922'] # invalid check digit
+            })
+    >>> clean_bg_pnf(df, 'pnf')
+            pnf             pnf_clean
+    0       7111 042 925    7111042925
+    1       7111042922      NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_bg_pnf(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is PNF in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(pnf.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(pnf.is_valid)
+        else:
+            return df.applymap(pnf.is_valid)
+    return pnf.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of PNF, the compact format is the same as the standard one.
+    """
+    val = str(val)
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_bg_pnf(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [pnf.compact(val)]
+
+    return result

--- a/dataprep/clean/clean_bg_vat.py
+++ b/dataprep/clean/clean_bg_vat.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing Bulgarian VAT numbers (VATs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.bg import vat
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_bg_vat(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Bulgarian VAT numbers (VATs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of VAT type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of VAT, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of VAT data.
+
+    >>> df = pd.DataFrame({{
+            "vat": [
+            'BG 175 074 752',
+            '175074752',
+            '175074751']
+            })
+    >>> clean_bg_vat(df, 'vat')
+            vat             vat_clean
+    0       BG 175 074 752  175074752
+    1       175074752       175074752
+    2       175074751       NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_bg_vat(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is VAT in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(vat.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(vat.is_valid)
+        else:
+            return df.applymap(vat.is_valid)
+    return vat.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of VAT, the compact format is the same as the standard one.
+    """
+    val = str(val)
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_bg_vat(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [vat.compact(val)]
+
+    return result

--- a/dataprep/clean/clean_br_cnpj.py
+++ b/dataprep/clean/clean_br_cnpj.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing CNPJ numbers, Brazilian company identifier.
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.br import cnpj
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_br_cnpj(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Brazilian company identifier data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CNPJ type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CNPJ data.
+
+    >>> df = pd.DataFrame({{
+            "cnpj": [
+            '16727230000197',
+            '16.727.230.0001-98', # InvalidChecksum
+            '16.727.230/0001=97'] # invalid delimiter
+            })
+    >>> clean_br_cnpj(df, 'cnpj')
+            cnpj                cnpj_clean
+    0       16727230000197      16.727.230/0001-97
+    1       16.727.230.0001-98  NaN
+    2       16.727.230/0001=97  NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_br_cnpj(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CNPJ in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(cnpj.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(cnpj.is_valid)
+        else:
+            return df.applymap(cnpj.is_valid)
+    return cnpj.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_br_cnpj(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [cnpj.compact(val)]
+    elif output_format == "standard":
+        result = [cnpj.format(val)]
+
+    return result

--- a/dataprep/clean/clean_br_cpf.py
+++ b/dataprep/clean/clean_br_cpf.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing CPF numbers, Brazilian national identifier.
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.br import cpf
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_br_cpf(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Brazilian national identifier data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CPF type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CPF data.
+
+    >>> df = pd.DataFrame({{
+            "cpf": [
+            '23100299900',
+            '231.002.999-00', # InvalidChecksum
+            '390.533.447=0'] # invalid delimiter
+            })
+    >>> clean_br_cpf(df, 'cpf')
+            cpf                 cpf_clean
+    0       23100299900         231.002.999-00
+    1       231.002.999-00      NaN
+    2       390.533.447=0       NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_br_cpf(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CPF in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(cpf.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(cpf.is_valid)
+        else:
+            return df.applymap(cpf.is_valid)
+    return cpf.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_br_cpf(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [cpf.compact(val)]
+    elif output_format == "standard":
+        result = [cpf.format(val)]
+
+    return result

--- a/dataprep/clean/clean_by_unp.py
+++ b/dataprep/clean/clean_by_unp.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing Belarusian UNP numbers (UNPs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.by import unp
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_by_unp(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Belarusian UNP numbers (UNPs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of UNP type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of UNP, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of UNP data.
+
+    >>> df = pd.DataFrame({{
+            "unp": [
+            '200988541',
+            'УНП MA1953684',
+            '200988542']
+            })
+    >>> clean_by_unp(df, 'unp')
+            unp             unp_clean
+    0       200988541       200988541
+    1       УНП MA1953684   MA1953684
+    2       200988542       NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_by_unp(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is UNP in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(unp.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(unp.is_valid)
+        else:
+            return df.applymap(unp.is_valid)
+    return unp.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of UNP, the compact format is the same as the standard one.
+    """
+    val = str(val)
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_by_unp(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [unp.compact(val)]
+
+    return result

--- a/dataprep/clean/clean_ca_bn.py
+++ b/dataprep/clean/clean_ca_bn.py
@@ -1,0 +1,163 @@
+"""
+Clean and validate a DataFrame column containing Canadian Business Numbers (BNs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ca import bn
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ca_bn(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Canadian Business Numbers (BNs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of BN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of BN, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of BN data.
+
+    >>> df = pd.DataFrame({{
+            "bn": [
+            '12302 6635',
+            '12302 6635 RC 0001'
+            '12345678Z']
+            })
+    >>> clean_ca_bn(df, 'bn')
+            bn                      bn_clean
+    0       12302 6635              123026635
+    1       12302 6635 RC 0001      123026635RC0001
+    2       12345678Z               NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ca_bn(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is BN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(bn.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(bn.is_valid)
+        else:
+            return df.applymap(bn.is_valid)
+    return bn.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of BN, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ca_bn(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [bn.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_ca_sin.py
+++ b/dataprep/clean/clean_ca_sin.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Canadian Social Insurance Numbers(SINs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ca import sin
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ca_sin(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Canadian Social Insurance Numbers(SINs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of SIN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of SIN data.
+
+    >>> df = pd.DataFrame({{
+            "sin": [
+            '123456782',
+            '12345678Z',]
+            })
+    >>> clean_ca_sin(df, 'sin')
+            sin                 sin_clean
+    0       123456782           123-456-782
+    1       12345678Z           NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ca_sin(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is SIN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(sin.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(sin.is_valid)
+        else:
+            return df.applymap(sin.is_valid)
+    return sin.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ca_sin(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [sin.compact(val)] + result
+    elif output_format == "standard":
+        result = [sin.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_ch_esr.py
+++ b/dataprep/clean/clean_ch_esr.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Swiss EinzahlungsSchein mit Referenznummer (ESRs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ch import esr
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ch_esr(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Swiss EinzahlungsSchein mit Referenznummer (ESRs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of ESR type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of ESR data.
+
+    >>> df = pd.DataFrame({{
+            "esr": [
+            "18 78583",
+            "210000000003139471430009016"]
+            })
+    >>> clean_ch_esr(df, 'esr')
+            esr                             esr_clean
+    0       18 78583                        00 00000 00000 00000 00018 78583
+    1       210000000003139471430009016     NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ch_esr(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is ESR in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(esr.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(esr.is_valid)
+        else:
+            return df.applymap(esr.is_valid)
+    return esr.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ch_esr(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [esr.compact(val)] + result
+    elif output_format == "standard":
+        result = [esr.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_ch_ssn.py
+++ b/dataprep/clean/clean_ch_ssn.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Swiss social security numbers (SSNs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ch import ssn
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ch_ssn(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Swiss social security numbers (SSNs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of SSN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of SSN data.
+
+    >>> df = pd.DataFrame({{
+            "ssn": [
+            '7569217076985',
+            '756.9217.0769.84',]
+            })
+    >>> clean_ch_ssn(df, 'ssn')
+            ssn                      ssn_clean
+    0       7569217076985            756.9217.0769.85
+    1       756.9217.0769.84         NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ch_ssn(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is SSN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(ssn.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(ssn.is_valid)
+        else:
+            return df.applymap(ssn.is_valid)
+    return ssn.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ch_ssn(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [ssn.compact(val)] + result
+    elif output_format == "standard":
+        result = [ssn.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_ch_uid.py
+++ b/dataprep/clean/clean_ch_uid.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Swiss business identifiers (UIDs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ch import uid
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ch_uid(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Swiss business identifiers (UIDs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of UID type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of UID data.
+
+    >>> df = pd.DataFrame({{
+            "uid": [
+            'CHE100155212',
+            'CHE-100.155.213',]
+            })
+    >>> clean_ch_uid(df, 'uid')
+            uid                      uid_clean
+    0       CHE100155212             CHE-100.155.212
+    1       CHE-100.155.213          NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ch_uid(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is UID in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(uid.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(uid.is_valid)
+        else:
+            return df.applymap(uid.is_valid)
+    return uid.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ch_uid(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [uid.compact(val)] + result
+    elif output_format == "standard":
+        result = [uid.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_ch_vat.py
+++ b/dataprep/clean/clean_ch_vat.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Swiss VAT numbers (VATs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ch import vat
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ch_vat(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Swiss VAT numbers (VATs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of VAT type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of VAT data.
+
+    >>> df = pd.DataFrame({{
+            "vat": [
+            'CHE107787577IVA',
+            'CHE-107.787.578 IVA',]
+            })
+    >>> clean_ch_vat(df, 'vat')
+            vat                      vat_clean
+    0       CHE107787577IVA          CHE-107.787.577 IVA
+    1       CHE-107.787.578 IVA      NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ch_vat(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is VAT in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(vat.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(vat.is_valid)
+        else:
+            return df.applymap(vat.is_valid)
+    return vat.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ch_vat(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [vat.compact(val)] + result
+    elif output_format == "standard":
+        result = [vat.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_cl_rut.py
+++ b/dataprep/clean/clean_cl_rut.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Chile RUT/RUN numbers (RUTs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.cl import rut
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_cl_rut(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Chile RUT/RUN numbers (RUTs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of RUT type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of RUT data.
+
+    >>> df = pd.DataFrame({{
+            "rut": [
+            "125319092",
+            "76086A28-5"]
+            })
+    >>> clean_cl_rut(df, 'rut')
+            rut               rut_clean
+    0       125319092         12.531.909-2
+    1       76086A28-5        NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_cl_rut(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is RUT in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(rut.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(rut.is_valid)
+        else:
+            return df.applymap(rut.is_valid)
+    return rut.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_cl_rut(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [rut.compact(val)] + result
+    elif output_format == "standard":
+        result = [rut.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_cn_ric.py
+++ b/dataprep/clean/clean_cn_ric.py
@@ -1,0 +1,172 @@
+"""
+Clean and validate a DataFrame column containing Chinese Resident Identity Card Number (RICs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.cn import ric
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_cn_ric(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Chinese Resident Identity Card Number (RICs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of RIC type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', return the birth date of the person.
+            If output_format = 'birthplace', return the place of birth of the person.
+            Note: in the case of RIC, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of RIC data.
+
+    >>> df = pd.DataFrame({{
+            "ric": [
+            "360426199101010071",
+            "99999999999"]
+            })
+    >>> clean_cn_ric(df, 'ric')
+            ric                     ric_clean
+    0       360426199101010071      51 824 753 556
+    1       99999999999         NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate", "birthplace"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard", "birthdate" or "birthplace".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_cn_ric(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is RIC in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(ric.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(ric.is_valid)
+        else:
+            return df.applymap(ric.is_valid)
+    return ric.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', return the birth date of the person.
+           If output_format = 'birthplace', return the place of birth of the person.
+           Note: in the case of RIC, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_cn_ric(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [ric.compact(val)] + result
+    elif output_format == "standard":
+        result = [ric.format(val)] + result
+    elif output_format == "birthdate":
+        result = [ric.get_birth_date(val)] + result
+    elif output_format == "birthplace":
+        result = [ric.get_birth_place(val)] + result
+
+    return result

--- a/dataprep/clean/clean_cn_uscc.py
+++ b/dataprep/clean/clean_cn_uscc.py
@@ -1,0 +1,164 @@
+"""
+Clean and validate a DataFrame column containing Chinese Unified Social Credit Code
+(China tax number) (USCCs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.cn import uscc
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_cn_uscc(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Chinese Unified Social Credit Code (USCCs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of USCC type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note that in the case of USCC, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of USCC data.
+
+    >>> df = pd.DataFrame({{
+            "uscc": [
+            "9 1 110000 600037341L",
+            "A1110000600037341L"]
+            })
+    >>> clean_cn_uscc(df, 'uscc')
+            uscc                        uscc_clean
+    0       9 1 110000 600037341L       91110000600037341L
+    1       A1110000600037341L          NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_cn_uscc(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is USCC in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(uscc.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(uscc.is_valid)
+        else:
+            return df.applymap(uscc.is_valid)
+    return uscc.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note that in the case of USCC, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_cn_uscc(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [uscc.compact(val)] + result
+    elif output_format == "standard":
+        result = [uscc.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_co_nit.py
+++ b/dataprep/clean/clean_co_nit.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Colombian identity codes (NITs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.co import nit
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_co_nit(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Colombian identity codes (NITs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of NIT type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of NIT data.
+
+    >>> df = pd.DataFrame({{
+            "nit": [
+            "2131234321",
+            "2131234325"]
+            })
+    >>> clean_co_nit(df, 'nit')
+            nit                nit_clean
+    0       2131234321         213.123.432-1
+    1       2131234325         NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_co_nit(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is NIT in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(nit.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(nit.is_valid)
+        else:
+            return df.applymap(nit.is_valid)
+    return nit.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_co_nit(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [nit.compact(val)] + result
+    elif output_format == "standard":
+        result = [nit.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_cr_cpf.py
+++ b/dataprep/clean/clean_cr_cpf.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Costa Rica physical person ID number (CPFs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.cr import cpf
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_cr_cpf(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Costa Rica physical person ID number (CPFs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CPF type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CPF data.
+
+    >>> df = pd.DataFrame({{
+            "cpf": [
+            "1-613-584",
+            "30-1234-1234"]
+            })
+    >>> clean_cr_cpf(df, 'cpf')
+            cpf              cpf_clean
+    0       1-613-584        01-0613-0584
+    1       30-1234-1234     NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_cr_cpf(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CPF in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(cpf.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(cpf.is_valid)
+        else:
+            return df.applymap(cpf.is_valid)
+    return cpf.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_cr_cpf(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [cpf.compact(val)] + result
+    elif output_format == "standard":
+        result = [cpf.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_cr_cpj.py
+++ b/dataprep/clean/clean_cr_cpj.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Costa Rica tax number (CPJs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.cr import cpj
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_cr_cpj(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Costa Rica tax number (CPJs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CPJ type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CPJ data.
+
+    >>> df = pd.DataFrame({{
+            "cpj": [
+            "4 000 042138",
+            "3-534-123559"]
+            })
+    >>> clean_cr_cpj(df, 'cpj')
+            cpj                 cpj_clean
+    0       4 000 042138        4-000-042138
+    1       3-534-123559        NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_cr_cpj(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CPJ in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(cpj.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(cpj.is_valid)
+        else:
+            return df.applymap(cpj.is_valid)
+    return cpj.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_cr_cpj(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [cpj.compact(val)] + result
+    elif output_format == "standard":
+        result = [cpj.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_cr_cr.py
+++ b/dataprep/clean/clean_cr_cr.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Costa Rica foreigners ID number (CRs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.cr import cr
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_cr_cr(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Costa Rica foreigners ID number (CRs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CR type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of CR, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CR data.
+
+    >>> df = pd.DataFrame({{
+            "cr": [
+            '122200569906',
+            '12345678',]
+            })
+    >>> clean_cr_cr(df, 'cr')
+            cr                      cr_clean
+    0       122200569906            122200569906
+    1       12345678                NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_cr_cr(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CR in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(cr.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(cr.is_valid)
+        else:
+            return df.applymap(cr.is_valid)
+    return cr.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of CR, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_cr_cr(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [cr.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_cu_ni.py
+++ b/dataprep/clean/clean_cu_ni.py
@@ -1,0 +1,170 @@
+"""
+Clean and validate a DataFrame column containing Cuban identity card numbers (NIs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.cu import ni
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_cu_ni(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Cuban identity card numbers (NIs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of NI type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', return the date of birth.
+            If output_format = 'gender', return the gender (M/F) from the person's NI.
+            Note: in the case of NI, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of NI data.
+
+    >>> df = pd.DataFrame({{
+            "ni": [
+            '91021027775',
+            '9102102777A',]
+            })
+    >>> clean_cu_ni(df, 'ni')
+            ni                      ni_clean
+    0       91021027775             91021027775
+    1       9102102777A             NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate", "gender"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard", "birthdate" or "gender".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_cu_ni(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is NI in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(ni.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(ni.is_valid)
+        else:
+            return df.applymap(ni.is_valid)
+    return ni.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', return the date of birth.
+           If output_format = 'gender', return the gender (M/F) from the person's NI.
+           Note: in the case of NI, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_cu_ni(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [ni.compact(val)] + result
+    elif output_format == "birthdate":
+        result = [ni.get_birth_date(val)] + result
+    elif output_format == "gender":
+        result = [ni.get_gender(val)] + result
+
+    return result

--- a/dataprep/clean/clean_cy_vat.py
+++ b/dataprep/clean/clean_cy_vat.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Cypriot VAT number (VATs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.cy import vat
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_cy_vat(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Cypriot VAT number (VATs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of VAT type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of VAT, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of VAT data.
+
+    >>> df = pd.DataFrame({{
+            "vat": [
+            '12302 6635',
+            'CY-10259033Z',]
+            })
+    >>> clean_cy_vat(df, 'vat')
+            vat                      vat_clean
+    0       CY-10259033P             10259033P
+    1       CY-10259033Z             NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_cy_vat(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is VAT in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(vat.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(vat.is_valid)
+        else:
+            return df.applymap(vat.is_valid)
+    return vat.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of VAT, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_cy_vat(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [vat.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_cz_dic.py
+++ b/dataprep/clean/clean_cz_dic.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Czech VAT number (DICs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.cz import dic
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_cz_dic(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Czech VAT number (DICs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of DIC type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of DIC, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of DIC data.
+
+    >>> df = pd.DataFrame({{
+            "dic": [
+            'CZ 25123891',
+            '25123890',]
+            })
+    >>> clean_cz_dic(df, 'dic')
+            dic                  dic_clean
+    0       CZ 25123891          25123891
+    1       25123890             NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_cz_dic(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is DIC in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(dic.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(dic.is_valid)
+        else:
+            return df.applymap(dic.is_valid)
+    return dic.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of DIC, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_cz_dic(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [dic.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_cz_rc.py
+++ b/dataprep/clean/clean_cz_rc.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Czech birth numbers (RCs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.cz import rc
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_cz_rc(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Czech birth numbers (RCs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of RC type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of RC data.
+
+    >>> df = pd.DataFrame({{
+            "rc": [
+            "7103192745",
+            "7103192746"]
+            })
+    >>> clean_cz_rc(df, 'rc')
+            rc                 rc_clean
+    0       7103192745         710319/2745
+    1       7103192746         NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_cz_rc(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is RC in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(rc.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(rc.is_valid)
+        else:
+            return df.applymap(rc.is_valid)
+    return rc.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_cz_rc(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [rc.compact(val)] + result
+    elif output_format == "standard":
+        result = [rc.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_de_handelsregisternummer.py
+++ b/dataprep/clean/clean_de_handelsregisternummer.py
@@ -1,0 +1,164 @@
+"""
+Clean and validate a DataFrame column containing German company registry id (handelsregisternummer).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.de import handelsregisternummer
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_de_handelsregisternummer(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean German company registry id type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of handelsregisternummer type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of handelsregisternummer,
+            the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of handelsregisternummer data.
+
+    >>> df = pd.DataFrame({{
+            "handelsregisternummer": [
+            'Aachen HRA 11223',
+            'Aachen HRC 44123',]
+            })
+    >>> clean_de_handelsregisternummer(df, 'handelsregisternummer')
+            handelsregisternummer   handelsregisternummer_clean
+    0       Aachen HRA 11223        Aachen HRA 11223
+    1       Aachen HRC 44123        NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_de_handelsregisternummer(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is handelsregisternummer in a DataFrame column.
+    For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(handelsregisternummer.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(handelsregisternummer.is_valid)
+        else:
+            return df.applymap(handelsregisternummer.is_valid)
+    return handelsregisternummer.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of handelsregisternummer,
+           the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_de_handelsregisternummer(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [handelsregisternummer.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_de_idnr.py
+++ b/dataprep/clean/clean_de_idnr.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing German personal tax number (IDNRs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.de import idnr
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_de_idnr(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean German personal tax number (IDNRs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of IDNR type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of IDNR data.
+
+    >>> df = pd.DataFrame({{
+            "idnr": [
+            "36574261809",
+            "36554266806"]
+            })
+    >>> clean_de_idnr(df, 'idnr')
+            idnr                idnr_clean
+    0       36574261809         36 574 261 809
+    1       36554266806         NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_de_idnr(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is IDNR in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(idnr.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(idnr.is_valid)
+        else:
+            return df.applymap(idnr.is_valid)
+    return idnr.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_de_idnr(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [idnr.compact(val)] + result
+    elif output_format == "standard":
+        result = [idnr.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_de_stnr.py
+++ b/dataprep/clean/clean_de_stnr.py
@@ -1,0 +1,167 @@
+"""
+Clean and validate a DataFrame column containing German tax numbers (STNRs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from typing import Optional
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.de import stnr
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_de_stnr(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean German tax numbers (STNRs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of STNR type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+    Examples
+    --------
+    Clean a column of STNR data.
+
+    >>> df = pd.DataFrame({{
+            "stnr": [
+            "181/815/0815 5",
+            "136695978"]
+            })
+    >>> clean_de_stnr(df, 'stnr')
+            stnr                 stnr_clean
+    0       181/815/0815 5       181/815/08155
+    1       136695978            NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_de_stnr(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+    region: Optional[str] = None,
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is STNR in a DataFrame column. For each cell, return True or False.
+    The region can be supplied to verify that the number is assigned in that region.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    region
+            Specify the region that the number belongs to.
+
+            (default: None)
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(stnr.is_valid, args=(region,))
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(stnr.is_valid, args=(region,))
+        else:
+            return df.applymap(lambda x: stnr.is_valid(x, region))
+    return stnr.is_valid(df, region)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_de_stnr(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [stnr.compact(val)] + result
+    elif output_format == "standard":
+        result = [stnr.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_de_vat.py
+++ b/dataprep/clean/clean_de_vat.py
@@ -1,0 +1,160 @@
+"""
+Clean and validate a DataFrame column containing German VAT numberss (VATs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.de import vat
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_de_vat(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean German VAT numberss (VATs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of VAT type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of VAT, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of VAT data.
+
+    >>> df = pd.DataFrame({{
+            "vat": [
+            'DE 136,695 976',
+            '136695978']
+            })
+    >>> clean_de_vat(df, 'vat')
+            vat                 vat_clean
+    0       DE 136,695 976      136695976
+    1       136695978           NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_de_vat(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is VAT in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(vat.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(vat.is_valid)
+        else:
+            return df.applymap(vat.is_valid)
+    return vat.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of VAT, the compact format is the same as the standard one.
+    """
+    val = str(val)
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_de_vat(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [vat.compact(val)]
+
+    return result

--- a/dataprep/clean/clean_de_wkn.py
+++ b/dataprep/clean/clean_de_wkn.py
@@ -1,0 +1,166 @@
+"""
+Clean and validate a DataFrame column containing Wertpapierkennnummer (WKNs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.de import wkn
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_de_wkn(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Wertpapierkennnummer (WKNs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of WKN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'isin', convert the number to an ISIN.
+            Note: in the case of WKN, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of WKN data.
+
+    >>> df = pd.DataFrame({{
+            "wkn": [
+            'A0MNRK',
+            'AOMNRK']
+            })
+    >>> clean_de_wkn(df, 'wkn')
+            wkn             wkn_clean
+    0       A0MNRK          A0MNRK
+    1       AOMNRK          NaN
+    """
+
+    if output_format not in {"compact", "standard", "isin"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "isin".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_de_wkn(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is WKN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(wkn.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(wkn.is_valid)
+        else:
+            return df.applymap(wkn.is_valid)
+    return wkn.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'isin', convert the number to an ISIN.
+           Note: in the case of WKN, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_de_wkn(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [wkn.compact(val)] + result
+    elif output_format == "isin":
+        result = [wkn.to_isin(val)] + result
+
+    return result

--- a/dataprep/clean/clean_dk_cpr.py
+++ b/dataprep/clean/clean_dk_cpr.py
@@ -1,0 +1,166 @@
+"""
+Clean and validate a DataFrame column containing Danish citizen number (CPRs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.dk import cpr
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_dk_cpr(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Danish citizen number (CPRs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CPR type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', split the number and return the birth date.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CPR data.
+
+    >>> df = pd.DataFrame({{
+            "cpr": [
+            "2110625629",
+            "511062-5629"]
+            })
+    >>> clean_dk_cpr(df, 'cpr')
+            cpr                 cpr_clean
+    0       2110625629          211062-5629
+    1       511062-5629         NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "birthdate".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_dk_cpr(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CPR in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(cpr.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(cpr.is_valid)
+        else:
+            return df.applymap(cpr.is_valid)
+    return cpr.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', split the number and return the birth date.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_dk_cpr(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [cpr.compact(val)] + result
+    elif output_format == "standard":
+        result = [cpr.format(val)] + result
+    elif output_format == "birthdate":
+        result = [cpr.get_birth_date(val)] + result
+
+    return result

--- a/dataprep/clean/clean_dk_cvr.py
+++ b/dataprep/clean/clean_dk_cvr.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Danish CVR number (CVRs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.dk import cvr
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_dk_cvr(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Danish CVR number (CVRs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CVR type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of CVR, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CVR data.
+
+    >>> df = pd.DataFrame({{
+            "cvr": [
+            'DK 13585628',
+            'DK 13585627']
+            })
+    >>> clean_dk_cvr(df, 'cvr')
+            cvr             cvr_clean
+    0       DK 13585628     13585628
+    1       DK 13585627     NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_dk_cvr(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CVR in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(cvr.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(cvr.is_valid)
+        else:
+            return df.applymap(cvr.is_valid)
+    return cvr.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of CVR, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_dk_cvr(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [cvr.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_do_cedula.py
+++ b/dataprep/clean/clean_do_cedula.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Dominican Republic national identifier (Cedulas).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.do import cedula
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_do_cedula(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Dominican Republic national identifier (Cedulas) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of Cedula type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of Cedula data.
+
+    >>> df = pd.DataFrame({{
+            "cedula": [
+            "22400022111",
+            "0011391820A"]
+            })
+    >>> clean_do_cedula(df, 'cedula')
+            cedula              cedula_clean
+    0       22400022111         224-0002211-1
+    1       0011391820A         NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_do_cedula(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is Cedula in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(cedula.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(cedula.is_valid)
+        else:
+            return df.applymap(cedula.is_valid)
+    return cedula.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_do_cedula(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [cedula.compact(val)] + result
+    elif output_format == "standard":
+        result = [cedula.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_do_ncf.py
+++ b/dataprep/clean/clean_do_ncf.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Dominican Republic invoice numbers (NCFs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.do import ncf
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_do_ncf(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Dominican Republic invoice numbers (NCFs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of NCF type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of NCF, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of NCF data.
+
+    >>> df = pd.DataFrame({{
+            "ncf": [
+            'E310000000005',
+            'Z0100000005',]
+            })
+    >>> clean_do_ncf(df, 'ncf')
+            ncf                 ncf_clean
+    0       E310000000005       E310000000005
+    1       Z0100000005         NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_do_ncf(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is NCF in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(ncf.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(ncf.is_valid)
+        else:
+            return df.applymap(ncf.is_valid)
+    return ncf.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of NCF, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_do_ncf(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [ncf.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_do_rnc.py
+++ b/dataprep/clean/clean_do_rnc.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Dominican Republic tax registration (RNCs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.do import rnc
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_do_rnc(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Dominican Republic tax registration (RNCs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of RNC type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of RNC data.
+
+    >>> df = pd.DataFrame({{
+            "rnc": [
+            "131246796",
+            "1018A0043"]
+            })
+    >>> clean_do_rnc(df, 'rnc')
+            rnc               rnc_clean
+    0       131246796         1-31-24679-6
+    1       1018A0043         NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_do_rnc(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is RNC in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(rnc.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(rnc.is_valid)
+        else:
+            return df.applymap(rnc.is_valid)
+    return rnc.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_do_rnc(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [rnc.compact(val)] + result
+    elif output_format == "standard":
+        result = [rnc.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_duplication_utils.py
+++ b/dataprep/clean/clean_duplication_utils.py
@@ -16,8 +16,8 @@ import pandas as pd
 import dask.dataframe as dd
 import dask
 from IPython.display import Javascript, display
-from metaphone import doublemetaphone
 from Levenshtein import distance
+from metaphone import doublemetaphone
 
 from .utils import to_dask
 

--- a/dataprep/clean/clean_ec_ci.py
+++ b/dataprep/clean/clean_ec_ci.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Ecuadorian personal identity codes (CIs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ec import ci
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ec_ci(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Ecuadorian personal identity codes (CIs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CI type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of CI, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CI data.
+
+    >>> df = pd.DataFrame({{
+            "ci": [
+            '171430710-3',
+            'BE431150351']
+            })
+    >>> clean_ec_ci(df, 'ci')
+            ci             ci_clean
+    0       171430710-3    1714307103
+    1       1714307104     NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ec_ci(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CI in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(ci.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(ci.is_valid)
+        else:
+            return df.applymap(ci.is_valid)
+    return ci.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of CI, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ec_ci(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [ci.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_ec_ruc.py
+++ b/dataprep/clean/clean_ec_ruc.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Ecuadorian company tax number (RUCs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ec import ruc
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ec_ruc(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Ecuadorian company tax number (RUCs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of RUC type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of RUC, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of RUC data.
+
+    >>> df = pd.DataFrame({{
+            "ruc": [
+            '1792060346-001',
+            '1763154690001']
+            })
+    >>> clean_ec_ruc(df, 'ruc')
+            ruc                 ruc_clean
+    0       1792060346-001      1792060346001
+    1       1763154690001       NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ec_ruc(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is RUC in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(ruc.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(ruc.is_valid)
+        else:
+            return df.applymap(ruc.is_valid)
+    return ruc.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of RUC, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ec_ruc(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [ruc.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_ee_ik.py
+++ b/dataprep/clean/clean_ee_ik.py
@@ -1,0 +1,170 @@
+"""
+Clean and validate a DataFrame column containing Estonian Personcal ID numbers (IKs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ee import ik
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ee_ik(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Estonian Personcal ID number (IKs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of IK type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', get the person's birthdate.
+            If output_format = 'gender', get the person's birth gender ('M' or 'F').
+            Note: in the case of IK, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of IK data.
+
+    >>> df = pd.DataFrame({
+            "ik": [
+            '36805280109',
+            '36805280108']
+            })
+    >>> clean_ee_ik(df, 'ik')
+            ik              ik_clean
+    0       36805280109     36805280109
+    1       36805280108     NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate", "gender"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard", "birthdate" or "gender".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ee_ik(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is IK in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(ik.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(ik.is_valid)
+        else:
+            return df.applymap(ik.is_valid)
+    return ik.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', get the person's birthdate.
+           If output_format = 'gender', get the person's birth gender ('M' or 'F').
+           Note: in the case of IK, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ee_ik(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [ik.compact(val)] + result
+    elif output_format == "birthdate":
+        result = [ik.get_birth_date(val)] + result
+    elif output_format == "gender":
+        result = [ik.get_gender(val)] + result
+
+    return result

--- a/dataprep/clean/clean_ee_kmkr.py
+++ b/dataprep/clean/clean_ee_kmkr.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Estonian KMKR numbers (KMKRs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ee import kmkr
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ee_kmkr(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Estonian KMKR numbers (KMKRs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of KMKR type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of KMKR, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of KMKR data.
+
+    >>> df = pd.DataFrame({{
+            "kmkr": [
+            'EE 100 931 558',
+            '100594103']
+            })
+    >>> clean_ee_kmkr(df, 'kmkr')
+            kmkr                kmkr_clean
+    0       EE 100 931 558      100931558
+    1       100594103           NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ee_kmkr(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is KMKR in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(kmkr.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(kmkr.is_valid)
+        else:
+            return df.applymap(kmkr.is_valid)
+    return kmkr.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of KMKR, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ee_kmkr(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [kmkr.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_ee_registrikood.py
+++ b/dataprep/clean/clean_ee_registrikood.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing Estonian organisation registration codes.
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ee import registrikood
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ee_registrikood(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Estonian organisation registration codes (Registrikoods) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of Registrikood type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of Registrikood, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of Registrikood data.
+
+    >>> df = pd.DataFrame({{
+            "registrikood": [
+            '12345678',
+            '12345679']
+            })
+    >>> clean_ee_registrikood(df, 'registrikood')
+            registrikood      registrikood_clean
+    0       12345678          12345678
+    1       12345679          NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ee_registrikood(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is Registrikood in a DataFrame column.
+    For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(registrikood.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(registrikood.is_valid)
+        else:
+            return df.applymap(registrikood.is_valid)
+    return registrikood.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of Registrikood, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ee_registrikood(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [registrikood.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_es_ccc.py
+++ b/dataprep/clean/clean_es_ccc.py
@@ -1,0 +1,166 @@
+"""
+Clean and validate a DataFrame column containing Spanish Bank Account Codes (CCCs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.es import ccc
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_es_ccc(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Spanish Bank Account Codes (CCCs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CCC type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'iban', convert the number to an IBAN.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CCC data.
+
+    >>> df = pd.DataFrame({{
+            "ccc": [
+            "12341234161234567890",
+            "134-1234-16 1234567890"]
+            })
+    >>> clean_es_ccc(df, 'ccc')
+            ccc                         ccc_clean
+    0       12341234161234567890        1234 1234 16 12345 67890
+    1       134-1234-16 1234567890      NaN
+    """
+
+    if output_format not in {"compact", "standard", "iban"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "iban".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_es_ccc(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CCC in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(ccc.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(ccc.is_valid)
+        else:
+            return df.applymap(ccc.is_valid)
+    return ccc.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'iban', convert the number to an IBAN.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_es_ccc(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [ccc.compact(val)] + result
+    elif output_format == "standard":
+        result = [ccc.format(val)] + result
+    elif output_format == "iban":
+        result = [ccc.to_iban(val)] + result
+
+    return result

--- a/dataprep/clean/clean_es_cif.py
+++ b/dataprep/clean/clean_es_cif.py
@@ -1,0 +1,188 @@
+"""
+Clean and validate a DataFrame column containing Spanish fiscal numbers (CIFs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.es import cif
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_es_cif(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    split: bool = False,
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Spanish fiscal numbers (CIFs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CIF type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of CIF, the compact format is the same as the standard one.
+
+            (default: "standard")
+        split
+            If True,
+                each component of derived from its number string will be put into its own column.
+
+            (default: False)
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CIF data.
+
+    >>> df = pd.DataFrame({{
+            "cif": [
+            'A13 585 625',
+            'M-1234567-L',]
+            })
+    >>> clean_es_cif(df, 'cif')
+            cif             cif_clean
+    0       A13 585 625     A13585625
+    1       M-1234567-L     NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, split, errors) for x in srs],
+        meta=object,
+    )
+
+    if split:
+        df = df.assign(
+            _temp_=df["clean_code_tup"].map(itemgetter(0), meta=("_temp", object)),
+            type_code=df["clean_code_tup"].map(itemgetter(1), meta=("type_code", object)),
+            province_code=df["clean_code_tup"].map(itemgetter(2), meta=("province_code", object)),
+            within_code=df["clean_code_tup"].map(itemgetter(3), meta=("within_code", object)),
+            check_digit=df["clean_code_tup"].map(itemgetter(4), meta=("check_digit", object)),
+        )
+    else:
+        df = df.assign(
+            _temp_=df["clean_code_tup"].map(itemgetter(0)),
+        )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_es_cif(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CIF in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(cif.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(cif.is_valid)
+        else:
+            return df.applymap(cif.is_valid)
+    return cif.is_valid(df)
+
+
+def _format(
+    val: Any, output_format: str = "standard", split: bool = False, errors: str = "coarse"
+) -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of CIF, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        if split:
+            return [np.nan, np.nan, np.nan, np.nan, np.nan]
+        else:
+            return [np.nan]
+
+    if not validate_es_cif(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        if split:
+            return [error_result, np.nan, np.nan, np.nan, np.nan]
+        else:
+            return [error_result]
+
+    if split:
+        result = list(cif.split(val))
+        if len(result) == 0:
+            return [np.nan, np.nan, np.nan, np.nan, np.nan]
+    if output_format in {"compact", "standard"}:
+        result = [cif.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_es_cups.py
+++ b/dataprep/clean/clean_es_cups.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Spanish meter point numbers (CUPSs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.es import cups
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_es_cups(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Spanish meter point numbers (CUPSs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CUPS type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CUPS data.
+
+    >>> df = pd.DataFrame({{
+            "cups": [
+            "ES1234123456789012JY1F",
+            "ES 1234-123456789012-XY 1F",]
+            })
+    >>> clean_es_cups(df, 'cups')
+            cups                            cups_clean
+    0       ES1234123456789012JY1F          ES 1234 1234 5678 9012 JY 1F
+    1       ES 1234-123456789012-XY 1F      NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_es_cups(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CUPS in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(cups.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(cups.is_valid)
+        else:
+            return df.applymap(cups.is_valid)
+    return cups.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_es_cups(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [cups.compact(val)] + result
+    elif output_format == "standard":
+        result = [cups.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_es_dni.py
+++ b/dataprep/clean/clean_es_dni.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Spanish personal identity codes (DNIs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.es import dni
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_es_dni(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Spanish personal identity codes (DNIs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of DNI type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of DNI, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of DNI data.
+
+    >>> df = pd.DataFrame({{
+            "dni": [
+            '54362315-K',
+            '54362315']
+            })
+    >>> clean_es_dni(df, 'dni')
+            dni             dni_clean
+    0       54362315-K      54362315K
+    1       54362315        NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_es_dni(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is DNI in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(dni.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(dni.is_valid)
+        else:
+            return df.applymap(dni.is_valid)
+    return dni.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of DNI, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_es_dni(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [dni.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_es_iban.py
+++ b/dataprep/clean/clean_es_iban.py
@@ -1,0 +1,166 @@
+"""
+Clean and validate a DataFrame column containing Spanish IBANs (IBANs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.es import iban
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_es_iban(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Spanish IBANs (IBANs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of IBAN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'ccc', return the CCC (Código Cuenta Corriente) part of the number.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of IBAN data.
+
+    >>> df = pd.DataFrame({{
+            "iban": [
+            "ES771234-1234-16 1234567890",
+            "R1601101050000010547023795",]
+            })
+    >>> clean_es_iban(df, 'iban')
+            iban                            iban_clean
+    0       ES771234-1234-16 1234567890     ES77 1234 1234 1612 3456 7890
+    1       R1601101050000010547023795      NaN
+    """
+
+    if output_format not in {"compact", "standard", "ccc"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "ccc".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_es_iban(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is IBAN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(iban.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(iban.is_valid)
+        else:
+            return df.applymap(iban.is_valid)
+    return iban.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'ccc', return the CCC (Código Cuenta Corriente) part of the number.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_es_iban(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [iban.compact(val)] + result
+    elif output_format == "standard":
+        result = [iban.format(val)] + result
+    elif output_format == "ccc":
+        result = [iban.to_ccc(val)] + result
+
+    return result

--- a/dataprep/clean/clean_es_nie.py
+++ b/dataprep/clean/clean_es_nie.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Spanish foreigner identity codes (NIEs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.es import nie
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_es_nie(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Spanish foreigner identity codes (NIEs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of NIE type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of NIE, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of NIE data.
+
+    >>> df = pd.DataFrame({{
+            "nie": [
+            'x-2482300w',
+            'x-2482300a']
+            })
+    >>> clean_es_nie(df, 'nie')
+            nie            nie_clean
+    0       x-2482300w     X2482300W
+    1       x-2482300a     NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_es_nie(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is NIE in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(nie.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(nie.is_valid)
+        else:
+            return df.applymap(nie.is_valid)
+    return nie.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of NIE, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_es_nie(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [nie.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_es_nif.py
+++ b/dataprep/clean/clean_es_nif.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Spanish NIF numbers (NIFs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.es import nif
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_es_nif(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Spanish NIF numbers (NIFs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of NIF type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of NIF, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of NIF data.
+
+    >>> df = pd.DataFrame({{
+            "nif": [
+            'ES B-58378431',
+            'B64717839']
+            })
+    >>> clean_es_nif(df, 'nif')
+            nif                 nif_clean
+    0       ES B-58378431       B58378431
+    1       B64717839           NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_es_nif(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is NIF in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(nif.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(nif.is_valid)
+        else:
+            return df.applymap(nif.is_valid)
+    return nif.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of NIF, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_es_nif(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [nif.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_es_referenciacatastral.py
+++ b/dataprep/clean/clean_es_referenciacatastral.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing Spanish real state ids.
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.es import referenciacatastral
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_es_referenciacatastral(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Spanish real state ids (Referencia Catastrals) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of Referencia Catastral type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of Referencia Catastral data.
+
+    >>> df = pd.DataFrame({{
+            "referenciacatastral": [
+            "4A08169P03PRAT0001LR",
+            "7837301/VG8173B 0001 TT",]
+            })
+    >>> clean_es_referenciacatastral(df, 'referenciacatastral')
+            referenciacatastral          referenciacatastral_clean
+    0       4A08169P03PRAT0001LR         4A08169 P03PRAT 0001 LR
+    1       7837301/VG8173B 0001 TT      NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_es_referenciacatastral(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is Referencia Catastral in a DataFrame column.
+    For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(referenciacatastral.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(referenciacatastral.is_valid)
+        else:
+            return df.applymap(referenciacatastral.is_valid)
+    return referenciacatastral.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_es_referenciacatastral(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [referenciacatastral.compact(val)] + result
+    elif output_format == "standard":
+        result = [referenciacatastral.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_eu_at_02.py
+++ b/dataprep/clean/clean_eu_at_02.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing AT-02 (SEPA Creditor identifier).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.eu import at_02
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_eu_at_02(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean AT-02 (SEPA Creditor identifier) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of AT-02 type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of AT-02, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of AT-02 data.
+
+    >>> df = pd.DataFrame({{
+            "at_02": [
+            'ES++()+23ZZZ4//7690558N',
+            'ES2900047690558N']
+            })
+    >>> clean_eu_at_02(df, 'at_02')
+            at_02                       at_02_clean
+    0       ES++()+23ZZZ4//7690558N     ES23ZZZ47690558N
+    1       ES2900047690558N            NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_eu_at_02(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is AT-02 in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(at_02.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(at_02.is_valid)
+        else:
+            return df.applymap(at_02.is_valid)
+    return at_02.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of AT-02, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_eu_at_02(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [at_02.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_eu_banknote.py
+++ b/dataprep/clean/clean_eu_banknote.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing Euro banknote serial numbers.
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.eu import banknote
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_eu_banknote(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Euro banknote serial numbers type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of Euro banknote type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of Euro banknote, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of Euro banknote data.
+
+    >>> df = pd.DataFrame({{
+            "banknote": [
+            'P36007033744',
+            'P36007033743']
+            })
+    >>> clean_eu_banknote(df, 'banknote')
+            banknote             banknote_clean
+    0       P36007033744         P36007033744
+    1       P36007033743         NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_eu_banknote(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is Euro banknote in a DataFrame column.
+    For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(banknote.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(banknote.is_valid)
+        else:
+            return df.applymap(banknote.is_valid)
+    return banknote.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of Euro banknote, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_eu_banknote(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [banknote.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_eu_eic.py
+++ b/dataprep/clean/clean_eu_eic.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing European Energy Identification Codes.
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.eu import eic
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_eu_eic(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean European Energy Identification Codes (EICs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of EIC type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of EIC, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of EIC data.
+
+    >>> df = pd.DataFrame({{
+            "eic": [
+            '22XWATTPLUS----G',
+            '22XWATTPLUS----X']
+            })
+    >>> clean_eu_eic(df, 'eic')
+            eic                 eic_clean
+    0       22XWATTPLUS----G    22XWATTPLUS----G
+    1       22XWATTPLUS----X    NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_eu_eic(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is EIC in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(eic.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(eic.is_valid)
+        else:
+            return df.applymap(eic.is_valid)
+    return eic.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of EIC, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_eu_eic(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [eic.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_eu_nace.py
+++ b/dataprep/clean/clean_eu_nace.py
@@ -1,0 +1,167 @@
+"""
+Clean and validate a DataFrame column containing
+classification for businesses in the European Union (NACE).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.eu import nace
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_eu_nace(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean classification for businesses in the European Union type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of NACE type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'label', return the category label for the number.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of NACE data.
+
+    >>> df = pd.DataFrame({{
+            "nace": [
+            "6201",
+            "99999999999"]
+            })
+    >>> clean_eu_nace(df, 'nace')
+            nace         nace_clean
+    0       6201         62.01
+    1       62059        NaN
+    """
+
+    if output_format not in {"compact", "standard", "label"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "label".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_eu_nace(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is NACE in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(nace.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(nace.is_valid)
+        else:
+            return df.applymap(nace.is_valid)
+    return nace.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'label', return the category label for the number.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_eu_nace(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [nace.compact(val)] + result
+    elif output_format == "standard":
+        result = [nace.format(val)] + result
+    elif output_format == "label":
+        result = [nace.get_label(val)] + result
+
+    return result

--- a/dataprep/clean/clean_eu_vat.py
+++ b/dataprep/clean/clean_eu_vat.py
@@ -1,0 +1,168 @@
+"""
+Clean and validate a DataFrame column containing European VAT numbers (VATs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.eu import vat
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_eu_vat(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean European VAT numbers (VATs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of VAT type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'country', guess the country code based on the number and
+                return the list of valid and lower case codes.
+            Note: in the case of VAT, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of VAT data.
+
+    >>> df = pd.DataFrame({{
+            "vat": [
+            'ATU 57194903',
+            'FR 61 954 506 077']
+            })
+    >>> clean_eu_vat(df, 'vat')
+            vat                 vat_clean
+    0       ATU 57194903        ATU57194903
+    1       FR 61 954 506 077   FR61954506077
+    """
+
+    if output_format not in {"compact", "standard", "country"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "country".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_eu_vat(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is VAT in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(vat.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(vat.is_valid)
+        else:
+            return df.applymap(vat.is_valid)
+    return vat.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'country', guess the country code based on the number and
+                return the list of valid and lower case codes.
+           Note: in the case of VAT, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_eu_vat(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [vat.compact(val)] + result
+    elif output_format == "country":
+        result = [vat.guess_country(val)] + result
+
+    return result

--- a/dataprep/clean/clean_fi_alv.py
+++ b/dataprep/clean/clean_fi_alv.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Finnish ALV numbers (ALVs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.fi import alv
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_fi_alv(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Finnish ALV numbers (ALVs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of ALV type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of ALV, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of ALV data.
+
+    >>> df = pd.DataFrame({{
+            "alv": [
+            'FI 20774740',
+            'FI 20774741']
+            })
+    >>> clean_fi_alv(df, 'alv')
+            alv             alv_clean
+    0       FI 20774740     20774740
+    1       FI 20774741     NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_fi_alv(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is ALV in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(alv.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(alv.is_valid)
+        else:
+            return df.applymap(alv.is_valid)
+    return alv.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of ALV, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_fi_alv(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [alv.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_fi_associationid.py
+++ b/dataprep/clean/clean_fi_associationid.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing Finnish association registry ids.
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.fi import associationid
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_fi_associationid(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Finnish association registry ids type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of Finnish association registry id.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of Finnish association registry id data.
+
+    >>> df = pd.DataFrame({{
+            "associationid": [
+            "1234",
+            "12df",]
+            })
+    >>> clean_fi_associationid(df, 'associationid')
+            associationid       associationid_clean
+    0       1234                1.234
+    1       12df                NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_fi_associationid(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is Finnish association registry id
+    in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(associationid.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(associationid.is_valid)
+        else:
+            return df.applymap(associationid.is_valid)
+    return associationid.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_fi_associationid(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [associationid.compact(val)] + result
+    elif output_format == "standard":
+        result = [associationid.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_fi_hetu.py
+++ b/dataprep/clean/clean_fi_hetu.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Finnish personal identity codes (HETUs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.fi import hetu
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_fi_hetu(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Finnish personal identity codes (HETUs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of HETU type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of HETU, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of HETU data.
+
+    >>> df = pd.DataFrame({{
+            "hetu": [
+            '131052a308t',
+            '131052-308U']
+            })
+    >>> clean_fi_hetu(df, 'hetu')
+            hetu             hetu_clean
+    0       131052a308t      131052A308T
+    1       131052-308U      NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_fi_hetu(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is HETU in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(hetu.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(hetu.is_valid)
+        else:
+            return df.applymap(hetu.is_valid)
+    return hetu.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of HETU, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_fi_hetu(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [hetu.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_fi_veronumero.py
+++ b/dataprep/clean/clean_fi_veronumero.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing Finnish individual tax numbers.
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.fi import veronumero
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_fi_veronumero(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Finnish individual tax numbers type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of Veronumero type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of Veronumero, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of Veronumero data.
+
+    >>> df = pd.DataFrame({{
+            "veronumero": [
+            '123456789123',
+            '12345678912A']
+            })
+    >>> clean_fi_veronumero(df, 'veronumero')
+            veronumero       veronumero_clean
+    0       123456789123     123456789123
+    1       12345678912A     NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_fi_veronumero(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is Veronumero in a DataFrame column.
+    For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(veronumero.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(veronumero.is_valid)
+        else:
+            return df.applymap(veronumero.is_valid)
+    return veronumero.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of Veronumero, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_fi_veronumero(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [veronumero.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_fi_ytunnus.py
+++ b/dataprep/clean/clean_fi_ytunnus.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Finnish business identifiers (y-tunnus).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.fi import ytunnus
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_fi_ytunnus(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Finnish business identifiers (y-tunnus) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of y-tunnus type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of y-tunnus data.
+
+    >>> df = pd.DataFrame({{
+            "ytunnus": [
+            "20774740",
+            "2077474-1",]
+            })
+    >>> clean_fi_ytunnus(df, 'ytunnus')
+            ytunnus          ytunnus_clean
+    0       20774740         2077474-0
+    1       2077474-1        NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_fi_ytunnus(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is y-tunnus in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(ytunnus.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(ytunnus.is_valid)
+        else:
+            return df.applymap(ytunnus.is_valid)
+    return ytunnus.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_fi_ytunnus(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [ytunnus.compact(val)] + result
+    elif output_format == "standard":
+        result = [ytunnus.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_fr_nif.py
+++ b/dataprep/clean/clean_fr_nif.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing French tax identification numbers (NIFs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.fr import nif
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_fr_nif(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean French tax identification numbers (NIFs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of NIF type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of NIF data.
+
+    >>> df = pd.DataFrame({{
+            "nif": [
+            "0701987765432",
+            "070198776543"]
+            })
+    >>> clean_fr_nif(df, 'nif')
+            nif                 nif_clean
+    0       0701987765432       07 01 987 765 432
+    1       070198776543        NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_fr_nif(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is NIF in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(nif.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(nif.is_valid)
+        else:
+            return df.applymap(nif.is_valid)
+    return nif.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_fr_nif(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [nif.compact(val)] + result
+    elif output_format == "standard":
+        result = [nif.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_fr_nir.py
+++ b/dataprep/clean/clean_fr_nir.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing
+French personal identification numbers (NIRs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.fr import nir
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_fr_nir(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean French personal identification numbers (NIRs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of NIR type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of NIR data.
+
+    >>> df = pd.DataFrame({{
+            "nir": [
+            "295109912611193",
+            "253072C07300443"]
+            })
+    >>> clean_fr_nir(df, 'nir')
+            nir                     nir_clean
+    0       295109912611193         2 95 10 99 126 111 93
+    1       253072C07300443         NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_fr_nir(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is NIR in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(nir.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(nir.is_valid)
+        else:
+            return df.applymap(nir.is_valid)
+    return nir.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_fr_nir(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [nir.compact(val)] + result
+    elif output_format == "standard":
+        result = [nir.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_fr_siren.py
+++ b/dataprep/clean/clean_fr_siren.py
@@ -1,0 +1,167 @@
+"""
+Clean and validate a DataFrame column containing
+French company identification numbers (SIRENs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.fr import siren
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_fr_siren(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean French company identification numbers (SIRENs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of SIREN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'tva', return a TVA that preposes two extra check digits to the data.
+            Note: in the case of SIREN, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of SIREN data.
+
+    >>> df = pd.DataFrame({{
+            "siren": [
+            '552 008 443',
+            '404833047']
+            })
+    >>> clean_fr_siren(df, 'siren')
+            siren           siren_clean
+    0       552 008 443     552008443
+    1       404833047       NaN
+    """
+
+    if output_format not in {"compact", "standard", "tva"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "tva".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_fr_siren(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is SIREN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(siren.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(siren.is_valid)
+        else:
+            return df.applymap(siren.is_valid)
+    return siren.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'tva', return a TVA that preposes two extra check digits to the data.
+           Note: in the case of SIREN, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_fr_siren(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [siren.compact(val)] + result
+    elif output_format == "tva":
+        result = [siren.to_tva(val)] + result
+
+    return result

--- a/dataprep/clean/clean_fr_siret.py
+++ b/dataprep/clean/clean_fr_siret.py
@@ -1,0 +1,171 @@
+"""
+Clean and validate a DataFrame column containing
+French company establishment identification numbers (SIRETs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.fr import siret
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_fr_siret(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean French company establishment identification numbers (SIRETs) data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of SIRET type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'siren', convert the SIRET number to a SIREN number.
+            If output_format = 'tva', convert the SIRET number to a TVA number.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of SIRET data.
+
+    >>> df = pd.DataFrame({{
+            "siret": [
+            "73282932000074",
+            "73282932000079"]
+            })
+    >>> clean_fr_siret(df, 'siret')
+            siret                 siret_clean
+    0       73282932000074        732 829 320 00074
+    1       73282932000079        NaN
+    """
+
+    if output_format not in {"compact", "standard", "siren", "tva"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard", "siren" or "tva".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_fr_siret(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is SIRET in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(siret.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(siret.is_valid)
+        else:
+            return df.applymap(siret.is_valid)
+    return siret.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'siren', convert the SIRET number to a SIREN number.
+           If output_format = 'tva', convert the SIRET number to a TVA number.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_fr_siret(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [siret.compact(val)] + result
+    elif output_format == "standard":
+        result = [siret.format(val)] + result
+    elif output_format == "siren":
+        result = [siret.to_siren(val)] + result
+    elif output_format == "tva":
+        result = [siret.to_tva(val)] + result
+
+    return result

--- a/dataprep/clean/clean_fr_tva.py
+++ b/dataprep/clean/clean_fr_tva.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing French TVA numbers (TVAs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.fr import tva
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_fr_tva(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean French TVA numbers (TVAs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of TVA type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of TVA, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of TVA data.
+
+    >>> df = pd.DataFrame({{
+            "tva": [
+            'Fr 40 303 265 045',
+            '84 323 140 391']
+            })
+    >>> clean_fr_tva(df, 'tva')
+            tva                     tva_clean
+    0       Fr 40 303 265 045       40303265045
+    1       84 323 140 391          NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_fr_tva(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is TVA in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(tva.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(tva.is_valid)
+        else:
+            return df.applymap(tva.is_valid)
+    return tva.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of TVA, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_fr_tva(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [tva.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_gb_nhs.py
+++ b/dataprep/clean/clean_gb_nhs.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing
+United Kingdom National Health Service patient identifier (NHSs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.gb import nhs
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_gb_nhs(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean United Kingdom NHS numbers (NHSs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of NHS type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of NHS data.
+
+    >>> df = pd.DataFrame({{
+            "nhs": [
+            "9434765870",
+            "9434765871"]
+            })
+    >>> clean_gb_nhs(df, 'nhs')
+            nhs                 nhs_clean
+    0       9434765870          943 476 5870
+    1       9434765871          NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_gb_nhs(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is NHS in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(nhs.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(nhs.is_valid)
+        else:
+            return df.applymap(nhs.is_valid)
+    return nhs.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_gb_nhs(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [nhs.compact(val)] + result
+    elif output_format == "standard":
+        result = [nhs.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_gb_sedol.py
+++ b/dataprep/clean/clean_gb_sedol.py
@@ -1,0 +1,167 @@
+"""
+Clean and validate a DataFrame column containing
+Stock Exchange Daily Official List numbers (SEDOLs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.gb import sedol
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_gb_sedol(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Stock Exchange Daily Official List number in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of SEDOL type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'isin', convert the number to an ISIN.
+            Note: in the case of SEDOL, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of SEDOL data.
+
+    >>> df = pd.DataFrame({{
+            "sedol": [
+            'B15KXQ8',
+            'B15KXQ7']
+            })
+    >>> clean_gb_sedol(df, 'sedol')
+            sedol           sedol_clean
+    0       B15KXQ8         B15KXQ8
+    1       B15KXQ7         NaN
+    """
+
+    if output_format not in {"compact", "standard", "isin"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "isin".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_gb_sedol(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is SEDOL in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(sedol.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(sedol.is_valid)
+        else:
+            return df.applymap(sedol.is_valid)
+    return sedol.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'isin', convert the number to an ISIN.
+           Note: in the case of SEDOL, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_gb_sedol(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [sedol.compact(val)] + result
+    elif output_format == "isin":
+        result = [sedol.to_isin(val)] + result
+
+    return result

--- a/dataprep/clean/clean_gb_upn.py
+++ b/dataprep/clean/clean_gb_upn.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing English Unique Pupil Numbers (UPNs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.gb import upn
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_gb_upn(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean English Unique Pupil Numbers (UPNs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of UPN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of UPN, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of UPN data.
+
+    >>> df = pd.DataFrame({{
+            "upn": [
+            'B801200005001',
+            'A801200005001']
+            })
+    >>> clean_gb_upn(df, 'upn')
+            upn                 upn_clean
+    0       B801200005001       B801200005001
+    1       A801200005001       NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_gb_upn(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is UPN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(upn.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(upn.is_valid)
+        else:
+            return df.applymap(upn.is_valid)
+    return upn.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of UPN, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_gb_upn(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [upn.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_gb_utr.py
+++ b/dataprep/clean/clean_gb_utr.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing
+United Kingdom Unique Taxpayer Reference (UTRs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.gb import utr
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_gb_utr(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean United Kingdom Unique Taxpayer Reference (UTRs) in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of UTR type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of UTR, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of UTR data.
+
+    >>> df = pd.DataFrame({{
+            "utr": [
+            '1955839661',
+            '2955839661',]
+            })
+    >>> clean_gb_utr(df, 'utr')
+            utr             utr_clean
+    0       1955839661      1955839661
+    1       2955839661      NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_gb_utr(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is UTR in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(utr.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(utr.is_valid)
+        else:
+            return df.applymap(utr.is_valid)
+    return utr.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of UTR, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_gb_utr(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [utr.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_gb_vat.py
+++ b/dataprep/clean/clean_gb_vat.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing United Kingdom VAT numbers (VATs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.gb import vat
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_gb_vat(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean United Kingdom VAT numbers (VATs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of VAT type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of VAT data.
+
+    >>> df = pd.DataFrame({{
+            "vat": [
+            "980780684",
+            "802311781"]
+            })
+    >>> clean_gb_vat(df, 'vat')
+            vat                 vat_clean
+    0       980780684           980 7806 84
+    1       802311781           NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_gb_vat(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is VAT in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(vat.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(vat.is_valid)
+        else:
+            return df.applymap(vat.is_valid)
+    return vat.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_gb_vat(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [vat.compact(val)] + result
+    elif output_format == "standard":
+        result = [vat.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_gr_amka.py
+++ b/dataprep/clean/clean_gr_amka.py
@@ -1,0 +1,170 @@
+"""
+Clean and validate a DataFrame column containing Greek social security numbers (AMKAs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.gr import amka
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_gr_amka(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Greek social security numbers (AMKAs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of AMKA type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', get the person's birthdate.
+            If output_format = 'gender', get the person's birth gender ('M' or 'F').
+            Note: in the case of AMKA, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of AMKA data.
+
+    >>> df = pd.DataFrame({{
+            "amka": [
+            '01013099997',
+            '01013099999']
+            })
+    >>> clean_gr_amka(df, 'amka')
+            amka            amka_clean
+    0       01013099997     01013099997
+    1       01013099999     NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate", "gender"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard", "birthdate" or "gender".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_gr_amka(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is AMKA in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(amka.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(amka.is_valid)
+        else:
+            return df.applymap(amka.is_valid)
+    return amka.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', get the person's birthdate.
+           If output_format = 'gender', get the person's birth gender ('M' or 'F').
+           Note: in the case of AMKA, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_gr_amka(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [amka.compact(val)] + result
+    elif output_format == "birthdate":
+        result = [amka.get_birth_date(val)] + result
+    elif output_format == "gender":
+        result = [amka.get_gender(val)] + result
+
+    return result

--- a/dataprep/clean/clean_gr_vat.py
+++ b/dataprep/clean/clean_gr_vat.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Greek VAT numbers (VATs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.gr import vat
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_gr_vat(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Greek VAT numbers (VATs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of VAT type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of VAT, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of VAT data.
+
+    >>> df = pd.DataFrame({{
+            "vat": [
+            'EL 094259216',
+            'EL 123456781']
+            })
+    >>> clean_gr_vat(df, 'vat')
+            vat             vat_clean
+    0       EL 094259216    094259216
+    1       EL 123456781    NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_gr_vat(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is VAT in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(vat.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(vat.is_valid)
+        else:
+            return df.applymap(vat.is_valid)
+    return vat.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of VAT, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_gr_vat(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [vat.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_gt_nit.py
+++ b/dataprep/clean/clean_gt_nit.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Guatemala tax numbers (NITs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.gt import nit
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_gt_nit(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Guatemala tax numbers (NITs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of NIT type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of NIT data.
+
+    >>> df = pd.DataFrame({{
+            "nit": [
+            "39525503",
+            "8977112-0",]
+            })
+    >>> clean_gt_nit(df, 'nit')
+            nit                 nit_clean
+    0       39525503            3952550-3
+    1       8977112-0           NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_gt_nit(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is NIT in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(nit.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(nit.is_valid)
+        else:
+            return df.applymap(nit.is_valid)
+    return nit.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_gt_nit(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [nit.compact(val)] + result
+    elif output_format == "standard":
+        result = [nit.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_hr_oib.py
+++ b/dataprep/clean/clean_hr_oib.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Croatian identification numbers (OIBs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.hr import oib
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_hr_oib(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Croatian identification numbers (OIBs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of OIB type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of OIB, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of OIB data.
+
+    >>> df = pd.DataFrame({{
+            "oib": [
+            'HR 33392005961',
+            '33392005962',]
+            })
+    >>> clean_hr_oib(df, 'oib')
+            oib               oib_clean
+    0       HR 33392005961    33392005961
+    1       33392005962       NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_hr_oib(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is OIB in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(oib.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(oib.is_valid)
+        else:
+            return df.applymap(oib.is_valid)
+    return oib.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of OIB, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_hr_oib(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [oib.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_hu_anum.py
+++ b/dataprep/clean/clean_hu_anum.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Hungarian ANUM numbers (ANUMs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.hu import anum
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_hu_anum(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Hungarian ANUM numbers (ANUMs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of ANUM type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of ANUM, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of ANUM data.
+
+    >>> df = pd.DataFrame({{
+            "anum": [
+            'HU-12892312',
+            'HU-12892313',]
+            })
+    >>> clean_hu_anum(df, 'anum')
+            anum             anum_clean
+    0       HU-12892312      12892312
+    1       HU-12892313      NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_hu_anum(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is ANUM in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(anum.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(anum.is_valid)
+        else:
+            return df.applymap(anum.is_valid)
+    return anum.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of ANUM, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_hu_anum(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [anum.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_id_npwp.py
+++ b/dataprep/clean/clean_id_npwp.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Indonesian VAT Numbers (NPWPs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.id import npwp
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_id_npwp(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Indonesian VAT Numbers (NPWPs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of NPWP type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of NPWP data.
+
+    >>> df = pd.DataFrame({{
+            "npwp": [
+            "013000666091000",
+            "123456789",]
+            })
+    >>> clean_id_npwp(df, 'npwp')
+            npwp                    npwp_clean
+    0       013000666091000         01.300.066.6-091.000
+    1       123456789               NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_id_npwp(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is NPWP in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(npwp.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(npwp.is_valid)
+        else:
+            return df.applymap(npwp.is_valid)
+    return npwp.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_id_npwp(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [npwp.compact(val)] + result
+    elif output_format == "standard":
+        result = [npwp.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_ie_pps.py
+++ b/dataprep/clean/clean_ie_pps.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Irish personal numbers (PPSs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ie import pps
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ie_pps(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Irish personal numbers (PPSs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of PPS type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of PPS, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of PPS data.
+
+    >>> df = pd.DataFrame({{
+            "pps": [
+            '6433435OA',
+            '6433435VH',]
+            })
+    >>> clean_ie_pps(df, 'pps')
+            pps             pps_clean
+    0       6433435OA       6433435OA
+    1       6433435VH       NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ie_pps(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is PPS in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(pps.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(pps.is_valid)
+        else:
+            return df.applymap(pps.is_valid)
+    return pps.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of PPS, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ie_pps(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [pps.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_ie_vat.py
+++ b/dataprep/clean/clean_ie_vat.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Irish VAT numbers (VATs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ie import vat
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ie_vat(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Irish VAT numbers (VATs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of VAT type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of VAT, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of VAT data.
+
+    >>> df = pd.DataFrame({{
+            "vat": [
+            'IE 6433435OA',
+            '6433435E',]
+            })
+    >>> clean_ie_vat(df, 'vat')
+            vat             vat_clean
+    0       IE 6433435OA    6433435OA
+    1       6433435E        NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ie_vat(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is VAT in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(vat.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(vat.is_valid)
+        else:
+            return df.applymap(vat.is_valid)
+    return vat.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of VAT, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ie_vat(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [vat.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_il_hp.py
+++ b/dataprep/clean/clean_il_hp.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Israeli company numbers (HPs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.il import hp
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_il_hp(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Israeli company numbers (HPs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of HP type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of HP, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of HP data.
+
+    >>> df = pd.DataFrame({{
+            "hp": [
+            ' 5161 79157 ',
+            '516179150',]
+            })
+    >>> clean_il_hp(df, 'hp')
+            hp              hp_clean
+    0        5161 79157     516179157
+    1       516179150       NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_il_hp(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is HP in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(hp.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(hp.is_valid)
+        else:
+            return df.applymap(hp.is_valid)
+    return hp.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of HP, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_il_hp(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [hp.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_il_idnr.py
+++ b/dataprep/clean/clean_il_idnr.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Israeli personal numbers (IDNRs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.il import idnr
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_il_idnr(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Israeli personal numbers (IDNRs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of IDNR type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of IDNR data.
+
+    >>> df = pd.DataFrame({{
+            "idnr": [
+            "39337423",
+            "3933742-2",]
+            })
+    >>> clean_il_idnr(df, 'idnr')
+            idnr             idnr_clean
+    0       39337423         03933742-3
+    1       3933742-2        NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_il_idnr(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is IDNR in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(idnr.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(idnr.is_valid)
+        else:
+            return df.applymap(idnr.is_valid)
+    return idnr.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_il_idnr(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [idnr.compact(val)] + result
+    elif output_format == "standard":
+        result = [idnr.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_in_aadhaar.py
+++ b/dataprep/clean/clean_in_aadhaar.py
@@ -1,0 +1,169 @@
+"""
+Clean and validate a DataFrame column containing
+Indian digital resident personal identity numbers (Aadhaars).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.in_ import aadhaar
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_in_aadhaar(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Indian digital resident personal identity number (Aadhaars) in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of Aadhaar type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'mask', Masks the first 8 digits as per MeitY guidelines for
+                securing identity information and Sensitive personal data.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of Aadhaar data.
+
+    >>> df = pd.DataFrame({{
+            "aadhaar": [
+            "234123412346",
+            "643343121",]
+            })
+    >>> clean_in_aadhaar(df, 'aadhaar')
+            aadhaar                 aadhaar_clean
+    0       234123412346            2341 2341 2346
+    1       643343121               NaN
+    """
+
+    if output_format not in {"compact", "standard", "mask"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "mask".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_in_aadhaar(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is Aadhaar in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(aadhaar.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(aadhaar.is_valid)
+        else:
+            return df.applymap(aadhaar.is_valid)
+    return aadhaar.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'mask', Masks the first 8 digits as per MeitY guidelines for
+                securing identity information and Sensitive personal data.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_in_aadhaar(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [aadhaar.compact(val)] + result
+    elif output_format == "standard":
+        result = [aadhaar.format(val)] + result
+    elif output_format == "mask":
+        result = [aadhaar.mask(val)] + result
+
+    return result

--- a/dataprep/clean/clean_in_pan.py
+++ b/dataprep/clean/clean_in_pan.py
@@ -1,0 +1,172 @@
+"""
+Clean and validate a DataFrame column containing Indian Permanent Account numbers (PANs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.in_ import pan
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_in_pan(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Indian Permanent Account numbers (PANs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of PAN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'info', return a dictionary containing information
+                that can be decoded from the PAN.
+            If output_format = 'mask', mask the PAN as per CBDT masking standard.
+            Note: in the case of PAN, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of PAN data.
+
+    >>> df = pd.DataFrame({{
+            "pan": [
+            'ACUPA7085R',
+            '234123412347',]
+            })
+    >>> clean_in_pan(df, 'pan')
+            pan             pan_clean
+    0       ACUPA7085R      ACUPA7085R
+    1       234123412347    NaN
+    """
+
+    if output_format not in {"compact", "standard", "info", "mask"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard", "info", "mask".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_in_pan(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is PAN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(pan.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(pan.is_valid)
+        else:
+            return df.applymap(pan.is_valid)
+    return pan.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'info', return a dictionary containing information
+                that can be decoded from the PAN.
+           If output_format = 'mask', mask the PAN as per CBDT masking standard.
+           Note: in the case of PAN, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_in_pan(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [pan.compact(val)] + result
+    elif output_format == "info":
+        result = [pan.info(val)] + result
+    elif output_format == "mask":
+        result = [pan.mask(val)] + result
+
+    return result

--- a/dataprep/clean/clean_is_kennitala.py
+++ b/dataprep/clean/clean_is_kennitala.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Icelandic identity codes (Kennitalas).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.is_ import kennitala
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_is_kennitala(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Icelandic identity codes (Kennitalas) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of Kennitala type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of Kennitala data.
+
+    >>> df = pd.DataFrame({{
+            "kennitala": [
+            "1201743399",
+            "320174-3399",]
+            })
+    >>> clean_is_kennitala(df, 'kennitala')
+            kennitala          kennitala_clean
+    0       1201743399         120174-3399
+    1       320174-3399        NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_is_kennitala(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is Kennitala in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(kennitala.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(kennitala.is_valid)
+        else:
+            return df.applymap(kennitala.is_valid)
+    return kennitala.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_is_kennitala(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [kennitala.compact(val)] + result
+    elif output_format == "standard":
+        result = [kennitala.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_is_vsk.py
+++ b/dataprep/clean/clean_is_vsk.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Icelandic VSK numbers (VSKs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.is_ import vsk
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_is_vsk(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Icelandic VSK numbers (VSKs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of VSK type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of VSK, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of VSK data.
+
+    >>> df = pd.DataFrame({{
+            "vsk": [
+            'IS 00621',
+            'IS 0062199',]
+            })
+    >>> clean_is_vsk(df, 'vsk')
+            vsk             vsk_clean
+    0       IS 00621        00621
+    1       IS 0062199      NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_is_vsk(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is VSK in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(vsk.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(vsk.is_valid)
+        else:
+            return df.applymap(vsk.is_valid)
+    return vsk.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of VSK, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_is_vsk(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [vsk.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_it_aic.py
+++ b/dataprep/clean/clean_it_aic.py
@@ -1,0 +1,183 @@
+"""
+Clean and validate a DataFrame column containing
+Italian code for identification of drugs (AICs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.it import aic
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_it_aic(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Italian code for identification of drugs (AICs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of AIC type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'base10', convert a BASE32 representation to a BASE10 one.
+            If output_format = 'base32', convert a BASE10 representation to a BASE32 one.
+            Note: in the case of AIC, the compact format is the same as the standard one.
+                And 'compact' may contain both BASE10 and BASE32 represatation.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of AIC data.
+
+    >>> df = pd.DataFrame({{
+            "aic": [
+            '000307052',
+            '999999',]
+            })
+    >>> clean_it_aic(df, 'aic')
+            aic             aic_clean
+    0       000307052       000307052
+    1       999999          NaN
+    """
+
+    if output_format not in {"compact", "standard", "base10", "base32"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard", "base10" or "base32".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_it_aic(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is AIC in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(aic.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(aic.is_valid)
+        else:
+            return df.applymap(aic.is_valid)
+    return aic.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'base10', convert a BASE32 representation to a BASE10 one.
+           If output_format = 'base32', convert a BASE10 representation to a BASE32 one.
+           Note: in the case of AIC, the compact format is the same as the standard one.
+               And 'compact' may contain both BASE10 and BASE32 represatation.
+    """
+    # pylint: disable=bare-except
+
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_it_aic(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [aic.compact(val)] + result
+    elif output_format == "base10":
+        try:
+            aic.validate_base10(val)
+            result = [val] + result
+        except:  # already know it is a valid AIC, so it can only be BASE32
+            result = [aic.from_base32(val)] + result
+    elif output_format == "base32":
+        try:
+            aic.validate_base32(val)
+            result = [val] + result
+        except:
+            result = [aic.to_base32(val)] + result
+
+    return result

--- a/dataprep/clean/clean_it_codicefiscale.py
+++ b/dataprep/clean/clean_it_codicefiscale.py
@@ -1,0 +1,171 @@
+"""
+Clean and validate a DataFrame column containing Italian fiscal codes (Codice Fiscales).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.it import codicefiscale
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_it_codicefiscale(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Italian fiscal code (Codice Fiscales) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of Codice Fiscale type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', get the person's birthdate.
+            If output_format = 'gender', get the person's birth gender ('M' or 'F').
+            Note: in the case of Codice Fiscale, the compact format is the same as the standard.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of Codice Fiscale data.
+
+    >>> df = pd.DataFrame({{
+            "codicefiscale": [
+            'RCCMNL83S18D969H',
+            'RCCMNL83S18D969']
+            })
+    >>> clean_it_codicefiscale(df, 'codicefiscale')
+            codicefiscale        codicefiscale_clean
+    0       RCCMNL83S18D969H     RCCMNL83S18D969H
+    1       RCCMNL83S18D969      NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate", "gender"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard", "birthdate" or "gender".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_it_codicefiscale(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is Codice Fiscale in a DataFrame column.
+    For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(codicefiscale.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(codicefiscale.is_valid)
+        else:
+            return df.applymap(codicefiscale.is_valid)
+    return codicefiscale.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', get the person's birthdate.
+           If output_format = 'gender', get the person's birth gender ('M' or 'F').
+           Note: in the case of Codice Fiscale, the compact format is the same as the standard.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_it_codicefiscale(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [codicefiscale.compact(val)] + result
+    elif output_format == "birthdate":
+        result = [codicefiscale.get_birth_date(val)] + result
+    elif output_format == "gender":
+        result = [codicefiscale.get_gender(val)] + result
+
+    return result

--- a/dataprep/clean/clean_it_iva.py
+++ b/dataprep/clean/clean_it_iva.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Italian IVA numbers (IVAs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.it import iva
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_it_iva(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Italian IVA numbers (IVAs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of IVA type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of IVA, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of IVA data.
+
+    >>> df = pd.DataFrame({{
+            "iva": [
+            'IT 00743110157',
+            '00743110158',]
+            })
+    >>> clean_it_iva(df, 'iva')
+            iva                 iva_clean
+    0       IT 00743110157      00743110157
+    1       00743110158         NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_it_iva(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is IVA in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(iva.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(iva.is_valid)
+        else:
+            return df.applymap(iva.is_valid)
+    return iva.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of IVA, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_it_iva(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [iva.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_jp_cn.py
+++ b/dataprep/clean/clean_jp_cn.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Japanese Corporate Numbers (CNs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.jp import cn
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_jp_cn(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Japanese Corporate Numbers (CNs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CN data.
+
+    >>> df = pd.DataFrame({{
+            "cn": [
+            "5835678256246",
+            "2-8356-7825-6246",]
+            })
+    >>> clean_jp_cn(df, 'cn')
+            cn                 cn_clean
+    0       5835678256246      5-8356-7825-6246
+    1       2-8356-7825-6246   NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_jp_cn(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(cn.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(cn.is_valid)
+        else:
+            return df.applymap(cn.is_valid)
+    return cn.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_jp_cn(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [cn.compact(val)] + result
+    elif output_format == "standard":
+        result = [cn.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_kr_brn.py
+++ b/dataprep/clean/clean_kr_brn.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing
+South Korea Business Registration Numbers (BRNs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.kr import brn
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_kr_brn(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean South Korea Business Registration Numbers (BRNs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of BRN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of BRN data.
+
+    >>> df = pd.DataFrame({{
+            "brn": [
+            "1348672683",
+            "123456789",]
+            })
+    >>> clean_kr_brn(df, 'brn')
+            brn                 brn_clean
+    0       1348672683          134-86-72683
+    1       123456789           NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_kr_brn(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is BRN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(brn.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(brn.is_valid)
+        else:
+            return df.applymap(brn.is_valid)
+    return brn.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_kr_brn(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [brn.compact(val)] + result
+    elif output_format == "standard":
+        result = [brn.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_kr_rrn.py
+++ b/dataprep/clean/clean_kr_rrn.py
@@ -1,0 +1,167 @@
+"""
+Clean and validate a DataFrame column containing
+South Korean resident registration numbers (RRNs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.kr import rrn
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_kr_rrn(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean South Korean resident registration numbers (RRNs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of RRN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', get the person's birthdate.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of RRN data.
+
+    >>> df = pd.DataFrame({{
+            "rrn": [
+            "971013-9019902",
+            "971013-9019903",]
+            })
+    >>> clean_kr_rrn(df, 'rrn')
+            rrn                 rrn_clean
+    0       971013-9019902      971013-9019902
+    1       971013-9019903      NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "birthdate".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_kr_rrn(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is RRN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(rrn.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(rrn.is_valid)
+        else:
+            return df.applymap(rrn.is_valid)
+    return rrn.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', get the person's birthdate.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_kr_rrn(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [rrn.compact(val)] + result
+    elif output_format == "standard":
+        result = [rrn.format(val)] + result
+    elif output_format == "birthdate":
+        result = [rrn.get_birth_date(val)] + result
+
+    return result

--- a/dataprep/clean/clean_li_peid.py
+++ b/dataprep/clean/clean_li_peid.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing
+Liechtenstein tax code for individuals and entities (PEIDs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.li import peid
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_li_peid(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Liechtenstein tax code for individuals and entities data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of PEID type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of PEID, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of PEID data.
+
+    >>> df = pd.DataFrame({{
+            "peid": [
+            '00001234567',
+            '00001234568913454545',]
+            })
+    >>> clean_li_peid(df, 'peid')
+            peid                    peid_clean
+    0       00001234567             1234567
+    1       00001234568913454545    NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_li_peid(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is PEID in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(peid.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(peid.is_valid)
+        else:
+            return df.applymap(peid.is_valid)
+    return peid.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of PEID, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_li_peid(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [peid.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_lt_asmens.py
+++ b/dataprep/clean/clean_lt_asmens.py
@@ -1,0 +1,167 @@
+"""
+Clean and validate a DataFrame column containing Lithuanian personal numbers (Asmens kodas).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.lt import asmens
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_lt_asmens(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Lithuanian personal numbers (Asmens kodas) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of Asmens kodas type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', return the birthdate of the person.
+            Note: in the case of Asmens kodas, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of Asmens kodas data.
+
+    >>> df = pd.DataFrame({{
+            "asmens": [
+            '33309240064',
+            '33309240164',]
+            })
+    >>> clean_lt_asmens(df, 'asmens')
+            asmens          asmens_clean
+    0       33309240064     33309240064
+    1       33309240164     NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "birthdate".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_lt_asmens(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is Asmens kodas in a DataFrame column.
+    For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(asmens.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(asmens.is_valid)
+        else:
+            return df.applymap(asmens.is_valid)
+    return asmens.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', return the birthdate of the person.
+           Note: in the case of Asmens kodas, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_lt_asmens(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [asmens.compact(val)] + result
+    elif output_format == "birthdate":
+        result = [asmens.get_birth_date(val)] + result
+
+    return result

--- a/dataprep/clean/clean_lt_pvm.py
+++ b/dataprep/clean/clean_lt_pvm.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Lithuanian PVM numbers (PVMs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.lt import pvm
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_lt_pvm(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Lithuanian PVM numbers (PVMs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of PVM type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of PVM, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of PVM data.
+
+    >>> df = pd.DataFrame({{
+            "pvm": [
+            '119511515',
+            '100001919018',]
+            })
+    >>> clean_lt_pvm(df, 'pvm')
+            pvm              pvm_clean
+    0       119511515        119511515
+    1       100001919018     NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_lt_pvm(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is PVM in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(pvm.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(pvm.is_valid)
+        else:
+            return df.applymap(pvm.is_valid)
+    return pvm.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of PVM, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_lt_pvm(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [pvm.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_lu_tva.py
+++ b/dataprep/clean/clean_lu_tva.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Luxembourgian TVA numbers (TVAs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.lu import tva
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_lu_tva(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Luxembourgian TVA numbers (TVAs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of TVA type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of TVA, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of TVA data.
+
+    >>> df = pd.DataFrame({{
+            "tva": [
+            'LU 150 274 42',
+            '150 274 43',]
+            })
+    >>> clean_lu_tva(df, 'tva')
+            tva                 tva_clean
+    0       LU 150 274 42       15027442
+    1       150 274 43          NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_lu_tva(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is TVA in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(tva.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(tva.is_valid)
+        else:
+            return df.applymap(tva.is_valid)
+    return tva.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of TVA, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_lu_tva(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [tva.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_lv_pvn.py
+++ b/dataprep/clean/clean_lv_pvn.py
@@ -1,0 +1,173 @@
+"""
+Clean and validate a DataFrame column containing Latvian PVN (VAT) numbers (PVTs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.lv import pvn
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_lv_pvn(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Latvian PVN (VAT) numbers (PVTs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of PVT type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', return the birthdate of the person. Note only when
+                PVN refers to a person (but not a legal entity) this format will be available.
+            Note: in the case of PVT, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of PVT data.
+
+    >>> df = pd.DataFrame({{
+            "pvn": [
+            '161175-19997',
+            '40003521601',]
+            })
+    >>> clean_lv_pvn(df, 'pvn')
+            pvn                     pvn_clean
+    0       161175-19997            16117519997
+    1       40003521601             NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "birthdate".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_lv_pvn(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is PVT in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(pvn.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(pvn.is_valid)
+        else:
+            return df.applymap(pvn.is_valid)
+    return pvn.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', return the birthdate of the person. Note only when
+                PVN refers to a person (but not a legal entity) this format will be available.
+           Note: in the case of PVT, the compact format is the same as the standard one.
+    """
+    # pylint: disable=bare-except
+
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_lv_pvn(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [pvn.compact(val)] + result
+    elif output_format == "birthdate":
+        try:
+            result = [pvn.get_birth_date(val)] + result
+        except:  # PVN stands for a legal entity
+            return [np.nan]
+
+    return result

--- a/dataprep/clean/clean_mc_tva.py
+++ b/dataprep/clean/clean_mc_tva.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Monacan TVA numbers (TVAs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.mc import tva
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_mc_tva(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Monacan TVA numbers (TVAs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of TVA type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of TVA, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of TVA data.
+
+    >>> df = pd.DataFrame({{
+            "tva": [
+            '53 0000 04605',
+            'FR 61 954 506 077',]
+            })
+    >>> clean_mc_tva(df, 'tva')
+            tva                     tva_clean
+    0       53 0000 04605           FR53000004605
+    1       FR 61 954 506 077       NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_mc_tva(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is TVA in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(tva.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(tva.is_valid)
+        else:
+            return df.applymap(tva.is_valid)
+    return tva.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of TVA, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_mc_tva(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [tva.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_md_idno.py
+++ b/dataprep/clean/clean_md_idno.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Moldavian company identification numbers (IDNOs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.md import idno
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_md_idno(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Moldavian company identification numbers (IDNOs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of IDNO type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of IDNO, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of IDNO data.
+
+    >>> df = pd.DataFrame({{
+            "idno": [
+            '1008600038413',
+            '1008600038412',]
+            })
+    >>> clean_md_idno(df, 'idno')
+            idno                idno_clean
+    0       1008600038413       1008600038413
+    1       1008600038412       NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_md_idno(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is IDNO in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(idno.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(idno.is_valid)
+        else:
+            return df.applymap(idno.is_valid)
+    return idno.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of IDNO, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_md_idno(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [idno.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_me_iban.py
+++ b/dataprep/clean/clean_me_iban.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Montenegro IBANs (IBANs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.me import iban
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_me_iban(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Montenegro IBANs (IBANs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of IBAN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of IBAN data.
+
+    >>> df = pd.DataFrame({{
+            "iban": [
+            "ME25510000000006234133",
+            "ME52510000000006234132",]
+            })
+    >>> clean_me_iban(df, 'iban')
+            iban                                iban_clean
+    0       ME25510000000006234133              ME 2551 0000 0000 0623 4133
+    1       ME52510000000006234132              NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_me_iban(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is IBAN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(iban.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(iban.is_valid)
+        else:
+            return df.applymap(iban.is_valid)
+    return iban.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_me_iban(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [iban.compact(val)] + result
+    elif output_format == "standard":
+        result = [iban.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_mt_vat.py
+++ b/dataprep/clean/clean_mt_vat.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Maltese VAT numbers (VATs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.mt import vat
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_mt_vat(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Maltese VAT numbers (VATs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of VAT type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of VAT, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of VAT data.
+
+    >>> df = pd.DataFrame({{
+            "vat": [
+            'MT 1167-9112',
+            '1167-9113',]
+            })
+    >>> clean_mt_vat(df, 'vat')
+            vat             vat_clean
+    0       MT 1167-9112    11679112
+    1       1167-9113       NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_mt_vat(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is VAT in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(vat.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(vat.is_valid)
+        else:
+            return df.applymap(vat.is_valid)
+    return vat.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of VAT, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_mt_vat(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [vat.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_mu_nid.py
+++ b/dataprep/clean/clean_mu_nid.py
@@ -1,0 +1,168 @@
+"""
+Clean and validate a DataFrame column containing Mauritian national ID numbers (NIDs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.mu import nid
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_mu_nid(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Mauritian national ID numbers (NIDs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of NID type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', return the birthdate of the person.
+            Note: in the case of NID, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of NID data.
+
+    >>> df = pd.DataFrame({{
+            "nid": [
+            'J2906201304089',
+            'J2906201304088',]
+            })
+    >>> clean_mu_nid(df, 'nid')
+            nid                 nid_clean
+    0       J2906201304089      J2906201304089
+    1       J2906201304088      NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "birthdate".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_mu_nid(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is NID in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(nid.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(nid.is_valid)
+        else:
+            return df.applymap(nid.is_valid)
+    return nid.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', return the birthdate of the person.
+           Note: in the case of NID, the compact format is the same as the standard one.
+    """
+    # pylint: disable=protected-access
+
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_mu_nid(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [nid.compact(val)] + result
+    elif output_format == "birthdate":
+        result = [nid._get_date(val)] + result
+
+    return result

--- a/dataprep/clean/clean_mx_curp.py
+++ b/dataprep/clean/clean_mx_curp.py
@@ -1,0 +1,170 @@
+"""
+Clean and validate a DataFrame column containing Mexican personal identifiers (CURPs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.mx import curp
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_mx_curp(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Estonian Personcal ID number (CURPs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CURP type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', get the person's birthdate.
+            If output_format = 'gender', get the person's birth gender ('M' or 'F').
+            Note: in the case of CURP, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CURP data.
+
+    >>> df = pd.DataFrame({{
+            "curp": [
+            'BOXW310820HNERXN09',
+            'BOXW310820HNERXN08']
+            })
+    >>> clean_mx_curp(df, 'curp')
+            curp                    curp_clean
+    0       BOXW310820HNERXN09      BOXW310820HNERXN09
+    1       BOXW310820HNERXN08      NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate", "gender"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard", "birthdate" or "gender".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_mx_curp(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CURP in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(curp.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(curp.is_valid)
+        else:
+            return df.applymap(curp.is_valid)
+    return curp.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', get the person's birthdate.
+           If output_format = 'gender', get the person's birth gender ('M' or 'F').
+           Note: in the case of CURP, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_mx_curp(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [curp.compact(val)] + result
+    elif output_format == "birthdate":
+        result = [curp.get_birth_date(val)] + result
+    elif output_format == "gender":
+        result = [curp.get_gender(val)] + result
+
+    return result

--- a/dataprep/clean/clean_mx_rfc.py
+++ b/dataprep/clean/clean_mx_rfc.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Mexican tax numbers (RFCs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.mx import rfc
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_mx_rfc(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Mexican tax numbers (RFCs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of RFC type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of RFC data.
+
+    >>> df = pd.DataFrame({{
+            "rfc": [
+            "GODE561231GR8",
+            "BUEI591231GH9",]
+            })
+    >>> clean_mx_rfc(df, 'rfc')
+            rfc                 rfc_clean
+    0       GODE561231GR8       GODE 561231 GR8
+    1       BUEI591231GH9       NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_mx_rfc(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is RFC in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(rfc.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(rfc.is_valid)
+        else:
+            return df.applymap(rfc.is_valid)
+    return rfc.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_mx_rfc(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [rfc.compact(val)] + result
+    elif output_format == "standard":
+        result = [rfc.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_my_nric.py
+++ b/dataprep/clean/clean_my_nric.py
@@ -1,0 +1,171 @@
+"""
+Clean and validate a DataFrame column containing
+Malaysian National Registration Identity Card Numbers (NRICs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.my import nric
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_my_nric(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Malaysian National Registration Identity Card Numbers (NRICs) in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of NRIC type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', return the registration date or the birth date.
+            If output_format = 'birthplace', return a dict containing the birthplace of the person.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of NRIC data.
+
+    >>> df = pd.DataFrame({{
+            "nric": [
+            "770305021234",
+            "771305-02-1234",]
+            })
+    >>> clean_my_nric(df, 'nric')
+            nric                 nric_clean
+    0       770305021234         770305-02-1234
+    1       771305-02-1234       NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate", "birthplace"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard", "birthdate" or "birthplace".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_my_nric(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is NRIC in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(nric.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(nric.is_valid)
+        else:
+            return df.applymap(nric.is_valid)
+    return nric.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', return the registration date or the birth date.
+           If output_format = 'birthplace', return a dict containing the birthplace of the person.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_my_nric(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [nric.compact(val)] + result
+    elif output_format == "standard":
+        result = [nric.format(val)] + result
+    elif output_format == "birthdate":
+        result = [nric.get_birth_date(val)] + result
+    elif output_format == "birthplace":
+        result = [nric.get_birth_place(val)] + result
+
+    return result

--- a/dataprep/clean/clean_nl_brin.py
+++ b/dataprep/clean/clean_nl_brin.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Brin numbers (BRINs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.nl import brin
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_nl_brin(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Brin numbers (BRINs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of BRIN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of BRIN, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of BRIN data.
+
+    >>> df = pd.DataFrame({{
+            "brin": [
+            '05 KO',
+            '30AJ0A',]
+            })
+    >>> clean_nl_brin(df, 'brin')
+            brin             brin_clean
+    0       05 KO            05KO
+    1       30AJ0A           NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_nl_brin(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is BRIN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(brin.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(brin.is_valid)
+        else:
+            return df.applymap(brin.is_valid)
+    return brin.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of BRIN, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_nl_brin(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [brin.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_nl_bsn.py
+++ b/dataprep/clean/clean_nl_bsn.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing Burgerservicenummer,
+the Dutch citizen identification numbers (BSNs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.nl import bsn
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_nl_bsn(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Burgerservicenummer (BSNs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of BSN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of BSN data.
+
+    >>> df = pd.DataFrame({{
+            "bsn": [
+            "111222333",
+            "1112223334",]
+            })
+    >>> clean_nl_bsn(df, 'bsn')
+            bsn                 bsn_clean
+    0       111222333           1112.22.333
+    1       1112223334          NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_nl_bsn(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is BSN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(bsn.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(bsn.is_valid)
+        else:
+            return df.applymap(bsn.is_valid)
+    return bsn.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_nl_bsn(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [bsn.compact(val)] + result
+    elif output_format == "standard":
+        result = [bsn.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_nl_btw.py
+++ b/dataprep/clean/clean_nl_btw.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Dutch BTW numbers (BTWs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.nl import btw
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_nl_btw(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Dutch BTW numbers (BTWs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of BTW type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of BTW, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of BTW data.
+
+    >>> df = pd.DataFrame({{
+            "btw": [
+            '004495445B01',
+            '123456789B90',]
+            })
+    >>> clean_nl_btw(df, 'btw')
+            btw             btw_clean
+    0       004495445B01    004495445B01
+    1       123456789B90    NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_nl_btw(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is BTW in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(btw.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(btw.is_valid)
+        else:
+            return df.applymap(btw.is_valid)
+    return btw.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of BTW, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_nl_btw(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [btw.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_nl_onderwijsnummer.py
+++ b/dataprep/clean/clean_nl_onderwijsnummer.py
@@ -1,0 +1,163 @@
+"""
+Clean and validate a DataFrame column containing Onderwijsnummer,
+the Dutch student identification number.
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.nl import onderwijsnummer
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_nl_onderwijsnummer(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Onderwijsnummer type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of onderwijsnummer type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of onderwijsnummer, the compact is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of onderwijsnummer data.
+
+    >>> df = pd.DataFrame({{
+            "onderwijsnummer": [
+            '1012.22.331',
+            '2112.22.337',]
+            })
+    >>> clean_nl_onderwijsnummer(df, 'onderwijsnummer')
+            onderwijsnummer         onderwijsnummer_clean
+    0       1012.22.331             0403019261
+    1       2112.22.337             NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_nl_onderwijsnummer(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is onderwijsnummer in a DataFrame column.
+    For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(onderwijsnummer.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(onderwijsnummer.is_valid)
+        else:
+            return df.applymap(onderwijsnummer.is_valid)
+    return onderwijsnummer.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of onderwijsnummer, the compact is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_nl_onderwijsnummer(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [onderwijsnummer.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_nl_postcode.py
+++ b/dataprep/clean/clean_nl_postcode.py
@@ -1,0 +1,162 @@
+"""
+Clean and validate a DataFrame column containing Dutch postal codes.
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.nl import postcode
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_nl_postcode(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Dutch postal codes type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of postcode type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of postcode, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of postcode data.
+
+    >>> df = pd.DataFrame({{
+            "postcode": [
+            'NL-2611ET',
+            '26112 ET',]
+            })
+    >>> clean_nl_postcode(df, 'postcode')
+            postcode      postcode_clean
+    0       NL-2611ET     2611ET
+    1       26112 ET      NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_nl_postcode(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is postcode in a DataFrame column.
+    For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(postcode.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(postcode.is_valid)
+        else:
+            return df.applymap(postcode.is_valid)
+    return postcode.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of postcode, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_nl_postcode(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [postcode.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_no_fodselsnummer.py
+++ b/dataprep/clean/clean_no_fodselsnummer.py
@@ -1,0 +1,171 @@
+"""
+Clean and validate a DataFrame column containing Norwegian birth numbers.
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.no import fodselsnummer
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_no_fodselsnummer(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Estonian Personcal ID number type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of fodselsnummer type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', get the person's birthdate.
+            If output_format = 'gender', get the person's birth gender ('M' or 'F').
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of fodselsnummer data.
+
+    >>> df = pd.DataFrame({{
+            "fodselsnummer": [
+            '15108695088',
+            '15108695077']
+            })
+    >>> clean_no_fodselsnummer(df, 'fodselsnummer')
+            fodselsnummer       fodselsnummer_clean
+    0       15108695088         151086 95088
+    1       15108695077         NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate", "gender"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard", "birthdate" or "gender".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_no_fodselsnummer(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is fodselsnummer in a DataFrame column.
+    For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(fodselsnummer.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(fodselsnummer.is_valid)
+        else:
+            return df.applymap(fodselsnummer.is_valid)
+    return fodselsnummer.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', get the person's birthdate.
+           If output_format = 'gender', get the person's birth gender ('M' or 'F').
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_no_fodselsnummer(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "standard":
+        result = [fodselsnummer.format(val)] + result
+    elif output_format == "compact":
+        result = [fodselsnummer.compact(val)] + result
+    elif output_format == "birthdate":
+        result = [fodselsnummer.get_birth_date(val)] + result
+    elif output_format == "gender":
+        result = [fodselsnummer.get_gender(val)] + result
+
+    return result

--- a/dataprep/clean/clean_no_iban.py
+++ b/dataprep/clean/clean_no_iban.py
@@ -1,0 +1,166 @@
+"""
+Clean and validate a DataFrame column containing Norwegian IBANs (IBANs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.no import iban
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_no_iban(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Norwegian IBANs (IBANs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of IBAN type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'kontonr', return the Norwegian bank account part of the number.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of IBAN data.
+
+    >>> df = pd.DataFrame({{
+            "iban": [
+            'NO9386011117947',
+            'NO92 8601 1117 947',]
+            })
+    >>> clean_no_iban(df, 'iban')
+            iban                    iban_clean
+    0       NO9386011117947         NO93 8601 1117 947
+    1       NO92 8601 1117 947      NaN
+    """
+
+    if output_format not in {"compact", "standard", "kontonr"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "kontonr".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_no_iban(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is IBAN in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(iban.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(iban.is_valid)
+        else:
+            return df.applymap(iban.is_valid)
+    return iban.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'kontonr', return the Norwegian bank account part of the number.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_no_iban(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [iban.compact(val)] + result
+    elif output_format == "standard":
+        result = [iban.format(val)] + result
+    elif output_format == "kontonr":
+        result = [iban.to_kontonr(val)] + result
+
+    return result

--- a/dataprep/clean/clean_no_kontonr.py
+++ b/dataprep/clean/clean_no_kontonr.py
@@ -1,0 +1,166 @@
+"""
+Clean and validate a DataFrame column containing Norwegian bank account numbers (kontonrs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.no import kontonr
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_no_kontonr(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Norwegian bank account numbers (kontonrs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of kontonr type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'iban', convert the number to an IBAN.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of kontonr data.
+
+    >>> df = pd.DataFrame({{
+            "kontonr": [
+            "8601 11 17947",
+            "8601 11 17949",]
+            })
+    >>> clean_no_kontonr(df, 'kontonr')
+            kontonr               kontonr_clean
+    0       8601 11 17947         8601.11.17947
+    1       8601 11 17949         NaN
+    """
+
+    if output_format not in {"compact", "standard", "iban"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "iban".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_no_kontonr(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is kontonr in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(kontonr.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(kontonr.is_valid)
+        else:
+            return df.applymap(kontonr.is_valid)
+    return kontonr.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'iban', convert the number to an IBAN.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_no_kontonr(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [kontonr.compact(val)] + result
+    elif output_format == "standard":
+        result = [kontonr.format(val)] + result
+    elif output_format == "iban":
+        result = [kontonr.to_iban(val)] + result
+
+    return result

--- a/dataprep/clean/clean_no_mva.py
+++ b/dataprep/clean/clean_no_mva.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Norwegian VAT numbers (MVAs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.no import mva
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_no_mva(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Norwegian VAT numbers (MVAs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of MVA type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of MVA data.
+
+    >>> df = pd.DataFrame({{
+            "mva": [
+            "995525828MVA",
+            "NO 995 525 829 MVA",]
+            })
+    >>> clean_no_mva(df, 'mva')
+            mva                     mva_clean
+    0       995525828MVA            NO 995 525 828 MVA
+    1       NO 995 525 829 MVA      NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_no_mva(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is MVA in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(mva.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(mva.is_valid)
+        else:
+            return df.applymap(mva.is_valid)
+    return mva.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_no_mva(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [mva.compact(val)] + result
+    elif output_format == "standard":
+        result = [mva.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_no_orgnr.py
+++ b/dataprep/clean/clean_no_orgnr.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Norwegian organisation numbers (Orgnrs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.no import orgnr
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_no_orgnr(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Norwegian organisation numbers (Orgnrs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of Orgnr type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of Orgnr data.
+
+    >>> df = pd.DataFrame({{
+            "orgnr": [
+            "988077917",
+            "988 077 918",]
+            })
+    >>> clean_no_orgnr(df, 'orgnr')
+            orgnr               orgnr_clean
+    0       988077917           988 077 917
+    1       988 077 918         NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_no_orgnr(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is Orgnr in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(orgnr.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(orgnr.is_valid)
+        else:
+            return df.applymap(orgnr.is_valid)
+    return orgnr.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_no_orgnr(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [orgnr.compact(val)] + result
+    elif output_format == "standard":
+        result = [orgnr.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_nz_bankaccount.py
+++ b/dataprep/clean/clean_nz_bankaccount.py
@@ -1,0 +1,169 @@
+"""
+Clean and validate a DataFrame column containing New Zealand bank account numbers.
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.nz import bankaccount
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_nz_bankaccount(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean New Zealand bank account numbers type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of bankaccount type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'info', return a dictionary of data about the supplied number.
+                This typically returns the name of the bank and branch and a BIC if it is valid.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of bankaccount data.
+
+    >>> df = pd.DataFrame({{
+            "bankaccount": [
+            "51824753556",
+            "99999999999",]
+            })
+    >>> clean_nz_bankaccount(df, 'bankaccount')
+            bankaccount              bankaccount_clean
+    0       0102420100194000         01-0242-0100194-000
+    1       01-0242-0100195-00       NaN
+    """
+
+    if output_format not in {"compact", "standard", "info"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "info".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_nz_bankaccount(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is bankaccount in a DataFrame column.
+    For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(bankaccount.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(bankaccount.is_valid)
+        else:
+            return df.applymap(bankaccount.is_valid)
+    return bankaccount.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'info', return a dictionary of data about the supplied number.
+            This typically returns the name of the bank and branch and a BIC if it is valid.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_nz_bankaccount(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [bankaccount.compact(val)] + result
+    elif output_format == "standard":
+        result = [bankaccount.format(val)] + result
+    elif output_format == "info":
+        result = [bankaccount.info(val)] + result
+
+    return result

--- a/dataprep/clean/clean_nz_ird.py
+++ b/dataprep/clean/clean_nz_ird.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing New Zealand IRD numbers (IRDs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.nz import ird
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_nz_ird(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean New Zealand IRD numbers (IRDs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of IRD type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of IRD data.
+
+    >>> df = pd.DataFrame({{
+            "ird": [
+            "49091850",
+            "136410133",]
+            })
+    >>> clean_nz_ird(df, 'ird')
+            ird              ird_clean
+    0       49091850         49-091-850
+    1       136410133        NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_nz_ird(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is IRD in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(ird.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(ird.is_valid)
+        else:
+            return df.applymap(ird.is_valid)
+    return ird.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_nz_ird(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [ird.compact(val)] + result
+    elif output_format == "standard":
+        result = [ird.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_pe_cui.py
+++ b/dataprep/clean/clean_pe_cui.py
@@ -1,0 +1,166 @@
+"""
+Clean and validate a DataFrame column containing Peruvian personal numbers (CUIs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.pe import cui
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_pe_cui(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Peruvian personal numbers (CUIs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CUI type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'ruc', convert the number to a valid RUC.
+            Note: in the case of CUI, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CUI data.
+
+    >>> df = pd.DataFrame({
+            "cui": [
+            "10117410",
+            "10117410-3",]
+            })
+    >>> clean_pe_cui(df, 'cui')
+            cui             cui_clean
+    0       10117410        10117410
+    1       10117410-3      NaN
+    """
+
+    if output_format not in {"compact", "standard", "ruc"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "ruc".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_pe_cui(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CUI in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(cui.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(cui.is_valid)
+        else:
+            return df.applymap(cui.is_valid)
+    return cui.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'ruc', convert the number to a valid RUC.
+           Note: in the case of CUI, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_pe_cui(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [cui.compact(val)] + result
+    elif output_format == "ruc":
+        result = [cui.to_ruc(val)] + result
+
+    return result

--- a/dataprep/clean/clean_pe_ruc.py
+++ b/dataprep/clean/clean_pe_ruc.py
@@ -1,0 +1,173 @@
+"""
+Clean and validate a DataFrame column containing Peruvian fiscal numbers (RUCs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.pe import ruc
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_pe_ruc(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Peruvian fiscal numbers (RUCs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of RUC type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'dni', return the DNI (CUI) part of the number for natural persons.
+                If the RUC is not for natural persons, return NaN.
+            Note: in the case of RUC, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of RUC data.
+
+    >>> df = pd.DataFrame({
+            "ruc": [
+            "20512333797",
+            "20512333798",]
+            })
+    >>> clean_pe_ruc(df, 'ruc')
+            ruc             ruc_clean
+    0       20512333797     20512333797
+    1       20512333798     NaN
+    """
+
+    if output_format not in {"compact", "standard", "dni"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "dni".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_pe_ruc(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is RUC in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(ruc.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(ruc.is_valid)
+        else:
+            return df.applymap(ruc.is_valid)
+    return ruc.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'dni', return the DNI (CUI) part of the number for natural persons.
+               If the RUC is not for natural persons, return NaN.
+           Note: in the case of RUC, the compact format is the same as the standard one.
+    """
+    # pylint: disable=bare-except
+
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_pe_ruc(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [ruc.compact(val)] + result
+    if output_format == "dni":
+        try:
+            result = [ruc.to_dni(val)] + result
+        except:  # only when the RUC is not for persons
+            result = [np.nan]
+
+    return result

--- a/dataprep/clean/clean_pl_nip.py
+++ b/dataprep/clean/clean_pl_nip.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Polish VAT numbers (NIPs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.pl import nip
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_pl_nip(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Polish VAT numbers (NIPs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of NIP type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of NIP data.
+
+    >>> df = pd.DataFrame({{
+            "nip": [
+            "PL 8567346215",
+            "PL 8567346216",]
+            })
+    >>> clean_pl_nip(df, 'nip')
+            nip                 nip_clean
+    0       PL 8567346215       856-734-62-15
+    1       PL 8567346216       NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_pl_nip(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is NIP in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(nip.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(nip.is_valid)
+        else:
+            return df.applymap(nip.is_valid)
+    return nip.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_pl_nip(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [nip.compact(val)] + result
+    elif output_format == "standard":
+        result = [nip.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_pl_pesel.py
+++ b/dataprep/clean/clean_pl_pesel.py
@@ -1,0 +1,170 @@
+"""
+Clean and validate a DataFrame column containing Polish national identification numbers (PESELs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.pl import pesel
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_pl_pesel(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Estonian Personcal ID number (PESELs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of PESEL type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', get the person's birthdate.
+            If output_format = 'gender', get the person's birth gender ('M' or 'F').
+            Note: in the case of PESEL, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of PESEL data.
+
+    >>> df = pd.DataFrame({
+            "pesel": [
+            "44051401359",
+            "44051401358",]
+            })
+    >>> clean_pl_pesel(df, 'pesel')
+            pesel           pesel_clean
+    0       44051401359     44051401359
+    1       44051401358     NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate", "gender"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard", "birthdate" or "gender".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_pl_pesel(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is PESEL in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(pesel.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(pesel.is_valid)
+        else:
+            return df.applymap(pesel.is_valid)
+    return pesel.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', get the person's birthdate.
+           If output_format = 'gender', get the person's birth gender ('M' or 'F').
+           Note: in the case of PESEL, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_pl_pesel(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [pesel.compact(val)] + result
+    elif output_format == "birthdate":
+        result = [pesel.get_birth_date(val)] + result
+    elif output_format == "gender":
+        result = [pesel.get_gender(val)] + result
+
+    return result

--- a/dataprep/clean/clean_pl_regon.py
+++ b/dataprep/clean/clean_pl_regon.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Polish register of economic units (REGONs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.pl import regon
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_pl_regon(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Polish register of economic units (REGONs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of REGON type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of REGON, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of REGON data.
+
+    >>> df = pd.DataFrame({{
+            "regon": [
+            '192598184',
+            '192598183',]
+            })
+    >>> clean_pl_regon(df, 'regon')
+            regon           regon_clean
+    0       192598184       192598184
+    1       192598183       NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_pl_regon(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is REGON in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(regon.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(regon.is_valid)
+        else:
+            return df.applymap(regon.is_valid)
+    return regon.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of REGON, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_pl_regon(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [regon.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_pt_nif.py
+++ b/dataprep/clean/clean_pt_nif.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Portuguese NIF numbers (NIFs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.pt import nif
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_pt_nif(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Portuguese NIF numbers (NIFs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of NIF type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of NIF, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of NIF data.
+
+    >>> df = pd.DataFrame({{
+            "nif": [
+            'PT 501 964 843',
+            'PT 501 964 842',]
+            })
+    >>> clean_pt_nif(df, 'nif')
+            nif                 nif_clean
+    0       PT 501 964 843      PT 501 964 843
+    1       PT 501 964 842      NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_pt_nif(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is NIF in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(nif.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(nif.is_valid)
+        else:
+            return df.applymap(nif.is_valid)
+    return nif.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of NIF, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_pt_nif(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [nif.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_py_ruc.py
+++ b/dataprep/clean/clean_py_ruc.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Paraguay RUC numbers (RUCs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.py import ruc
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_py_ruc(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Paraguay RUC numbers (RUCs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of RUC type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of RUC data.
+
+    >>> df = pd.DataFrame({{
+            "ruc": [
+            "800000358",
+            "80123456789",]
+            })
+    >>> clean_py_ruc(df, 'ruc')
+            ruc                 ruc_clean
+    0       800000358           80000035-8
+    1       80123456789         NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_py_ruc(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is RUC in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(ruc.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(ruc.is_valid)
+        else:
+            return df.applymap(ruc.is_valid)
+    return ruc.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_py_ruc(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format == "compact":
+        result = [ruc.compact(val)] + result
+    elif output_format == "standard":
+        result = [ruc.format(val)] + result
+
+    return result

--- a/dataprep/clean/clean_ro_cf.py
+++ b/dataprep/clean/clean_ro_cf.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Romanian CF (CF) numbers (CFs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ro import cf
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ro_cf(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Romanian CF (CF) numbers (CFs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CF type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of CF, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CF data.
+
+    >>> df = pd.DataFrame({
+            "cf": [
+            "RO 185 472 90",
+            "RO 185 472 903333",]
+            })
+    >>> clean_ro_cf(df, 'cf')
+            cf                      cf_clean
+    0       RO 185 472 90           RO18547290
+    1       RO 185 472 903333       NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ro_cf(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CF in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(cf.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(cf.is_valid)
+        else:
+            return df.applymap(cf.is_valid)
+    return cf.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of CF, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ro_cf(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [cf.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_ro_cnp.py
+++ b/dataprep/clean/clean_ro_cnp.py
@@ -1,0 +1,166 @@
+"""
+Clean and validate a DataFrame column containing Romanian Numerical Personal Codes (CNPs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ro import cnp
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ro_cnp(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Estonian Personcal ID number (CNPs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CNP type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            If output_format = 'birthdate', get the person's birthdate.
+            Note: in the case of CNP, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CNP data.
+
+    >>> df = pd.DataFrame({
+            "cnp": [
+            "1630615123457",
+            "0800101221142",]
+            })
+    >>> clean_ro_cnp(df, 'cnp')
+            cnp                 cnp_clean
+    0       1630615123457       1630615123457
+    1       0800101221142       NaN
+    """
+
+    if output_format not in {"compact", "standard", "birthdate"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. "
+            'It needs to be "compact", "standard" or "birthdate".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ro_cnp(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CNP in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(cnp.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(cnp.is_valid)
+        else:
+            return df.applymap(cnp.is_valid)
+    return cnp.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           If output_format = 'birthdate', get the person's birthdate.
+           Note: in the case of CNP, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ro_cnp(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [cnp.compact(val)] + result
+    elif output_format == "birthdate":
+        result = [cnp.get_birth_date(val)] + result
+
+    return result

--- a/dataprep/clean/clean_ro_cui.py
+++ b/dataprep/clean/clean_ro_cui.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Romanian company identifiers (CUIs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ro import cui
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ro_cui(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Romanian company identifiers (CUIs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of CUI type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of CUI, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of CUI data.
+
+    >>> df = pd.DataFrame({
+            "cui": [
+            "185 472 90",
+            "185 472 91",]
+            })
+    >>> clean_ro_cui(df, 'cui')
+            cui             cui_clean
+    0       185 472 90      18547290
+    1       185 472 91      NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ro_cui(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is CUI in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(cui.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(cui.is_valid)
+        else:
+            return df.applymap(cui.is_valid)
+    return cui.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of CUI, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ro_cui(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [cui.compact(val)] + result
+
+    return result

--- a/dataprep/clean/clean_ro_onrc.py
+++ b/dataprep/clean/clean_ro_onrc.py
@@ -1,0 +1,161 @@
+"""
+Clean and validate a DataFrame column containing Romanian Trade Register identifiers (ONRCs).
+"""
+# pylint: disable=too-many-lines, too-many-arguments, too-many-branches
+from typing import Any, Union
+from operator import itemgetter
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+
+from stdnum.ro import onrc
+from ..progress_bar import ProgressBar
+from .utils import NULL_VALUES, to_dask
+
+
+def clean_ro_onrc(
+    df: Union[pd.DataFrame, dd.DataFrame],
+    column: str,
+    output_format: str = "standard",
+    inplace: bool = False,
+    errors: str = "coerce",
+    progress: bool = True,
+) -> pd.DataFrame:
+    """
+    Clean Romanian Trade Register identifiers (ONRCs) type data in a DataFrame column.
+
+    Parameters
+    ----------
+        df
+            A pandas or Dask DataFrame containing the data to be cleaned.
+        col
+            The name of the column containing data of ONRC type.
+        output_format
+            The output format of standardized number string.
+            If output_format = 'compact', return string without any separators or whitespace.
+            If output_format = 'standard', return string with proper separators and whitespace.
+            Note: in the case of ONRC, the compact format is the same as the standard one.
+
+            (default: "standard")
+        inplace
+           If True, delete the column containing the data that was cleaned.
+           Otherwise, keep the original column.
+
+           (default: False)
+        errors
+            How to handle parsing errors.
+            - ‘coerce’: invalid parsing will be set to NaN.
+            - ‘ignore’: invalid parsing will return the input.
+            - ‘raise’: invalid parsing will raise an exception.
+
+            (default: 'coerce')
+        progress
+            If True, display a progress bar.
+
+            (default: True)
+
+    Examples
+    --------
+    Clean a column of ONRC data.
+
+    >>> df = pd.DataFrame({{
+            "onrc": [
+            "J52/750/2012",
+            "X52/750/2012",]
+            })
+    >>> clean_ro_onrc(df, 'onrc')
+            onrc             onrc_clean
+    0       J52/750/2012     J52/750/2012
+    1       X52/750/2012     NaN
+    """
+
+    if output_format not in {"compact", "standard"}:
+        raise ValueError(
+            f"output_format {output_format} is invalid. " 'It needs to be "compact" or "standard".'
+        )
+
+    # convert to dask
+    df = to_dask(df)
+
+    # To clean, create a new column "clean_code_tup" which contains
+    # the cleaned values and code indicating how the initial value was
+    # changed in a tuple. Then split the column of tuples and count the
+    # amount of different codes to produce the report
+    df["clean_code_tup"] = df[column].map_partitions(
+        lambda srs: [_format(x, output_format, errors) for x in srs],
+        meta=object,
+    )
+
+    df = df.assign(
+        _temp_=df["clean_code_tup"].map(itemgetter(0)),
+    )
+
+    df = df.rename(columns={"_temp_": f"{column}_clean"})
+
+    df = df.drop(columns=["clean_code_tup"])
+
+    if inplace:
+        df[column] = df[f"{column}_clean"]
+        df = df.drop(columns=f"{column}_clean")
+        df = df.rename(columns={column: f"{column}_clean"})
+
+    with ProgressBar(minimum=1, disable=not progress):
+        df = df.compute()
+
+    return df
+
+
+def validate_ro_onrc(
+    df: Union[str, pd.Series, dd.Series, pd.DataFrame, dd.DataFrame],
+    column: str = "",
+) -> Union[bool, pd.Series, pd.DataFrame]:
+    """
+    Validate if a data cell is ONRC in a DataFrame column. For each cell, return True or False.
+
+    Parameters
+    ----------
+    df
+            A pandas or Dask DataFrame containing the data to be validated.
+    col
+            The name of the column to be validated.
+    """
+    if isinstance(df, (pd.Series, dd.Series)):
+        return df.apply(onrc.is_valid)
+    elif isinstance(df, (pd.DataFrame, dd.DataFrame)):
+        if column != "":
+            return df[column].apply(onrc.is_valid)
+        else:
+            return df.applymap(onrc.is_valid)
+    return onrc.is_valid(df)
+
+
+def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -> Any:
+    """
+    Reformat a number string with proper separators and whitespace.
+
+    Parameters
+    ----------
+    val
+           The value of number string.
+    output_format
+           If output_format = 'compact', return string without any separators or whitespace.
+           If output_format = 'standard', return string with proper separators and whitespace.
+           Note: in the case of ONRC, the compact format is the same as the standard one.
+    """
+    val = str(val)
+    result: Any = []
+
+    if val in NULL_VALUES:
+        return [np.nan]
+
+    if not validate_ro_onrc(val):
+        if errors == "raise":
+            raise ValueError(f"Unable to parse value {val}")
+        error_result = val if errors == "ignore" else np.nan
+        return [error_result]
+
+    if output_format in {"compact", "standard"}:
+        result = [onrc.compact(val)] + result
+
+    return result

--- a/docs/source/api_reference/dataprep.clean.rst
+++ b/docs/source/api_reference/dataprep.clean.rst
@@ -90,3 +90,5 @@ US Street Addresses
    :members:
    :undoc-members:
    :show-inheritance:
+
+  

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,92 +1,99 @@
 [[package]]
-name = "aiohttp"
-version = "3.7.4.post0"
-description = "Async http client/server framework (asyncio)"
 category = "main"
+description = "Async http client/server framework (asyncio)"
+name = "aiohttp"
 optional = false
 python-versions = ">=3.6"
+version = "3.7.4.post0"
 
 [package.dependencies]
 async-timeout = ">=3.0,<4.0"
 attrs = ">=17.3.0"
 chardet = ">=2.0,<5.0"
-idna-ssl = {version = ">=1.0", markers = "python_version < \"3.7\""}
 multidict = ">=4.5,<7.0"
 typing-extensions = ">=3.6.5"
 yarl = ">=1.0,<2.0"
+
+[package.dependencies.idna-ssl]
+python = "<3.7"
+version = ">=1.0"
 
 [package.extras]
 speedups = ["aiodns", "brotlipy", "cchardet"]
 
 [[package]]
-name = "alabaster"
-version = "0.7.12"
+category = "dev"
 description = "A configurable sidebar-enabled Sphinx theme"
-category = "dev"
+name = "alabaster"
 optional = false
 python-versions = "*"
+version = "0.7.12"
 
 [[package]]
-name = "appdirs"
-version = "1.4.4"
+category = "dev"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
+name = "appdirs"
 optional = false
 python-versions = "*"
+version = "1.4.4"
 
 [[package]]
-name = "appnope"
-version = "0.1.2"
+category = "main"
 description = "Disable App Nap on macOS >= 10.9"
-category = "main"
+marker = "sys_platform == \"darwin\" or platform_system == \"Darwin\" or python_version >= \"3.3\" and sys_platform == \"darwin\""
+name = "appnope"
 optional = false
 python-versions = "*"
+version = "0.1.2"
 
 [[package]]
-name = "argh"
-version = "0.26.2"
-description = "An unobtrusive argparse wrapper with natural syntax"
 category = "dev"
+description = "An unobtrusive argparse wrapper with natural syntax"
+name = "argh"
 optional = false
 python-versions = "*"
+version = "0.26.2"
 
 [[package]]
-name = "argon2-cffi"
-version = "20.1.0"
-description = "The secure Argon2 password hashing algorithm."
 category = "main"
+description = "The secure Argon2 password hashing algorithm."
+name = "argon2-cffi"
 optional = false
 python-versions = "*"
+version = "20.1.0"
 
 [package.dependencies]
 cffi = ">=1.0.0"
 six = "*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pytest", "sphinx", "wheel", "pre-commit"]
+dev = ["coverage (>=5.0.2)", "hypothesis", "pytest", "sphinx", "wheel", "pre-commit"]
 docs = ["sphinx"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pytest"]
+tests = ["coverage (>=5.0.2)", "hypothesis", "pytest"]
 
 [[package]]
-name = "astroid"
-version = "2.5"
-description = "An abstract syntax tree for Python with inference support."
 category = "dev"
+description = "An abstract syntax tree for Python with inference support."
+name = "astroid"
 optional = false
 python-versions = ">=3.6"
+version = "2.5"
 
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0"
-typed-ast = {version = ">=1.4.0,<1.5", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
 wrapt = ">=1.11,<1.13"
 
+[package.dependencies.typed-ast]
+python = "<3.8"
+version = ">=1.4.0,<1.5"
+
 [[package]]
-name = "asttokens"
-version = "2.0.5"
-description = "Annotate AST trees with source code positions"
 category = "main"
+description = "Annotate AST trees with source code positions"
+name = "asttokens"
 optional = false
 python-versions = "*"
+version = "2.0.5"
 
 [package.dependencies]
 six = "*"
@@ -95,74 +102,74 @@ six = "*"
 test = ["astroid", "pytest"]
 
 [[package]]
-name = "async-generator"
-version = "1.10"
-description = "Async generators and context managers for Python 3.5+"
 category = "main"
+description = "Async generators and context managers for Python 3.5+"
+name = "async-generator"
 optional = false
 python-versions = ">=3.5"
+version = "1.10"
 
 [[package]]
-name = "async-timeout"
-version = "3.0.1"
-description = "Timeout context manager for asyncio programs"
 category = "main"
+description = "Timeout context manager for asyncio programs"
+name = "async-timeout"
 optional = false
 python-versions = ">=3.5.3"
+version = "3.0.1"
 
 [[package]]
-name = "atomicwrites"
-version = "1.4.0"
-description = "Atomic file writes."
 category = "dev"
+description = "Atomic file writes."
+marker = "sys_platform == \"win32\""
+name = "atomicwrites"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.4.0"
 
 [[package]]
-name = "attrs"
-version = "20.3.0"
-description = "Classes Without Boilerplate"
 category = "main"
+description = "Classes Without Boilerplate"
+name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "20.3.0"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
 docs = ["furo", "sphinx", "zope.interface"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
-name = "babel"
-version = "2.9.0"
-description = "Internationalization utilities"
 category = "dev"
+description = "Internationalization utilities"
+name = "babel"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.9.0"
 
 [package.dependencies]
 pytz = ">=2015.7"
 
 [[package]]
-name = "backcall"
-version = "0.2.0"
-description = "Specifications for callback functions passed in to an API"
 category = "main"
+description = "Specifications for callback functions passed in to an API"
+name = "backcall"
 optional = false
 python-versions = "*"
+version = "0.2.0"
 
 [[package]]
-name = "black"
-version = "20.8b1"
-description = "The uncompromising code formatter."
 category = "dev"
+description = "The uncompromising code formatter."
+name = "black"
 optional = false
 python-versions = ">=3.6"
+version = "20.8b1"
 
 [package.dependencies]
 appdirs = "*"
 click = ">=7.1.2"
-dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.6,<1"
 regex = ">=2020.1.8"
@@ -170,17 +177,21 @@ toml = ">=0.10.1"
 typed-ast = ">=1.4.0"
 typing-extensions = ">=3.7.4"
 
+[package.dependencies.dataclasses]
+python = "<3.7"
+version = ">=0.6"
+
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
-name = "bleach"
-version = "3.3.0"
-description = "An easy safelist-based HTML-sanitizing tool."
 category = "main"
+description = "An easy safelist-based HTML-sanitizing tool."
+name = "bleach"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "3.3.0"
 
 [package.dependencies]
 packaging = "*"
@@ -188,30 +199,30 @@ six = ">=1.9.0"
 webencodings = "*"
 
 [[package]]
-name = "bokeh"
-version = "2.3.0"
-description = "Interactive plots and applications in the browser from Python"
 category = "main"
+description = "Interactive plots and applications in the browser from Python"
+name = "bokeh"
 optional = false
 python-versions = ">=3.6"
+version = "2.3.0"
 
 [package.dependencies]
 Jinja2 = ">=2.7"
+PyYAML = ">=3.10"
 numpy = ">=1.11.3"
 packaging = ">=16.8"
 pillow = ">=7.1.0"
 python-dateutil = ">=2.1"
-PyYAML = ">=3.10"
 tornado = ">=5.1"
 typing_extensions = ">=3.7.4"
 
 [[package]]
-name = "bottleneck"
-version = "1.3.2"
-description = "Fast NumPy array functions written in C"
 category = "main"
+description = "Fast NumPy array functions written in C"
+name = "bottleneck"
 optional = false
 python-versions = "*"
+version = "1.3.2"
 
 [package.dependencies]
 numpy = "*"
@@ -220,223 +231,245 @@ numpy = "*"
 doc = ["numpydoc", "sphinx", "gitpython"]
 
 [[package]]
-name = "certifi"
-version = "2020.12.5"
-description = "Python package for providing Mozilla's CA Bundle."
 category = "dev"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
 optional = false
 python-versions = "*"
+version = "2020.12.5"
 
 [[package]]
-name = "cffi"
-version = "1.14.5"
-description = "Foreign Function Interface for Python calling C code."
 category = "main"
+description = "Foreign Function Interface for Python calling C code."
+name = "cffi"
 optional = false
 python-versions = "*"
+version = "1.14.5"
 
 [package.dependencies]
 pycparser = "*"
 
 [[package]]
-name = "chardet"
-version = "4.0.0"
+category = "main"
 description = "Universal encoding detector for Python 2 and 3"
-category = "main"
+name = "chardet"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "4.0.0"
 
 [[package]]
-name = "click"
-version = "7.1.2"
+category = "main"
 description = "Composable command line interface toolkit"
-category = "main"
+name = "click"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "7.1.2"
 
 [[package]]
-name = "click-log"
-version = "0.3.2"
-description = "Logging integration for Click"
 category = "dev"
+description = "Logging integration for Click"
+name = "click-log"
 optional = false
 python-versions = "*"
+version = "0.3.2"
 
 [package.dependencies]
 click = "*"
 
 [[package]]
-name = "cloudpickle"
-version = "1.6.0"
-description = "Extended pickling support for Python objects"
 category = "main"
+description = "Extended pickling support for Python objects"
+name = "cloudpickle"
 optional = false
 python-versions = ">=3.5"
+version = "1.6.0"
 
 [[package]]
-name = "codecov"
-version = "2.1.11"
-description = "Hosted coverage reports for GitHub, Bitbucket and Gitlab"
 category = "dev"
+description = "Hosted coverage reports for GitHub, Bitbucket and Gitlab"
+name = "codecov"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.1.11"
 
 [package.dependencies]
 coverage = "*"
 requests = ">=2.7.9"
 
 [[package]]
-name = "colorama"
-version = "0.4.4"
-description = "Cross-platform colored terminal text."
 category = "main"
+description = "Cross-platform colored terminal text."
+name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.4.4"
 
 [[package]]
-name = "coverage"
-version = "5.5"
-description = "Code coverage measurement for Python"
 category = "dev"
+description = "Code coverage measurement for Python"
+name = "coverage"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "5.5"
 
 [package.extras]
 toml = ["toml"]
 
 [[package]]
-name = "cryptography"
-version = "3.4.7"
-description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "dev"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+marker = "sys_platform == \"linux\""
+name = "cryptography"
 optional = false
 python-versions = ">=3.6"
+version = "3.4.7"
 
 [package.dependencies]
 cffi = ">=1.12"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
+docs = ["sphinx (>=1.6.5,<1.8.0 || >1.8.0,<3.1.0 || >3.1.0,<3.1.1 || >3.1.1)", "sphinx-rtd-theme"]
 docstest = ["doc8", "pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools-rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,<3.79.2 || >3.79.2)"]
 
 [[package]]
-name = "cycler"
-version = "0.10.0"
-description = "Composable style cycles"
 category = "main"
+description = "Composable style cycles"
+name = "cycler"
 optional = false
 python-versions = "*"
+version = "0.10.0"
 
 [package.dependencies]
 six = "*"
 
 [[package]]
-name = "dask"
-version = "2.30.0"
-description = "Parallel PyData with Task Scheduling"
 category = "main"
+description = "Parallel PyData with Task Scheduling"
+name = "dask"
 optional = false
 python-versions = ">=3.6"
+version = "2.30.0"
 
 [package.dependencies]
-cloudpickle = {version = ">=0.2.2", optional = true, markers = "extra == \"delayed\""}
-fsspec = {version = ">=0.6.0", optional = true, markers = "extra == \"dataframe\""}
-numpy = {version = ">=1.13.0", optional = true, markers = "extra == \"array\""}
-pandas = {version = ">=0.23.0", optional = true, markers = "extra == \"dataframe\""}
-partd = {version = ">=0.3.10", optional = true, markers = "extra == \"dataframe\""}
 pyyaml = "*"
-toolz = {version = ">=0.8.2", optional = true, markers = "extra == \"array\""}
+
+[package.dependencies.cloudpickle]
+optional = true
+version = ">=0.2.2"
+
+[package.dependencies.fsspec]
+optional = true
+version = ">=0.6.0"
+
+[package.dependencies.numpy]
+optional = true
+version = ">=1.13.0"
+
+[package.dependencies.pandas]
+optional = true
+version = ">=0.23.0"
+
+[package.dependencies.partd]
+optional = true
+version = ">=0.3.10"
+
+[package.dependencies.toolz]
+optional = true
+version = ">=0.8.2"
 
 [package.extras]
 array = ["numpy (>=1.13.0)", "toolz (>=0.8.2)"]
 bag = ["cloudpickle (>=0.2.2)", "fsspec (>=0.6.0)", "toolz (>=0.8.2)", "partd (>=0.3.10)"]
-complete = ["bokeh (>=1.0.0,!=2.0.0)", "cloudpickle (>=0.2.2)", "distributed (>=2.0)", "fsspec (>=0.6.0)", "numpy (>=1.13.0)", "pandas (>=0.23.0)", "partd (>=0.3.10)", "toolz (>=0.8.2)"]
+complete = ["bokeh (>=1.0.0,<2.0.0 || >2.0.0)", "cloudpickle (>=0.2.2)", "distributed (>=2.0)", "fsspec (>=0.6.0)", "numpy (>=1.13.0)", "pandas (>=0.23.0)", "partd (>=0.3.10)", "toolz (>=0.8.2)"]
 dataframe = ["numpy (>=1.13.0)", "pandas (>=0.23.0)", "toolz (>=0.8.2)", "partd (>=0.3.10)", "fsspec (>=0.6.0)"]
 delayed = ["cloudpickle (>=0.2.2)", "toolz (>=0.8.2)"]
-diagnostics = ["bokeh (>=1.0.0,!=2.0.0)"]
+diagnostics = ["bokeh (>=1.0.0,<2.0.0 || >2.0.0)"]
 distributed = ["distributed (>=2.0)"]
 
 [[package]]
-name = "dataclasses"
-version = "0.6"
-description = "A backport of the dataclasses module for Python 3.6"
 category = "main"
+description = "A backport of the dataclasses module for Python 3.6"
+marker = "python_version < \"3.7\""
+name = "dataclasses"
 optional = false
 python-versions = "*"
+version = "0.6"
 
 [[package]]
-name = "decorator"
-version = "4.4.2"
-description = "Decorators for Humans"
 category = "main"
+description = "Decorators for Humans"
+name = "decorator"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
+version = "4.4.2"
 
 [[package]]
-name = "defusedxml"
-version = "0.7.1"
-description = "XML bomb protection for Python stdlib modules"
 category = "main"
+description = "XML bomb protection for Python stdlib modules"
+name = "defusedxml"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.7.1"
 
 [[package]]
-name = "docopt"
-version = "0.6.2"
+category = "dev"
 description = "Pythonic argument parser, that will make you smile"
-category = "dev"
+name = "docopt"
 optional = false
 python-versions = "*"
+version = "0.6.2"
 
 [[package]]
-name = "docutils"
-version = "0.16"
-description = "Docutils -- Python Documentation Utilities"
 category = "dev"
+description = "Docutils -- Python Documentation Utilities"
+name = "docutils"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.16"
 
 [[package]]
-name = "dotty-dict"
-version = "1.3.0"
-description = "Dictionary wrapper for quick access to deeply nested keys."
 category = "dev"
+description = "Dictionary wrapper for quick access to deeply nested keys."
+name = "dotty-dict"
 optional = false
 python-versions = "*"
+version = "1.3.0"
 
 [package.dependencies]
 setuptools_scm = "*"
 
 [[package]]
-name = "entrypoints"
-version = "0.3"
-description = "Discover and load entry points from installed packages."
 category = "main"
+description = "Discover and load entry points from installed packages."
+name = "entrypoints"
 optional = false
 python-versions = ">=2.7"
+version = "0.3"
 
 [[package]]
-name = "executing"
-version = "0.6.0"
-description = "Get the currently executing AST node of a frame, and other information"
 category = "main"
+description = "Get the currently executing AST node of a frame, and other information"
+name = "executing"
 optional = false
 python-versions = "*"
+version = "0.6.0"
 
 [[package]]
-name = "fsspec"
-version = "0.8.7"
-description = "File-system specification"
 category = "main"
+description = "File-system specification"
+name = "fsspec"
 optional = false
 python-versions = ">3.6"
+version = "0.8.7"
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
 
 [package.extras]
 abfs = ["adlfs"]
@@ -455,96 +488,100 @@ smb = ["smbprotocol"]
 ssh = ["paramiko"]
 
 [[package]]
-name = "future"
-version = "0.18.2"
-description = "Clean single-source support for Python 3 and 2"
 category = "main"
+description = "Clean single-source support for Python 3 and 2"
+name = "future"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "0.18.2"
 
 [[package]]
-name = "gitdb"
-version = "4.0.7"
-description = "Git Object Database"
 category = "dev"
+description = "Git Object Database"
+name = "gitdb"
 optional = false
 python-versions = ">=3.4"
+version = "4.0.7"
 
 [package.dependencies]
 smmap = ">=3.0.1,<5"
 
 [[package]]
-name = "gitpython"
-version = "3.1.14"
-description = "Python Git Library"
 category = "dev"
+description = "Python Git Library"
+name = "gitpython"
 optional = false
 python-versions = ">=3.4"
+version = "3.1.14"
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
 
 [[package]]
-name = "idna"
-version = "2.10"
-description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
+description = "Internationalized Domain Names in Applications (IDNA)"
+name = "idna"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.10"
 
 [[package]]
-name = "idna-ssl"
-version = "1.1.0"
-description = "Patch ssl.match_hostname for Unicode(idna) domains support"
 category = "main"
+description = "Patch ssl.match_hostname for Unicode(idna) domains support"
+marker = "python_version < \"3.7\""
+name = "idna-ssl"
 optional = false
 python-versions = "*"
+version = "1.1.0"
 
 [package.dependencies]
 idna = ">=2.0"
 
 [[package]]
-name = "imagesize"
-version = "1.2.0"
-description = "Getting image size from png/jpeg/jpeg2000/gif file"
 category = "dev"
+description = "Getting image size from png/jpeg/jpeg2000/gif file"
+name = "imagesize"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.2.0"
 
 [[package]]
-name = "importlib-metadata"
-version = "3.10.0"
-description = "Read metadata from Python packages"
 category = "main"
+description = "Read metadata from Python packages"
+name = "importlib-metadata"
 optional = false
 python-versions = ">=3.6"
+version = "3.10.0"
 
 [package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
+
+[package.dependencies.typing-extensions]
+python = "<3.8"
+version = ">=3.6.4"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
-name = "invoke"
-version = "1.5.0"
-description = "Pythonic task execution"
 category = "dev"
+description = "Pythonic task execution"
+name = "invoke"
 optional = false
 python-versions = "*"
+version = "1.5.0"
 
 [[package]]
-name = "ipykernel"
-version = "5.5.3"
-description = "IPython Kernel for Jupyter"
 category = "main"
+description = "IPython Kernel for Jupyter"
+name = "ipykernel"
 optional = false
 python-versions = ">=3.5"
+version = "5.5.3"
 
 [package.dependencies]
-appnope = {version = "*", markers = "platform_system == \"Darwin\""}
+appnope = "*"
 ipython = ">=5.0.0"
 jupyter-client = "*"
 tornado = ">=4.2"
@@ -554,23 +591,24 @@ traitlets = ">=4.1.0"
 test = ["pytest (!=5.3.4)", "pytest-cov", "flaky", "nose", "jedi (<=0.17.2)"]
 
 [[package]]
-name = "ipython"
-version = "7.16.1"
-description = "IPython: Productive Interactive Computing"
 category = "main"
+description = "IPython: Productive Interactive Computing"
+name = "ipython"
 optional = false
 python-versions = ">=3.6"
+version = "7.16.1"
 
 [package.dependencies]
-appnope = {version = "*", markers = "sys_platform == \"darwin\""}
+appnope = "*"
 backcall = "*"
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
+colorama = "*"
 decorator = "*"
 jedi = ">=0.10"
-pexpect = {version = "*", markers = "sys_platform != \"win32\""}
+pexpect = "*"
 pickleshare = "*"
 prompt-toolkit = ">=2.0.0,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.1.0"
 pygments = "*"
+setuptools = ">=18.5"
 traitlets = ">=4.2"
 
 [package.extras]
@@ -585,78 +623,85 @@ qtconsole = ["qtconsole"]
 test = ["nose (>=0.10.1)", "requests", "testpath", "pygments", "nbformat", "ipykernel", "numpy (>=1.14)"]
 
 [[package]]
-name = "ipython-genutils"
-version = "0.2.0"
-description = "Vestigial utilities from IPython"
 category = "main"
+description = "Vestigial utilities from IPython"
+name = "ipython-genutils"
 optional = false
 python-versions = "*"
+version = "0.2.0"
 
 [[package]]
-name = "ipywidgets"
-version = "7.6.3"
-description = "IPython HTML widgets for Jupyter"
 category = "main"
+description = "IPython HTML widgets for Jupyter"
+name = "ipywidgets"
 optional = false
 python-versions = "*"
+version = "7.6.3"
 
 [package.dependencies]
 ipykernel = ">=4.5.1"
-ipython = {version = ">=4.0.0", markers = "python_version >= \"3.3\""}
-jupyterlab-widgets = {version = ">=1.0.0", markers = "python_version >= \"3.6\""}
 nbformat = ">=4.2.0"
 traitlets = ">=4.3.1"
 widgetsnbextension = ">=3.5.0,<3.6.0"
+
+[package.dependencies.ipython]
+python = ">=3.3"
+version = ">=4.0.0"
+
+[package.dependencies.jupyterlab-widgets]
+python = ">=3.6"
+version = ">=1.0.0"
 
 [package.extras]
 test = ["pytest (>=3.6.0)", "pytest-cov", "mock"]
 
 [[package]]
-name = "isort"
-version = "5.8.0"
-description = "A Python utility / library to sort Python imports."
 category = "dev"
+description = "A Python utility / library to sort Python imports."
+name = "isort"
 optional = false
 python-versions = ">=3.6,<4.0"
+version = "5.8.0"
 
 [package.extras]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
 pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 requirements_deprecated_finder = ["pipreqs", "pip-api"]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
 
 [[package]]
-name = "jedi"
-version = "0.18.0"
-description = "An autocompletion tool for Python that can be used for text editors."
 category = "main"
+description = "An autocompletion tool for Python that can be used for text editors."
+name = "jedi"
 optional = false
 python-versions = ">=3.6"
+version = "0.18.0"
 
 [package.dependencies]
 parso = ">=0.8.0,<0.9.0"
 
 [package.extras]
-qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
+qa = ["flake8 (3.8.3)", "mypy (0.782)"]
 testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<6.0.0)"]
 
 [[package]]
-name = "jeepney"
-version = "0.6.0"
-description = "Low-level, pure Python DBus protocol wrapper."
 category = "dev"
+description = "Low-level, pure Python DBus protocol wrapper."
+marker = "sys_platform == \"linux\""
+name = "jeepney"
 optional = false
 python-versions = ">=3.6"
+version = "0.6.0"
 
 [package.extras]
 test = ["pytest", "pytest-trio", "pytest-asyncio", "testpath", "trio"]
 
 [[package]]
-name = "jinja2"
-version = "2.11.3"
-description = "A very fast and expressive template engine."
 category = "main"
+description = "A very fast and expressive template engine."
+name = "jinja2"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.11.3"
 
 [package.dependencies]
 MarkupSafe = ">=0.23"
@@ -665,20 +710,20 @@ MarkupSafe = ">=0.23"
 i18n = ["Babel (>=0.8)"]
 
 [[package]]
-name = "joblib"
-version = "1.0.1"
-description = "Lightweight pipelining with Python functions"
 category = "main"
+description = "Lightweight pipelining with Python functions"
+name = "joblib"
 optional = false
 python-versions = ">=3.6"
+version = "1.0.1"
 
 [[package]]
-name = "jsonpath-ng"
-version = "1.5.2"
-description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 category = "main"
+description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
+name = "jsonpath-ng"
 optional = false
 python-versions = "*"
+version = "1.5.2"
 
 [package.dependencies]
 decorator = "*"
@@ -686,30 +731,34 @@ ply = "*"
 six = "*"
 
 [[package]]
-name = "jsonschema"
-version = "3.2.0"
-description = "An implementation of JSON Schema validation for Python"
 category = "main"
+description = "An implementation of JSON Schema validation for Python"
+name = "jsonschema"
 optional = false
 python-versions = "*"
+version = "3.2.0"
 
 [package.dependencies]
 attrs = ">=17.4.0"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 pyrsistent = ">=0.14.0"
+setuptools = "*"
 six = ">=1.11.0"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
 
 [package.extras]
 format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors"]
 format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator (>0.1.0)", "rfc3339-validator"]
 
 [[package]]
-name = "jupyter-client"
-version = "6.1.12"
-description = "Jupyter protocol implementation and client libraries"
 category = "main"
+description = "Jupyter protocol implementation and client libraries"
+name = "jupyter-client"
 optional = false
 python-versions = ">=3.5"
+version = "6.1.12"
 
 [package.dependencies]
 jupyter-core = ">=4.6.0"
@@ -723,113 +772,120 @@ doc = ["sphinx (>=1.3.6)", "sphinx-rtd-theme", "sphinxcontrib-github-alt"]
 test = ["async-generator", "ipykernel", "ipython", "mock", "pytest-asyncio", "pytest-timeout", "pytest", "jedi (<0.18)"]
 
 [[package]]
-name = "jupyter-core"
-version = "4.7.1"
-description = "Jupyter core package. A base package on which Jupyter projects rely."
 category = "main"
+description = "Jupyter core package. A base package on which Jupyter projects rely."
+name = "jupyter-core"
 optional = false
 python-versions = ">=3.6"
+version = "4.7.1"
 
 [package.dependencies]
-pywin32 = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+pywin32 = ">=1.0"
 traitlets = "*"
 
 [[package]]
-name = "jupyterlab-pygments"
-version = "0.1.2"
-description = "Pygments theme using JupyterLab CSS variables"
 category = "main"
+description = "Pygments theme using JupyterLab CSS variables"
+name = "jupyterlab-pygments"
 optional = false
 python-versions = "*"
+version = "0.1.2"
 
 [package.dependencies]
 pygments = ">=2.4.1,<3"
 
 [[package]]
-name = "jupyterlab-widgets"
-version = "1.0.0"
-description = "A JupyterLab extension."
 category = "main"
+description = "A JupyterLab extension."
+marker = "python_version >= \"3.6\""
+name = "jupyterlab-widgets"
 optional = false
 python-versions = ">=3.6"
+version = "1.0.0"
 
 [[package]]
-name = "keyring"
-version = "23.0.1"
-description = "Store and access your passwords safely."
 category = "dev"
+description = "Store and access your passwords safely."
+name = "keyring"
 optional = false
 python-versions = ">=3.6"
+version = "23.0.1"
 
 [package.dependencies]
+SecretStorage = ">=3.2"
 importlib-metadata = ">=3.6"
-jeepney = {version = ">=0.4.2", markers = "sys_platform == \"linux\""}
-pywin32-ctypes = {version = "<0.1.0 || >0.1.0,<0.1.1 || >0.1.1", markers = "sys_platform == \"win32\""}
-SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
+jeepney = ">=0.4.2"
+pywin32-ctypes = "<0.1.0 || >0.1.0,<0.1.1 || >0.1.1"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
-name = "kiwisolver"
-version = "1.3.1"
-description = "A fast implementation of the Cassowary constraint solver"
 category = "main"
+description = "A fast implementation of the Cassowary constraint solver"
+name = "kiwisolver"
 optional = false
 python-versions = ">=3.6"
+version = "1.3.1"
 
 [[package]]
-name = "lazy-object-proxy"
-version = "1.6.0"
-description = "A fast and thorough lazy object proxy."
 category = "dev"
+description = "A fast and thorough lazy object proxy."
+name = "lazy-object-proxy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+version = "1.6.0"
 
 [[package]]
-name = "levenshtein"
-version = "0.12.0"
-description = "Python extension for computing string edit distances and similarities."
 category = "main"
+description = "Python extension for computing string edit distances and similarities."
+name = "levenshtein"
 optional = false
 python-versions = "*"
+version = "0.12.0"
+
+[package.dependencies]
+setuptools = "*"
 
 [[package]]
-name = "livereload"
-version = "2.6.3"
-description = "Python LiveReload is an awesome tool for web developers"
 category = "dev"
+description = "Python LiveReload is an awesome tool for web developers"
+name = "livereload"
 optional = false
 python-versions = "*"
+version = "2.6.3"
 
 [package.dependencies]
 six = "*"
-tornado = {version = "*", markers = "python_version > \"2.7\""}
+
+[package.dependencies.tornado]
+python = ">=2.8"
+version = "*"
 
 [[package]]
-name = "locket"
-version = "0.2.1"
-description = "File-based locks for Python for Linux and Windows"
 category = "main"
+description = "File-based locks for Python for Linux and Windows"
+name = "locket"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.2.1"
 
 [[package]]
-name = "markupsafe"
-version = "1.1.1"
-description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
+description = "Safely add untrusted strings to HTML/XML markup."
+name = "markupsafe"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "1.1.1"
 
 [[package]]
-name = "matplotlib"
-version = "3.3.4"
-description = "Python plotting package"
 category = "main"
+description = "Python plotting package"
+name = "matplotlib"
 optional = false
 python-versions = ">=3.6"
+version = "3.3.4"
 
 [package.dependencies]
 cycler = ">=0.10"
@@ -840,52 +896,52 @@ pyparsing = ">=2.0.3,<2.0.4 || >2.0.4,<2.1.2 || >2.1.2,<2.1.6 || >2.1.6"
 python-dateutil = ">=2.1"
 
 [[package]]
-name = "mccabe"
-version = "0.6.1"
+category = "dev"
 description = "McCabe checker, plugin for flake8"
-category = "dev"
+name = "mccabe"
 optional = false
 python-versions = "*"
+version = "0.6.1"
 
 [[package]]
-name = "metaphone"
-version = "0.6"
+category = "main"
 description = "A Python implementation of the metaphone and double metaphone algorithms."
-category = "main"
+name = "metaphone"
 optional = false
 python-versions = "*"
+version = "0.6"
 
 [[package]]
-name = "mistune"
-version = "0.8.4"
+category = "main"
 description = "The fastest markdown parser in pure Python"
-category = "main"
+name = "mistune"
 optional = false
 python-versions = "*"
+version = "0.8.4"
 
 [[package]]
-name = "more-itertools"
-version = "8.7.0"
-description = "More routines for operating on iterables, beyond itertools"
 category = "dev"
+description = "More routines for operating on iterables, beyond itertools"
+name = "more-itertools"
 optional = false
 python-versions = ">=3.5"
+version = "8.7.0"
 
 [[package]]
-name = "multidict"
-version = "5.1.0"
-description = "multidict implementation"
 category = "main"
+description = "multidict implementation"
+name = "multidict"
 optional = false
 python-versions = ">=3.6"
+version = "5.1.0"
 
 [[package]]
-name = "mypy"
-version = "0.770"
-description = "Optional static typing for Python"
 category = "dev"
+description = "Optional static typing for Python"
+name = "mypy"
 optional = false
 python-versions = ">=3.5"
+version = "0.770"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3,<0.5.0"
@@ -896,20 +952,20 @@ typing-extensions = ">=3.7.4"
 dmypy = ["psutil (>=4.0)"]
 
 [[package]]
-name = "mypy-extensions"
-version = "0.4.3"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
 category = "dev"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+name = "mypy-extensions"
 optional = false
 python-versions = "*"
+version = "0.4.3"
 
 [[package]]
-name = "nbclient"
-version = "0.5.3"
-description = "A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor."
 category = "main"
+description = "A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor."
+name = "nbclient"
 optional = false
 python-versions = ">=3.6.1"
+version = "0.5.3"
 
 [package.dependencies]
 async-generator = "*"
@@ -924,12 +980,12 @@ sphinx = ["Sphinx (>=1.7)", "sphinx-book-theme", "mock", "moto", "myst-parser"]
 test = ["codecov", "coverage", "ipython", "ipykernel", "ipywidgets", "pytest (>=4.1)", "pytest-cov (>=2.6.1)", "check-manifest", "flake8", "mypy", "tox", "bumpversion", "xmltodict", "pip (>=18.1)", "wheel (>=0.31.0)", "setuptools (>=38.6.0)", "twine (>=1.11.0)", "black"]
 
 [[package]]
-name = "nbconvert"
-version = "6.0.7"
-description = "Converting Jupyter Notebooks"
 category = "main"
+description = "Converting Jupyter Notebooks"
+name = "nbconvert"
 optional = false
 python-versions = ">=3.6"
+version = "6.0.7"
 
 [package.dependencies]
 bleach = "*"
@@ -947,19 +1003,19 @@ testpath = "*"
 traitlets = ">=4.2"
 
 [package.extras]
-all = ["pytest", "pytest-cov", "pytest-dependency", "ipykernel", "ipywidgets (>=7)", "pyppeteer (==0.2.2)", "tornado (>=4.0)", "sphinx (>=1.5.1)", "sphinx-rtd-theme", "nbsphinx (>=0.2.12)", "ipython"]
+all = ["pytest", "pytest-cov", "pytest-dependency", "ipykernel", "ipywidgets (>=7)", "pyppeteer (0.2.2)", "tornado (>=4.0)", "sphinx (>=1.5.1)", "sphinx-rtd-theme", "nbsphinx (>=0.2.12)", "ipython"]
 docs = ["sphinx (>=1.5.1)", "sphinx-rtd-theme", "nbsphinx (>=0.2.12)", "ipython"]
 serve = ["tornado (>=4.0)"]
-test = ["pytest", "pytest-cov", "pytest-dependency", "ipykernel", "ipywidgets (>=7)", "pyppeteer (==0.2.2)"]
-webpdf = ["pyppeteer (==0.2.2)"]
+test = ["pytest", "pytest-cov", "pytest-dependency", "ipykernel", "ipywidgets (>=7)", "pyppeteer (0.2.2)"]
+webpdf = ["pyppeteer (0.2.2)"]
 
 [[package]]
-name = "nbformat"
-version = "5.1.2"
-description = "The Jupyter Notebook format"
 category = "main"
+description = "The Jupyter Notebook format"
+name = "nbformat"
 optional = false
 python-versions = ">=3.5"
+version = "5.1.2"
 
 [package.dependencies]
 ipython-genutils = "*"
@@ -972,12 +1028,12 @@ fast = ["fastjsonschema"]
 test = ["check-manifest", "fastjsonschema", "testpath", "pytest", "pytest-cov"]
 
 [[package]]
-name = "nbsphinx"
-version = "0.7.1"
-description = "Jupyter Notebook Tools for Sphinx"
 category = "dev"
+description = "Jupyter Notebook Tools for Sphinx"
+name = "nbsphinx"
 optional = false
 python-versions = ">=3"
+version = "0.7.1"
 
 [package.dependencies]
 docutils = "*"
@@ -988,20 +1044,20 @@ sphinx = ">=1.8"
 traitlets = "*"
 
 [[package]]
-name = "nest-asyncio"
-version = "1.5.1"
-description = "Patch asyncio to allow nested event loops"
 category = "main"
+description = "Patch asyncio to allow nested event loops"
+name = "nest-asyncio"
 optional = false
 python-versions = ">=3.5"
+version = "1.5.1"
 
 [[package]]
-name = "nltk"
-version = "3.5"
-description = "Natural Language Toolkit"
 category = "main"
+description = "Natural Language Toolkit"
+name = "nltk"
 optional = false
 python-versions = "*"
+version = "3.5"
 
 [package.dependencies]
 click = "*"
@@ -1018,14 +1074,15 @@ tgrep = ["pyparsing"]
 twitter = ["twython"]
 
 [[package]]
-name = "notebook"
-version = "6.3.0"
-description = "A web-based notebook environment for interactive computing"
 category = "main"
+description = "A web-based notebook environment for interactive computing"
+name = "notebook"
 optional = false
 python-versions = ">=3.6"
+version = "6.3.0"
 
 [package.dependencies]
+Send2Trash = ">=1.5.0"
 argon2-cffi = "*"
 ipykernel = "*"
 ipython-genutils = "*"
@@ -1036,7 +1093,6 @@ nbconvert = "*"
 nbformat = "*"
 prometheus-client = "*"
 pyzmq = ">=17"
-Send2Trash = ">=1.5.0"
 terminado = ">=0.8.3"
 tornado = ">=6.1"
 traitlets = ">=4.2.1"
@@ -1047,31 +1103,31 @@ json-logging = ["json-logging"]
 test = ["pytest", "coverage", "requests", "nbval", "selenium", "pytest-cov", "requests-unixsocket"]
 
 [[package]]
-name = "numpy"
-version = "1.19.5"
-description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
+description = "NumPy is the fundamental package for array computing with Python."
+name = "numpy"
 optional = false
 python-versions = ">=3.6"
+version = "1.19.5"
 
 [[package]]
-name = "packaging"
-version = "20.9"
-description = "Core utilities for Python packages"
 category = "main"
+description = "Core utilities for Python packages"
+name = "packaging"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "20.9"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
 
 [[package]]
-name = "pandas"
-version = "1.1.5"
-description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
+description = "Powerful data structures for data analysis, time series, and statistics"
+name = "pandas"
 optional = false
 python-versions = ">=3.6.1"
+version = "1.1.5"
 
 [package.dependencies]
 numpy = ">=1.15.4"
@@ -1082,32 +1138,32 @@ pytz = ">=2017.2"
 test = ["pytest (>=4.0.2)", "pytest-xdist", "hypothesis (>=3.58)"]
 
 [[package]]
-name = "pandocfilters"
-version = "1.4.3"
-description = "Utilities for writing pandoc filters in python"
 category = "main"
+description = "Utilities for writing pandoc filters in python"
+name = "pandocfilters"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.4.3"
 
 [[package]]
-name = "parso"
-version = "0.8.2"
-description = "A Python Parser"
 category = "main"
+description = "A Python Parser"
+name = "parso"
 optional = false
 python-versions = ">=3.6"
+version = "0.8.2"
 
 [package.extras]
-qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
+qa = ["flake8 (3.8.3)", "mypy (0.782)"]
 testing = ["docopt", "pytest (<6.0.0)"]
 
 [[package]]
-name = "partd"
-version = "1.1.0"
-description = "Appendable key-value storage"
 category = "main"
+description = "Appendable key-value storage"
+name = "partd"
 optional = false
 python-versions = ">=3.5"
+version = "1.1.0"
 
 [package.dependencies]
 locket = "*"
@@ -1117,273 +1173,283 @@ toolz = "*"
 complete = ["numpy (>=1.9.0)", "pandas (>=0.19.0)", "pyzmq", "blosc"]
 
 [[package]]
-name = "pathspec"
-version = "0.8.1"
-description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
+description = "Utility library for gitignore style pattern matching of file paths."
+name = "pathspec"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.8.1"
 
 [[package]]
-name = "pathtools"
-version = "0.1.2"
-description = "File system general utilities"
 category = "dev"
+description = "File system general utilities"
+name = "pathtools"
 optional = false
 python-versions = "*"
+version = "0.1.2"
 
 [[package]]
-name = "pexpect"
-version = "4.8.0"
-description = "Pexpect allows easy control of interactive console applications."
 category = "main"
+description = "Pexpect allows easy control of interactive console applications."
+marker = "python_version >= \"3.3\" and sys_platform != \"win32\" or sys_platform != \"win32\""
+name = "pexpect"
 optional = false
 python-versions = "*"
+version = "4.8.0"
 
 [package.dependencies]
 ptyprocess = ">=0.5"
 
 [[package]]
-name = "pickleshare"
-version = "0.7.5"
-description = "Tiny 'shelve'-like database with concurrency support"
 category = "main"
+description = "Tiny 'shelve'-like database with concurrency support"
+name = "pickleshare"
 optional = false
 python-versions = "*"
+version = "0.7.5"
 
 [[package]]
-name = "pillow"
-version = "8.1.2"
-description = "Python Imaging Library (Fork)"
 category = "main"
+description = "Python Imaging Library (Fork)"
+name = "pillow"
 optional = false
 python-versions = ">=3.6"
+version = "8.1.2"
 
 [[package]]
-name = "pkginfo"
-version = "1.7.0"
-description = "Query metadatdata from sdists / bdists / installed packages."
 category = "dev"
+description = "Query metadatdata from sdists / bdists / installed packages."
+name = "pkginfo"
 optional = false
 python-versions = "*"
+version = "1.7.0"
 
 [package.extras]
 testing = ["nose", "coverage"]
 
 [[package]]
-name = "pluggy"
-version = "0.13.1"
-description = "plugin and hook calling mechanisms for python"
 category = "dev"
+description = "plugin and hook calling mechanisms for python"
+name = "pluggy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.13.1"
 
 [package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
 
 [package.extras]
 dev = ["pre-commit", "tox"]
 
 [[package]]
-name = "ply"
-version = "3.11"
+category = "main"
 description = "Python Lex & Yacc"
-category = "main"
+name = "ply"
 optional = false
 python-versions = "*"
+version = "3.11"
 
 [[package]]
-name = "port-for"
-version = "0.3.1"
-description = "Utility that helps with local TCP ports managment. It can find an unused TCP localhost port and remember the association."
 category = "dev"
+description = "Utility that helps with local TCP ports managment. It can find an unused TCP localhost port and remember the association."
+name = "port-for"
 optional = false
 python-versions = "*"
+version = "0.3.1"
 
 [[package]]
-name = "probableparsing"
-version = "0.0.1"
+category = "main"
 description = "Common methods for propbable parsers"
-category = "main"
+name = "probableparsing"
 optional = false
 python-versions = "*"
+version = "0.0.1"
 
 [[package]]
-name = "prometheus-client"
-version = "0.9.0"
-description = "Python client for the Prometheus monitoring system."
 category = "main"
+description = "Python client for the Prometheus monitoring system."
+name = "prometheus-client"
 optional = false
 python-versions = "*"
+version = "0.9.0"
 
 [package.extras]
 twisted = ["twisted"]
 
 [[package]]
-name = "prompt-toolkit"
-version = "3.0.18"
-description = "Library for building powerful interactive command lines in Python"
 category = "main"
+description = "Library for building powerful interactive command lines in Python"
+name = "prompt-toolkit"
 optional = false
 python-versions = ">=3.6.1"
+version = "3.0.18"
 
 [package.dependencies]
 wcwidth = "*"
 
 [[package]]
-name = "ptyprocess"
-version = "0.7.0"
-description = "Run a subprocess in a pseudo terminal"
 category = "main"
+description = "Run a subprocess in a pseudo terminal"
+marker = "sys_platform != \"win32\" or os_name != \"nt\" or python_version >= \"3.3\" and sys_platform != \"win32\""
+name = "ptyprocess"
 optional = false
 python-versions = "*"
+version = "0.7.0"
 
 [[package]]
-name = "pure-eval"
-version = "0.2.1"
-description = "Safely evaluate AST nodes without side effects"
 category = "main"
+description = "Safely evaluate AST nodes without side effects"
+name = "pure-eval"
 optional = false
 python-versions = "*"
+version = "0.2.1"
 
 [package.extras]
 tests = ["pytest"]
 
 [[package]]
-name = "py"
-version = "1.10.0"
+category = "main"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "main"
+name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.10.0"
 
 [[package]]
-name = "pycparser"
-version = "2.20"
+category = "main"
 description = "C parser in Python"
-category = "main"
+name = "pycparser"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.20"
 
 [[package]]
-name = "pydantic"
-version = "1.8.1"
-description = "Data validation and settings management using python 3.6 type hinting"
 category = "main"
+description = "Data validation and settings management using python 3.6 type hinting"
+name = "pydantic"
 optional = false
 python-versions = ">=3.6.1"
+version = "1.8.1"
 
 [package.dependencies]
-dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
 typing-extensions = ">=3.7.4.3"
+
+[package.dependencies.dataclasses]
+python = "<3.7"
+version = ">=0.6"
 
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
 
 [[package]]
-name = "pygments"
-version = "2.8.1"
-description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
+description = "Pygments is a syntax highlighting package written in Python."
+name = "pygments"
 optional = false
 python-versions = ">=3.5"
+version = "2.8.1"
 
 [[package]]
-name = "pylint"
-version = "2.6.0"
-description = "python code static checker"
 category = "dev"
+description = "python code static checker"
+name = "pylint"
 optional = false
 python-versions = ">=3.5.*"
+version = "2.6.0"
 
 [package.dependencies]
 astroid = ">=2.4.0,<=2.5"
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
+colorama = "*"
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.7"
 toml = ">=0.7.1"
 
 [[package]]
-name = "pyparsing"
-version = "2.4.7"
-description = "Python parsing module"
 category = "main"
+description = "Python parsing module"
+name = "pyparsing"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "2.4.7"
 
 [[package]]
-name = "pyrsistent"
-version = "0.17.3"
-description = "Persistent/Functional/Immutable data structures"
 category = "main"
+description = "Persistent/Functional/Immutable data structures"
+name = "pyrsistent"
 optional = false
 python-versions = ">=3.5"
+version = "0.17.3"
 
 [[package]]
-name = "pytest"
-version = "5.4.3"
-description = "pytest: simple powerful testing with Python"
 category = "dev"
+description = "pytest: simple powerful testing with Python"
+name = "pytest"
 optional = false
 python-versions = ">=3.5"
+version = "5.4.3"
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+atomicwrites = ">=1.0"
 attrs = ">=17.4.0"
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+colorama = "*"
 more-itertools = ">=4.0.0"
 packaging = "*"
 pluggy = ">=0.12,<1.0"
 py = ">=1.5.0"
 wcwidth = "*"
 
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
+
 [package.extras]
-checkqa-mypy = ["mypy (==v0.761)"]
+checkqa-mypy = ["mypy (v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-name = "pytest-cov"
-version = "2.11.1"
-description = "Pytest plugin for measuring coverage."
 category = "dev"
+description = "Pytest plugin for measuring coverage."
+name = "pytest-cov"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.11.1"
 
 [package.dependencies]
 coverage = ">=5.2.1"
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
-name = "python-crfsuite"
-version = "0.9.7"
-description = "Python binding for CRFsuite"
 category = "main"
+description = "Python binding for CRFsuite"
+name = "python-crfsuite"
 optional = false
 python-versions = "*"
+version = "0.9.7"
 
 [[package]]
-name = "python-dateutil"
-version = "2.8.1"
-description = "Extensions to the standard Python datetime module"
 category = "main"
+description = "Extensions to the standard Python datetime module"
+name = "python-dateutil"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+version = "2.8.1"
 
 [package.dependencies]
 six = ">=1.5"
 
 [[package]]
-name = "python-gitlab"
-version = "2.6.0"
-description = "Interact with GitLab API"
 category = "dev"
+description = "Interact with GitLab API"
+name = "python-gitlab"
 optional = false
 python-versions = ">=3.6.0"
+version = "2.6.0"
 
 [package.dependencies]
 requests = ">=2.22.0"
@@ -1394,12 +1460,12 @@ autocompletion = ["argcomplete (>=1.10.0,<2)"]
 yaml = ["PyYaml (>=5.2)"]
 
 [[package]]
-name = "python-semantic-release"
-version = "7.15.1"
-description = "Automatic Semantic Versioning for Python projects"
 category = "dev"
+description = "Automatic Semantic Versioning for Python projects"
+name = "python-semantic-release"
 optional = false
 python-versions = "*"
+version = "7.15.1"
 
 [package.dependencies]
 click = ">=7,<8"
@@ -1412,96 +1478,113 @@ requests = ">=2.25,<3"
 semver = ">=2.10,<3"
 tomlkit = ">=0.7.0,<1.0.0"
 twine = ">=3,<4"
+wheel = "*"
 
 [package.extras]
 dev = ["mypy", "tox", "isort", "black"]
-docs = ["Sphinx (==1.3.6)"]
-test = ["coverage (>=5,<6)", "pytest (>=5,<6)", "pytest-xdist (>=1,<2)", "pytest-mock (>=2,<3)", "responses (==0.5.0)", "mock (==1.3.0)"]
+docs = ["Sphinx (1.3.6)"]
+test = ["coverage (>=5,<6)", "pytest (>=5,<6)", "pytest-xdist (>=1,<2)", "pytest-mock (>=2,<3)", "responses (0.5.0)", "mock (1.3.0)"]
 
 [[package]]
-name = "pytz"
-version = "2021.1"
+category = "main"
+description = "Python module to handle standardized numbers and codes"
+name = "python-stdnum"
+optional = false
+python-versions = "*"
+version = "1.16"
+
+[package.extras]
+soap = ["zeep"]
+soap-alt = ["suds"]
+soap-fallback = ["pysimplesoap"]
+
+[[package]]
+category = "main"
 description = "World timezone definitions, modern and historical"
-category = "main"
+name = "pytz"
 optional = false
 python-versions = "*"
+version = "2021.1"
 
 [[package]]
-name = "pywin32"
-version = "300"
+category = "main"
 description = "Python for Window Extensions"
-category = "main"
+marker = "sys_platform == \"win32\""
+name = "pywin32"
 optional = false
 python-versions = "*"
+version = "300"
 
 [[package]]
-name = "pywin32-ctypes"
-version = "0.2.0"
-description = ""
 category = "dev"
+description = ""
+marker = "sys_platform == \"win32\""
+name = "pywin32-ctypes"
 optional = false
 python-versions = "*"
+version = "0.2.0"
 
 [[package]]
-name = "pywinpty"
-version = "0.5.7"
+category = "main"
 description = "Python bindings for the winpty library"
-category = "main"
+marker = "os_name == \"nt\""
+name = "pywinpty"
 optional = false
 python-versions = "*"
+version = "0.5.7"
 
 [[package]]
-name = "pyyaml"
-version = "5.4.1"
-description = "YAML parser and emitter for Python"
 category = "main"
+description = "YAML parser and emitter for Python"
+name = "pyyaml"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+version = "5.4.1"
 
 [[package]]
-name = "pyzmq"
-version = "22.0.3"
-description = "Python bindings for 0MQ"
 category = "main"
+description = "Python bindings for 0MQ"
+name = "pyzmq"
 optional = false
 python-versions = ">=3.6"
+version = "22.0.3"
 
 [package.dependencies]
-cffi = {version = "*", markers = "implementation_name == \"pypy\""}
-py = {version = "*", markers = "implementation_name == \"pypy\""}
+cffi = "*"
+py = "*"
 
 [[package]]
-name = "readme-renderer"
-version = "29.0"
-description = "readme_renderer is a library for rendering \"readme\" descriptions for Warehouse"
 category = "dev"
+description = "readme_renderer is a library for rendering \"readme\" descriptions for Warehouse"
+name = "readme-renderer"
 optional = false
 python-versions = "*"
+version = "29.0"
 
 [package.dependencies]
+Pygments = ">=2.5.1"
 bleach = ">=2.1.0"
 docutils = ">=0.13.1"
-Pygments = ">=2.5.1"
 six = "*"
 
 [package.extras]
 md = ["cmarkgfm (>=0.5.0,<0.6.0)"]
 
 [[package]]
-name = "regex"
-version = "2020.11.13"
-description = "Alternative regular expression module, to replace re."
 category = "main"
+description = "Alternative regular expression module, to replace re."
+name = "regex"
 optional = false
 python-versions = "*"
+version = "2020.11.13"
 
 [[package]]
-name = "requests"
-version = "2.25.1"
-description = "Python HTTP for Humans."
 category = "dev"
+description = "Python HTTP for Humans."
+name = "requests"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.25.1"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
@@ -1511,70 +1594,70 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
-name = "requests-toolbelt"
-version = "0.9.1"
-description = "A utility belt for advanced users of python-requests"
 category = "dev"
+description = "A utility belt for advanced users of python-requests"
+name = "requests-toolbelt"
 optional = false
 python-versions = "*"
+version = "0.9.1"
 
 [package.dependencies]
 requests = ">=2.0.1,<3.0.0"
 
 [[package]]
-name = "rfc3986"
-version = "1.4.0"
-description = "Validating URI References per RFC 3986"
 category = "dev"
+description = "Validating URI References per RFC 3986"
+name = "rfc3986"
 optional = false
 python-versions = "*"
+version = "1.4.0"
 
 [package.extras]
 idna2008 = ["idna"]
 
 [[package]]
-name = "rope"
-version = "0.16.0"
-description = "a python refactoring library..."
 category = "dev"
+description = "a python refactoring library..."
+name = "rope"
 optional = false
 python-versions = "*"
+version = "0.16.0"
 
 [package.extras]
 dev = ["pytest"]
 
 [[package]]
-name = "rstcheck"
-version = "3.3.1"
-description = "Checks syntax of reStructuredText and code blocks nested within it"
 category = "dev"
+description = "Checks syntax of reStructuredText and code blocks nested within it"
+name = "rstcheck"
 optional = false
 python-versions = "*"
+version = "3.3.1"
 
 [package.dependencies]
 docutils = ">=0.7"
 
 [[package]]
-name = "scipy"
-version = "1.5.4"
-description = "SciPy: Scientific Library for Python"
 category = "main"
+description = "SciPy: Scientific Library for Python"
+name = "scipy"
 optional = false
 python-versions = ">=3.6"
+version = "1.5.4"
 
 [package.dependencies]
 numpy = ">=1.14.5"
 
 [[package]]
-name = "seaborn"
-version = "0.10.1"
-description = "seaborn: statistical data visualization"
 category = "dev"
+description = "seaborn: statistical data visualization"
+name = "seaborn"
 optional = false
 python-versions = ">=3.6"
+version = "0.10.1"
 
 [package.dependencies]
 matplotlib = ">=2.1.2"
@@ -1583,86 +1666,91 @@ pandas = ">=0.22.0"
 scipy = ">=1.0.1"
 
 [[package]]
-name = "secretstorage"
-version = "3.3.1"
-description = "Python bindings to FreeDesktop.org Secret Service API"
 category = "dev"
+description = "Python bindings to FreeDesktop.org Secret Service API"
+marker = "sys_platform == \"linux\""
+name = "secretstorage"
 optional = false
 python-versions = ">=3.6"
+version = "3.3.1"
 
 [package.dependencies]
 cryptography = ">=2.0"
 jeepney = ">=0.6"
 
 [[package]]
-name = "semver"
-version = "2.13.0"
-description = "Python helper for Semantic Versioning (http://semver.org/)"
 category = "dev"
+description = "Python helper for Semantic Versioning (http://semver.org/)"
+name = "semver"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.13.0"
 
 [[package]]
-name = "send2trash"
-version = "1.5.0"
-description = "Send file to trash natively under Mac OS X, Windows and Linux."
 category = "main"
+description = "Send file to trash natively under Mac OS X, Windows and Linux."
+name = "send2trash"
 optional = false
 python-versions = "*"
+version = "1.5.0"
 
 [[package]]
-name = "setuptools-scm"
-version = "6.0.1"
-description = "the blessed package to manage your versions by scm tags"
 category = "dev"
+description = "the blessed package to manage your versions by scm tags"
+name = "setuptools-scm"
 optional = false
 python-versions = ">=3.6"
+version = "6.0.1"
+
+[package.dependencies]
+setuptools = ">=45"
 
 [package.extras]
 toml = ["toml"]
 
 [[package]]
-name = "six"
-version = "1.15.0"
-description = "Python 2 and 3 compatibility utilities"
 category = "main"
+description = "Python 2 and 3 compatibility utilities"
+name = "six"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "1.15.0"
 
 [[package]]
-name = "smmap"
-version = "4.0.0"
-description = "A pure Python implementation of a sliding window memory map manager"
 category = "dev"
+description = "A pure Python implementation of a sliding window memory map manager"
+name = "smmap"
 optional = false
 python-versions = ">=3.5"
+version = "4.0.0"
 
 [[package]]
-name = "snowballstemmer"
-version = "2.1.0"
-description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
 category = "dev"
+description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
+name = "snowballstemmer"
 optional = false
 python-versions = "*"
+version = "2.1.0"
 
 [[package]]
-name = "sphinx"
-version = "3.5.3"
-description = "Python documentation generator"
 category = "dev"
+description = "Python documentation generator"
+name = "sphinx"
 optional = false
 python-versions = ">=3.5"
+version = "3.5.3"
 
 [package.dependencies]
+Jinja2 = ">=2.3"
+Pygments = ">=2.0"
 alabaster = ">=0.7,<0.8"
 babel = ">=1.3"
-colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
+colorama = ">=0.3.5"
 docutils = ">=0.12"
 imagesize = "*"
-Jinja2 = ">=2.3"
 packaging = "*"
-Pygments = ">=2.0"
 requests = ">=2.5.0"
+setuptools = "*"
 snowballstemmer = ">=1.1"
 sphinxcontrib-applehelp = "*"
 sphinxcontrib-devhelp = "*"
@@ -1677,29 +1765,29 @@ lint = ["flake8 (>=3.5.0)", "isort", "mypy (>=0.800)", "docutils-stubs"]
 test = ["pytest", "pytest-cov", "html5lib", "cython", "typed-ast"]
 
 [[package]]
-name = "sphinx-autobuild"
-version = "0.7.1"
-description = "Watch a Sphinx directory and rebuild the documentation when a change is detected. Also includes a livereload enabled web server."
 category = "dev"
+description = "Watch a Sphinx directory and rebuild the documentation when a change is detected. Also includes a livereload enabled web server."
+name = "sphinx-autobuild"
 optional = false
 python-versions = "*"
+version = "0.7.1"
 
 [package.dependencies]
+PyYAML = ">=3.10"
 argh = ">=0.24.1"
 livereload = ">=2.3.0"
 pathtools = ">=0.1.2"
 port-for = "0.3.1"
-PyYAML = ">=3.10"
 tornado = ">=3.2"
 watchdog = ">=0.7.1"
 
 [[package]]
-name = "sphinx-autodoc-typehints"
-version = "1.11.1"
-description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
 category = "dev"
+description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
+name = "sphinx-autodoc-typehints"
 optional = false
 python-versions = ">=3.5.2"
+version = "1.11.1"
 
 [package.dependencies]
 Sphinx = ">=3.0"
@@ -1709,142 +1797,142 @@ test = ["pytest (>=3.1.0)", "typing-extensions (>=3.5)", "sphobjinv (>=2.0)", "S
 type_comments = ["typed-ast (>=1.4.0)"]
 
 [[package]]
-name = "sphinxcontrib-applehelp"
-version = "1.0.2"
+category = "dev"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
-category = "dev"
+name = "sphinxcontrib-applehelp"
 optional = false
 python-versions = ">=3.5"
-
-[package.extras]
-lint = ["flake8", "mypy", "docutils-stubs"]
-test = ["pytest"]
-
-[[package]]
-name = "sphinxcontrib-devhelp"
 version = "1.0.2"
-description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
-category = "dev"
-optional = false
-python-versions = ">=3.5"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
-name = "sphinxcontrib-htmlhelp"
-version = "1.0.3"
-description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 category = "dev"
+description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
+name = "sphinxcontrib-devhelp"
 optional = false
 python-versions = ">=3.5"
+version = "1.0.2"
+
+[package.extras]
+lint = ["flake8", "mypy", "docutils-stubs"]
+test = ["pytest"]
+
+[[package]]
+category = "dev"
+description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
+name = "sphinxcontrib-htmlhelp"
+optional = false
+python-versions = ">=3.5"
+version = "1.0.3"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest", "html5lib"]
 
 [[package]]
-name = "sphinxcontrib-jsmath"
-version = "1.0.1"
-description = "A sphinx extension which renders display math in HTML via JavaScript"
 category = "dev"
+description = "A sphinx extension which renders display math in HTML via JavaScript"
+name = "sphinxcontrib-jsmath"
 optional = false
 python-versions = ">=3.5"
+version = "1.0.1"
 
 [package.extras]
 test = ["pytest", "flake8", "mypy"]
 
 [[package]]
-name = "sphinxcontrib-qthelp"
-version = "1.0.3"
+category = "dev"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
-category = "dev"
+name = "sphinxcontrib-qthelp"
 optional = false
 python-versions = ">=3.5"
+version = "1.0.3"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
-name = "sphinxcontrib-serializinghtml"
-version = "1.1.4"
+category = "dev"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
-category = "dev"
+name = "sphinxcontrib-serializinghtml"
 optional = false
 python-versions = ">=3.5"
+version = "1.1.4"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
 
 [[package]]
-name = "terminado"
-version = "0.9.4"
-description = "Tornado websocket backend for the Xterm.js Javascript terminal emulator library."
 category = "main"
+description = "Tornado websocket backend for the Xterm.js Javascript terminal emulator library."
+name = "terminado"
 optional = false
 python-versions = ">=3.6"
+version = "0.9.4"
 
 [package.dependencies]
-ptyprocess = {version = "*", markers = "os_name != \"nt\""}
-pywinpty = {version = ">=0.5", markers = "os_name == \"nt\""}
+ptyprocess = "*"
+pywinpty = ">=0.5"
 tornado = ">=4"
 
 [package.extras]
 test = ["pytest"]
 
 [[package]]
-name = "testpath"
-version = "0.4.4"
-description = "Test utilities for code working with files and commands"
 category = "main"
+description = "Test utilities for code working with files and commands"
+name = "testpath"
 optional = false
 python-versions = "*"
+version = "0.4.4"
 
 [package.extras]
 test = ["pathlib2"]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
 category = "dev"
+description = "Python Library for Tom's Obvious, Minimal Language"
+name = "toml"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "0.10.2"
 
 [[package]]
-name = "tomlkit"
-version = "0.7.0"
-description = "Style preserving TOML library"
 category = "dev"
+description = "Style preserving TOML library"
+name = "tomlkit"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.7.0"
 
 [[package]]
-name = "toolz"
-version = "0.11.1"
-description = "List processing tools and functional utilities"
 category = "main"
+description = "List processing tools and functional utilities"
+name = "toolz"
 optional = false
 python-versions = ">=3.5"
+version = "0.11.1"
 
 [[package]]
-name = "tornado"
-version = "6.1"
-description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
 category = "main"
+description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
+name = "tornado"
 optional = false
 python-versions = ">= 3.5"
+version = "6.1"
 
 [[package]]
-name = "tqdm"
-version = "4.59.0"
-description = "Fast, Extensible Progress Meter"
 category = "main"
+description = "Fast, Extensible Progress Meter"
+name = "tqdm"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "4.59.0"
 
 [package.extras]
 dev = ["py-make (>=0.1.0)", "twine", "wheel"]
@@ -1852,12 +1940,12 @@ notebook = ["ipywidgets (>=6)"]
 telegram = ["requests"]
 
 [[package]]
-name = "traitlets"
-version = "4.3.3"
-description = "Traitlets Python config system"
 category = "main"
+description = "Traitlets Python config system"
+name = "traitlets"
 optional = false
 python-versions = "*"
+version = "4.3.3"
 
 [package.dependencies]
 decorator = "*"
@@ -1868,12 +1956,12 @@ six = "*"
 test = ["pytest", "mock"]
 
 [[package]]
-name = "twine"
-version = "3.4.1"
-description = "Collection of utilities for publishing packages on PyPI"
 category = "dev"
+description = "Collection of utilities for publishing packages on PyPI"
+name = "twine"
 optional = false
 python-versions = ">=3.6"
+version = "3.4.1"
 
 [package.dependencies]
 colorama = ">=0.4.3"
@@ -1887,41 +1975,41 @@ rfc3986 = ">=1.4.0"
 tqdm = ">=4.14"
 
 [[package]]
-name = "typed-ast"
-version = "1.4.2"
+category = "dev"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
-category = "dev"
+name = "typed-ast"
 optional = false
 python-versions = "*"
+version = "1.4.2"
 
 [[package]]
-name = "typing-extensions"
-version = "3.7.4.3"
-description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+name = "typing-extensions"
 optional = false
 python-versions = "*"
+version = "3.7.4.3"
 
 [[package]]
-name = "urllib3"
-version = "1.26.4"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "dev"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "1.26.4"
 
 [package.extras]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 brotli = ["brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
-name = "usaddress"
-version = "0.5.10"
-description = "Parse US addresses using conditional random fields"
 category = "main"
+description = "Parse US addresses using conditional random fields"
+name = "usaddress"
 optional = false
 python-versions = "*"
+version = "0.5.10"
 
 [package.dependencies]
 future = ">=0.14"
@@ -1929,12 +2017,12 @@ probableparsing = "*"
 python-crfsuite = ">=0.7"
 
 [[package]]
-name = "varname"
-version = "0.8.1"
-description = "Dark magics about variable names in python."
 category = "main"
+description = "Dark magics about variable names in python."
+name = "varname"
 optional = false
 python-versions = ">=3.6,<4.0"
+version = "0.8.1"
 
 [package.dependencies]
 asttokens = ">=2.0.0,<3.0.0"
@@ -1942,50 +2030,61 @@ executing = "*"
 pure_eval = "<1.0.0"
 
 [[package]]
-name = "watchdog"
-version = "2.0.2"
-description = "Filesystem events monitoring"
 category = "dev"
+description = "Filesystem events monitoring"
+name = "watchdog"
 optional = false
 python-versions = ">=3.6"
+version = "2.0.2"
 
 [package.extras]
 watchmedo = ["PyYAML (>=3.10)", "argh (>=0.24.1)"]
 
 [[package]]
-name = "wcwidth"
-version = "0.2.5"
+category = "main"
 description = "Measures the displayed width of unicode strings in a terminal"
-category = "main"
+name = "wcwidth"
 optional = false
 python-versions = "*"
+version = "0.2.5"
 
 [[package]]
-name = "webencodings"
-version = "0.5.1"
+category = "main"
 description = "Character encoding aliases for legacy web content"
-category = "main"
+name = "webencodings"
 optional = false
 python-versions = "*"
+version = "0.5.1"
 
 [[package]]
-name = "widgetsnbextension"
-version = "3.5.1"
-description = "IPython HTML widgets for Jupyter"
+category = "dev"
+description = "A built-package format for Python"
+name = "wheel"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "0.37.0"
+
+[package.extras]
+test = ["pytest (>=3.0.0)", "pytest-cov"]
+
+[[package]]
 category = "main"
+description = "IPython HTML widgets for Jupyter"
+name = "widgetsnbextension"
 optional = false
 python-versions = "*"
+version = "3.5.1"
 
 [package.dependencies]
 notebook = ">=4.4.1"
 
 [[package]]
-name = "wordcloud"
-version = "1.8.1"
-description = "A little word cloud generator"
 category = "main"
+description = "A little word cloud generator"
+name = "wordcloud"
 optional = false
 python-versions = "*"
+version = "1.8.1"
 
 [package.dependencies]
 matplotlib = "*"
@@ -1993,42 +2092,44 @@ numpy = ">=1.6.1"
 pillow = "*"
 
 [[package]]
-name = "wrapt"
-version = "1.12.1"
-description = "Module for decorators, wrappers and monkey patching."
 category = "dev"
+description = "Module for decorators, wrappers and monkey patching."
+name = "wrapt"
 optional = false
 python-versions = "*"
+version = "1.12.1"
 
 [[package]]
-name = "yarl"
-version = "1.6.3"
-description = "Yet another URL library"
 category = "main"
+description = "Yet another URL library"
+name = "yarl"
 optional = false
 python-versions = ">=3.6"
+version = "1.6.3"
 
 [package.dependencies]
 idna = ">=2.0"
 multidict = ">=4.0"
-typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
+
+[package.dependencies.typing-extensions]
+python = "<3.8"
+version = ">=3.7.4"
 
 [[package]]
-name = "zipp"
-version = "3.4.1"
-description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+name = "zipp"
 optional = false
 python-versions = ">=3.6"
+version = "3.4.1"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-lock-version = "1.1"
+content-hash = "99c0795c5cbcad2eb190a4e4066984fa9ffcf4e1d879978f7bf04af3f3dd1e7a"
 python-versions = "^3.6.1"
-content-hash = "eccb4baae02b57e30c2fbbf66e6575be8d5016d37ebdff28719ddb2f569c08e0"
 
 [metadata.files]
 aiohttp = [
@@ -2105,6 +2206,10 @@ argon2-cffi = [
     {file = "argon2_cffi-20.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:9dfd5197852530294ecb5795c97a823839258dfd5eb9420233c7cfedec2058f2"},
     {file = "argon2_cffi-20.1.0-cp39-cp39-win32.whl", hash = "sha256:e2db6e85c057c16d0bd3b4d2b04f270a7467c147381e8fd73cbbe5bc719832be"},
     {file = "argon2_cffi-20.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:8a84934bd818e14a17943de8099d41160da4a336bcc699bb4c394bbb9b94bd32"},
+    {file = "argon2_cffi-20.1.0-pp36-pypy36_pp73-macosx_10_7_x86_64.whl", hash = "sha256:b94042e5dcaa5d08cf104a54bfae614be502c6f44c9c89ad1535b2ebdaacbd4c"},
+    {file = "argon2_cffi-20.1.0-pp36-pypy36_pp73-win32.whl", hash = "sha256:8282b84ceb46b5b75c3a882b28856b8cd7e647ac71995e71b6705ec06fc232c3"},
+    {file = "argon2_cffi-20.1.0-pp37-pypy37_pp73-macosx_10_7_x86_64.whl", hash = "sha256:3aa804c0e52f208973845e8b10c70d8957c9e5a666f702793256242e9167c4e0"},
+    {file = "argon2_cffi-20.1.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:36320372133a003374ef4275fbfce78b7ab581440dfca9f9471be3dd9a522428"},
 ]
 astroid = [
     {file = "astroid-2.5-py3-none-any.whl", hash = "sha256:87ae7f2398b8a0ae5638ddecf9987f081b756e0e9fc071aeebdca525671fc4dc"},
@@ -2172,24 +2277,36 @@ cffi = [
     {file = "cffi-1.14.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:48e1c69bbacfc3d932221851b39d49e81567a4d4aac3b21258d9c24578280058"},
     {file = "cffi-1.14.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:69e395c24fc60aad6bb4fa7e583698ea6cc684648e1ffb7fe85e3c1ca131a7d5"},
     {file = "cffi-1.14.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:9e93e79c2551ff263400e1e4be085a1210e12073a31c2011dbbda14bda0c6132"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24ec4ff2c5c0c8f9c6b87d5bb53555bf267e1e6f70e52e5a9740d32861d36b6f"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c3f39fa737542161d8b0d680df2ec249334cd70a8f420f71c9304bd83c3cbed"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:681d07b0d1e3c462dd15585ef5e33cb021321588bebd910124ef4f4fb71aef55"},
     {file = "cffi-1.14.5-cp36-cp36m-win32.whl", hash = "sha256:58e3f59d583d413809d60779492342801d6e82fefb89c86a38e040c16883be53"},
     {file = "cffi-1.14.5-cp36-cp36m-win_amd64.whl", hash = "sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813"},
     {file = "cffi-1.14.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2894f2df484ff56d717bead0a5c2abb6b9d2bf26d6960c4604d5c48bbc30ee73"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0857f0ae312d855239a55c81ef453ee8fd24136eaba8e87a2eceba644c0d4c06"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:cd2868886d547469123fadc46eac7ea5253ea7fcb139f12e1dfc2bbd406427d1"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:35f27e6eb43380fa080dccf676dece30bef72e4a67617ffda586641cd4508d49"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06d7cd1abac2ffd92e65c0609661866709b4b2d82dd15f611e602b9b188b0b69"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f861a89e0043afec2a51fd177a567005847973be86f709bbb044d7f42fc4e05"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc5a8e069b9ebfa22e26d0e6b97d6f9781302fe7f4f2b8776c3e1daea35f1adc"},
     {file = "cffi-1.14.5-cp37-cp37m-win32.whl", hash = "sha256:9ff227395193126d82e60319a673a037d5de84633f11279e336f9c0f189ecc62"},
     {file = "cffi-1.14.5-cp37-cp37m-win_amd64.whl", hash = "sha256:9cf8022fb8d07a97c178b02327b284521c7708d7c71a9c9c355c178ac4bbd3d4"},
     {file = "cffi-1.14.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8b198cec6c72df5289c05b05b8b0969819783f9418e0409865dac47288d2a053"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:ad17025d226ee5beec591b52800c11680fca3df50b8b29fe51d882576e039ee0"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6c97d7350133666fbb5cf4abdc1178c812cb205dc6f41d174a7b0f18fb93337e"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8ae6299f6c68de06f136f1f9e69458eae58f1dacf10af5c17353eae03aa0d827"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:04c468b622ed31d408fea2346bec5bbffba2cc44226302a0de1ade9f5ea3d373"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:06db6321b7a68b2bd6df96d08a5adadc1fa0e8f419226e25b2a5fbf6ccc7350f"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:293e7ea41280cb28c6fcaaa0b1aa1f533b8ce060b9e701d78511e1e6c4a1de76"},
     {file = "cffi-1.14.5-cp38-cp38-win32.whl", hash = "sha256:b85eb46a81787c50650f2392b9b4ef23e1f126313b9e0e9013b35c15e4288e2e"},
     {file = "cffi-1.14.5-cp38-cp38-win_amd64.whl", hash = "sha256:1f436816fc868b098b0d63b8920de7d208c90a67212546d02f84fe78a9c26396"},
     {file = "cffi-1.14.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1071534bbbf8cbb31b498d5d9db0f274f2f7a865adca4ae429e147ba40f73dea"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:9de2e279153a443c656f2defd67769e6d1e4163952b3c622dcea5b08a6405322"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:158d0d15119b4b7ff6b926536763dc0714313aa59e320ddf787502c70c4d4bee"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf1ac1984eaa7675ca8d5745a8cb87ef7abecb5592178406e55858d411eadc0"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:df5052c5d867c1ea0b311fb7c3cd28b19df469c056f7fdcfe88c7473aa63e333"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:24a570cd11895b60829e941f2613a4f79df1a27344cbbb82164ef2e0116f09c7"},
     {file = "cffi-1.14.5-cp39-cp39-win32.whl", hash = "sha256:afb29c1ba2e5a3736f1c301d9d0abe3ec8b86957d04ddfa9d7a6a42b9367e396"},
     {file = "cffi-1.14.5-cp39-cp39-win_amd64.whl", hash = "sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d"},
     {file = "cffi-1.14.5.tar.gz", hash = "sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"},
@@ -2526,20 +2643,39 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-win32.whl", hash = "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 matplotlib = [
@@ -2931,6 +3067,10 @@ python-gitlab = [
 python-semantic-release = [
     {file = "python-semantic-release-7.15.1.tar.gz", hash = "sha256:1f9a5b22964154a4587b1801d4d802c7f0d0d387ce4d9d64c089f895b9fb9b01"},
     {file = "python_semantic_release-7.15.1-py3-none-any.whl", hash = "sha256:d3cb3d07c81e2bacbd74d014265b89b8ce5b144d3ac567cdfd76fc5369638ba8"},
+]
+python-stdnum = [
+    {file = "python-stdnum-1.16.tar.gz", hash = "sha256:4248d898042a801fc4eff96fbfe4bf63a43324854efe3b5534718c1c195c6f43"},
+    {file = "python_stdnum-1.16-py2.py3-none-any.whl", hash = "sha256:2e2c56c548ca166b95547a8d748f4d71320a5b4896960717c8e6380e08d993a5"},
 ]
 pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
@@ -3341,6 +3481,10 @@ wcwidth = [
 webencodings = [
     {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
     {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
+]
+wheel = [
+    {file = "wheel-0.37.0-py2.py3-none-any.whl", hash = "sha256:21014b2bd93c6d0034b6ba5d35e4eb284340e09d63c59aef6fc14b0f346146fd"},
+    {file = "wheel-0.37.0.tar.gz", hash = "sha256:e2ef7239991699e3355d54f8e968a21bb940a1dbf34a4d226741e64462516fad"},
 ]
 widgetsnbextension = [
     {file = "widgetsnbextension-3.5.1-py2.py3-none-any.whl", hash = "sha256:bd314f8ceb488571a5ffea6cc5b9fc6cba0adaf88a9d2386b93a489751938bcd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,9 @@ ipywidgets = "^7.5"
 regex = "^2020.10.15"
 usaddress = "^0.5.10"
 levenshtein = "^0.12.0"
-varname = "^0.8.1"
 metaphone = "^0.6"
+varname = "^0.8.1"
+python-stdnum = "^1.16"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.4"


### PR DESCRIPTION
# Description

Implementation and document for several number type clean functions. The implementation refers to [stdnum](https://github.com/arthurdejong/python-stdnum) library and follows the [unified API design](https://github.com/sfu-db/dataprep/issues/655).

# How Has This Been Tested?

Unit tests

# Snapshots:

![image](https://user-images.githubusercontent.com/66409637/125450011-fd96f30b-4af5-4ebb-aa9f-c94f6d2f7b68.png)
![image](https://user-images.githubusercontent.com/66409637/125450025-5c060090-c692-4572-886c-87362f2b5e3c.png)
![image](https://user-images.githubusercontent.com/66409637/125450076-d661e947-b6a8-4cf3-9484-a3da81a53b96.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
