### PR TITLE
docs(clean): add documentation for multiple clean functions for number types

### DIFF
--- a/dataprep/clean/clean_cy_vat.py
+++ b/dataprep/clean/clean_cy_vat.py
@@ -61,7 +61,7 @@ def clean_cy_vat(
 
     >>> df = pd.DataFrame({{
             "vat": [
-            '12302 6635',
+            'CY-10259033P',
             'CY-10259033Z',]
             })
     >>> clean_cy_vat(df, 'vat')

--- a/dataprep/clean/clean_de_vat.py
+++ b/dataprep/clean/clean_de_vat.py
@@ -1,5 +1,5 @@
 """
-Clean and validate a DataFrame column containing German VAT numberss (VATs).
+Clean and validate a DataFrame column containing German VAT numbers (VATs).
 """
 # pylint: disable=too-many-lines, too-many-arguments, too-many-branches
 from typing import Any, Union

--- a/dataprep/clean/clean_de_wkn.py
+++ b/dataprep/clean/clean_de_wkn.py
@@ -1,5 +1,6 @@
 """
-Clean and validate a DataFrame column containing Wertpapierkennnummer (WKNs).
+Clean and validate a DataFrame column containing
+German Securities Identification Codes (WKNs).
 """
 # pylint: disable=too-many-lines, too-many-arguments, too-many-branches
 from typing import Any, Union

--- a/dataprep/clean/clean_fi_associationid.py
+++ b/dataprep/clean/clean_fi_associationid.py
@@ -58,7 +58,7 @@ def clean_fi_associationid(
     --------
     Clean a column of Finnish association registry id data.
 
-    >>> df = pd.DataFrame({{
+    >>> df = pd.DataFrame({
             "associationid": [
             "1234",
             "12df",]

--- a/dataprep/clean/clean_fr_siret.py
+++ b/dataprep/clean/clean_fr_siret.py
@@ -24,7 +24,7 @@ def clean_fr_siret(
     progress: bool = True,
 ) -> pd.DataFrame:
     """
-    Clean French company establishment identification numbers (SIRETs) data in a DataFrame column.
+    Clean French Company Establishment Identification Numbers (SIRETs) in a DataFrame column.
 
     Parameters
     ----------

--- a/dataprep/clean/clean_in_aadhaar.py
+++ b/dataprep/clean/clean_in_aadhaar.py
@@ -36,7 +36,7 @@ def clean_in_aadhaar(
             The output format of standardized number string.
             If output_format = 'compact', return string without any separators or whitespace.
             If output_format = 'standard', return string with proper separators and whitespace.
-            If output_format = 'mask', Masks the first 8 digits as per MeitY guidelines for
+            If output_format = 'mask', mask the first 8 digits as per MeitY guidelines for
                 securing identity information and Sensitive personal data.
 
             (default: "standard")

--- a/dataprep/clean/clean_lv_pvn.py
+++ b/dataprep/clean/clean_lv_pvn.py
@@ -1,5 +1,5 @@
 """
-Clean and validate a DataFrame column containing Latvian PVN (VAT) numbers (PVTs).
+Clean and validate a DataFrame column containing Latvian PVN (VAT) numbers (PVNs).
 """
 # pylint: disable=too-many-lines, too-many-arguments, too-many-branches
 from typing import Any, Union
@@ -23,21 +23,21 @@ def clean_lv_pvn(
     progress: bool = True,
 ) -> pd.DataFrame:
     """
-    Clean Latvian PVN (VAT) numbers (PVTs) type data in a DataFrame column.
+    Clean Latvian PVN (VAT) numbers (PVNs) type data in a DataFrame column.
 
     Parameters
     ----------
         df
             A pandas or Dask DataFrame containing the data to be cleaned.
         col
-            The name of the column containing data of PVT type.
+            The name of the column containing data of PVN type.
         output_format
             The output format of standardized number string.
             If output_format = 'compact', return string without any separators or whitespace.
             If output_format = 'standard', return string with proper separators and whitespace.
             If output_format = 'birthdate', return the birthdate of the person. Note only when
                 PVN refers to a person (but not a legal entity) this format will be available.
-            Note: in the case of PVT, the compact format is the same as the standard one.
+            Note: in the case of PVN, the compact format is the same as the standard one.
 
             (default: "standard")
         inplace
@@ -59,7 +59,7 @@ def clean_lv_pvn(
 
     Examples
     --------
-    Clean a column of PVT data.
+    Clean a column of PVN data.
 
     >>> df = pd.DataFrame({{
             "pvn": [
@@ -114,7 +114,7 @@ def validate_lv_pvn(
     column: str = "",
 ) -> Union[bool, pd.Series, pd.DataFrame]:
     """
-    Validate if a data cell is PVT in a DataFrame column. For each cell, return True or False.
+    Validate if a data cell is PVN in a DataFrame column. For each cell, return True or False.
 
     Parameters
     ----------
@@ -146,7 +146,7 @@ def _format(val: Any, output_format: str = "standard", errors: str = "coarse") -
            If output_format = 'standard', return string with proper separators and whitespace.
            If output_format = 'birthdate', return the birthdate of the person. Note only when
                 PVN refers to a person (but not a legal entity) this format will be available.
-           Note: in the case of PVT, the compact format is the same as the standard one.
+           Note: in the case of PVN, the compact format is the same as the standard one.
     """
     # pylint: disable=bare-except
 

--- a/dataprep/clean/clean_no_fodselsnummer.py
+++ b/dataprep/clean/clean_no_fodselsnummer.py
@@ -23,7 +23,7 @@ def clean_no_fodselsnummer(
     progress: bool = True,
 ) -> pd.DataFrame:
     """
-    Clean Estonian Personcal ID number type data in a DataFrame column.
+    Clean Norwegian birth number data in a DataFrame column.
 
     Parameters
     ----------

--- a/dataprep/clean/clean_no_iban.py
+++ b/dataprep/clean/clean_no_iban.py
@@ -59,7 +59,7 @@ def clean_no_iban(
     --------
     Clean a column of IBAN data.
 
-    >>> df = pd.DataFrame({{
+    >>> df = pd.DataFrame({
             "iban": [
             'NO9386011117947',
             'NO92 8601 1117 947',]

--- a/dataprep/clean/clean_no_kontonr.py
+++ b/dataprep/clean/clean_no_kontonr.py
@@ -59,7 +59,7 @@ def clean_no_kontonr(
     --------
     Clean a column of kontonr data.
 
-    >>> df = pd.DataFrame({{
+    >>> df = pd.DataFrame({
             "kontonr": [
             "8601 11 17947",
             "8601 11 17949",]

--- a/dataprep/clean/clean_no_orgnr.py
+++ b/dataprep/clean/clean_no_orgnr.py
@@ -58,7 +58,7 @@ def clean_no_orgnr(
     --------
     Clean a column of Orgnr data.
 
-    >>> df = pd.DataFrame({{
+    >>> df = pd.DataFrame({
             "orgnr": [
             "988077917",
             "988 077 918",]

--- a/dataprep/clean/clean_nz_bankaccount.py
+++ b/dataprep/clean/clean_nz_bankaccount.py
@@ -60,10 +60,10 @@ def clean_nz_bankaccount(
     --------
     Clean a column of bankaccount data.
 
-    >>> df = pd.DataFrame({{
+    >>> df = pd.DataFrame({
             "bankaccount": [
-            "51824753556",
-            "99999999999",]
+            "0102420100194000",
+            "01-0242-0100195-00",]
             })
     >>> clean_nz_bankaccount(df, 'bankaccount')
             bankaccount              bankaccount_clean

--- a/dataprep/clean/clean_nz_ird.py
+++ b/dataprep/clean/clean_nz_ird.py
@@ -58,7 +58,7 @@ def clean_nz_ird(
     --------
     Clean a column of IRD data.
 
-    >>> df = pd.DataFrame({{
+    >>> df = pd.DataFrame({
             "ird": [
             "49091850",
             "136410133",]

--- a/dataprep/clean/clean_pl_regon.py
+++ b/dataprep/clean/clean_pl_regon.py
@@ -59,7 +59,7 @@ def clean_pl_regon(
     --------
     Clean a column of REGON data.
 
-    >>> df = pd.DataFrame({{
+    >>> df = pd.DataFrame({
             "regon": [
             '192598184',
             '192598183',]

--- a/dataprep/clean/clean_pt_nif.py
+++ b/dataprep/clean/clean_pt_nif.py
@@ -59,14 +59,14 @@ def clean_pt_nif(
     --------
     Clean a column of NIF data.
 
-    >>> df = pd.DataFrame({{
+    >>> df = pd.DataFrame({
             "nif": [
             'PT 501 964 843',
             'PT 501 964 842',]
             })
     >>> clean_pt_nif(df, 'nif')
             nif                 nif_clean
-    0       PT 501 964 843      PT 501 964 843
+    0       PT 501 964 843      501964843
     1       PT 501 964 842      NaN
     """
 

--- a/dataprep/clean/clean_py_ruc.py
+++ b/dataprep/clean/clean_py_ruc.py
@@ -58,7 +58,7 @@ def clean_py_ruc(
     --------
     Clean a column of RUC data.
 
-    >>> df = pd.DataFrame({{
+    >>> df = pd.DataFrame({
             "ruc": [
             "800000358",
             "80123456789",]

--- a/dataprep/clean/clean_ro_cf.py
+++ b/dataprep/clean/clean_ro_cf.py
@@ -1,5 +1,5 @@
 """
-Clean and validate a DataFrame column containing Romanian CF (CF) numbers (CFs).
+Clean and validate a DataFrame column containing Romanian CF (VAT) numbers (CFs).
 """
 # pylint: disable=too-many-lines, too-many-arguments, too-many-branches
 from typing import Any, Union
@@ -23,7 +23,7 @@ def clean_ro_cf(
     progress: bool = True,
 ) -> pd.DataFrame:
     """
-    Clean Romanian CF (CF) numbers (CFs) type data in a DataFrame column.
+    Clean Romanian CF (VAT) numbers (CFs) type data in a DataFrame column.
 
     Parameters
     ----------

--- a/dataprep/clean/clean_ro_onrc.py
+++ b/dataprep/clean/clean_ro_onrc.py
@@ -59,7 +59,7 @@ def clean_ro_onrc(
     --------
     Clean a column of ONRC data.
 
-    >>> df = pd.DataFrame({{
+    >>> df = pd.DataFrame({
             "onrc": [
             "J52/750/2012",
             "X52/750/2012",]

--- a/docs/source/api_reference/dataprep.clean.rst
+++ b/docs/source/api_reference/dataprep.clean.rst
@@ -91,14 +91,1011 @@ US Street Addresses
    :undoc-members:
    :show-inheritance:
 
-<<<<<<< HEAD
-  
-=======
-ISBN Strings
--------------------
+Australian Business Numbers
+---------------------------
 
-.. automodule:: dataprep.clean.clean_isbn
+.. automodule:: dataprep.clean.clean_au_abn
    :members:
    :undoc-members:
    :show-inheritance:
->>>>>>> e9afded... feat/17_clean_functions
+
+Australian Company Numbers
+--------------------------
+
+.. automodule:: dataprep.clean.clean_au_acn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Australian Tax File Numbers
+---------------------------
+
+.. automodule:: dataprep.clean.clean_au_tfn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Belgian VAT Numbers
+-------------------
+
+.. automodule:: dataprep.clean.clean_be_vat
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Bulgarian National Identification Numbers
+-----------------------------------------
+
+.. automodule:: dataprep.clean.clean_bg_egn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Bulgarian VAT Numbers
+---------------------
+
+.. automodule:: dataprep.clean.clean_bg_vat
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Belarusian UNP Numbers
+----------------------
+
+.. automodule:: dataprep.clean.clean_by_unp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Canadian Business Numbers
+-------------------------
+
+.. automodule:: dataprep.clean.clean_ca_bn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Swiss Einzahlungsschein MIT Referenznummers
+-------------------------------------------
+
+.. automodule:: dataprep.clean.clean_ch_esr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Swiss Social Security Numbers
+-----------------------------
+
+.. automodule:: dataprep.clean.clean_ch_ssn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Swiss Business Identifiers
+--------------------------
+
+.. automodule:: dataprep.clean.clean_ch_uid
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Swiss VAT Numbers
+-----------------
+
+.. automodule:: dataprep.clean.clean_ch_vat
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Chile RUT/RUN Numbers
+---------------------
+
+.. automodule:: dataprep.clean.clean_cl_rut
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Chinese Resident Identity Card Numbers
+--------------------------------------
+
+.. automodule:: dataprep.clean.clean_cn_ric
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Colombian Identity Codes
+------------------------
+
+.. automodule:: dataprep.clean.clean_co_nit
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Costa Rica Physical Person ID Numbers
+-------------------------------------
+
+.. automodule:: dataprep.clean.clean_cr_cpf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Costa Rica Tax Numbers
+----------------------
+
+.. automodule:: dataprep.clean.clean_cr_cpj
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Costa Rica Foreigners ID Numbers
+--------------------------------
+
+.. automodule:: dataprep.clean.clean_cr_cr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Cuban Identity Card Numbers
+---------------------------
+
+.. automodule:: dataprep.clean.clean_cu_ni
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Cypriot VAT Numbers
+-------------------
+
+.. automodule:: dataprep.clean.clean_cy_vat
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Czech VAT Numbers
+-----------------
+
+.. automodule:: dataprep.clean.clean_cz_dic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Czech Birth Numbers
+-------------------
+
+.. automodule:: dataprep.clean.clean_cz_rc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+German Company Registry IDs
+---------------------------
+
+.. automodule:: dataprep.clean.clean_de_handelsregisternummer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+German Personal Tax Numbers
+---------------------------
+
+.. automodule:: dataprep.clean.clean_de_idnr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+German Tax Numbers
+------------------
+
+.. automodule:: dataprep.clean.clean_de_stnr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+German VAT Numbers
+------------------
+
+.. automodule:: dataprep.clean.clean_de_vat
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+German Securities Identification Codes
+---------------------
+
+.. automodule:: dataprep.clean.clean_de_wkn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Danish Citizen Numbers
+----------------------
+
+.. automodule:: dataprep.clean.clean_dk_cpr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Danish CVR Numbers
+------------------
+
+.. automodule:: dataprep.clean.clean_dk_cvr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Dominican Republic National Identifiers
+---------------------------------------
+
+.. automodule:: dataprep.clean.clean_do_cedula
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Dominican Republic Invoice Numbers
+----------------------------------
+
+.. automodule:: dataprep.clean.clean_do_ncf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Dominican Republic Tax Registrations
+------------------------------------
+
+.. automodule:: dataprep.clean.clean_do_rnc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Ecuadorian Personal Identity Codes
+----------------------------------
+
+.. automodule:: dataprep.clean.clean_ec_ci
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Ecuadorian Company Tax Numbers
+------------------------------
+
+.. automodule:: dataprep.clean.clean_ec_ruc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Estonian Personcal ID Numbers
+-----------------------------
+
+.. automodule:: dataprep.clean.clean_ee_ik
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Estonian KMKR Numbers
+---------------------
+
+.. automodule:: dataprep.clean.clean_ee_kmkr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Spanish Bank Account Codes
+--------------------------
+
+.. automodule:: dataprep.clean.clean_es_ccc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Spanish Fiscal Numbers
+----------------------
+
+.. automodule:: dataprep.clean.clean_es_cif
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Spanish Meter Point Numbers
+---------------------------
+
+.. automodule:: dataprep.clean.clean_es_cups
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Spanish Personal Identity Codes
+-------------------------------
+
+.. automodule:: dataprep.clean.clean_es_dni
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Spanish IBANs
+-------------
+
+.. automodule:: dataprep.clean.clean_es_iban
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Spanish Foreigner Identity Codes
+--------------------------------
+
+.. automodule:: dataprep.clean.clean_es_nie
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Spanish NIF Numbers
+-------------------
+
+.. automodule:: dataprep.clean.clean_es_nif
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Classification For Businesses In The European Union
+---------------------------------------------------
+
+.. automodule:: dataprep.clean.clean_eu_nace
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+European VAT Numbers
+--------------------
+
+.. automodule:: dataprep.clean.clean_eu_vat
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Finnish ALV Numbers
+-------------------
+
+.. automodule:: dataprep.clean.clean_fi_alv
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Finnish Personal Identity Codes
+-------------------------------
+
+.. automodule:: dataprep.clean.clean_fi_hetu
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Finnish Business Identifiers
+----------------------------
+
+.. automodule:: dataprep.clean.clean_fi_ytunnus
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+French Tax Identification Numbers
+---------------------------------
+
+.. automodule:: dataprep.clean.clean_fr_nif
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+French Personal Identification Numbers
+--------------------------------------
+
+.. automodule:: dataprep.clean.clean_fr_nir
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+French Company Identification Numbers
+-------------------------------------
+
+.. automodule:: dataprep.clean.clean_fr_siren
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+French TVA Numbers
+------------------
+
+.. automodule:: dataprep.clean.clean_fr_tva
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Stock Exchange Daily Official List Numbers
+------------------------------------------
+
+.. automodule:: dataprep.clean.clean_gb_sedol
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+English Unique Pupil Numbers
+----------------------------
+
+.. automodule:: dataprep.clean.clean_gb_upn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+United Kingdom Unique Taxpayer References
+-----------------------------------------
+
+.. automodule:: dataprep.clean.clean_gb_utr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+United Kingdom VAT Numbers
+--------------------------
+
+.. automodule:: dataprep.clean.clean_gb_vat
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Greek Social Security Numbers
+-----------------------------
+
+.. automodule:: dataprep.clean.clean_gr_amka
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Greek VAT Numbers
+-----------------
+
+.. automodule:: dataprep.clean.clean_gr_vat
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Guatemala Tax Numbers
+---------------------
+
+.. automodule:: dataprep.clean.clean_gt_nit
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Croatian Identification Numbers
+-------------------------------
+
+.. automodule:: dataprep.clean.clean_hr_oib
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Hungarian ANUM Numbers
+----------------------
+
+.. automodule:: dataprep.clean.clean_hu_anum
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Indonesian VAT Numbers
+----------------------
+
+.. automodule:: dataprep.clean.clean_id_npwp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Irish Personal Numbers
+----------------------
+
+.. automodule:: dataprep.clean.clean_ie_pps
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Irish VAT Numbers
+-----------------
+
+.. automodule:: dataprep.clean.clean_ie_vat
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Israeli Company Numbers
+-----------------------
+
+.. automodule:: dataprep.clean.clean_il_hp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Israeli Personal Numbers
+------------------------
+
+.. automodule:: dataprep.clean.clean_il_idnr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Indian Digital Resident Personal Identity Numbers
+-------------------------------------------------
+
+.. automodule:: dataprep.clean.clean_in_aadhaar
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Indian Permanent Account Numbers
+--------------------------------
+
+.. automodule:: dataprep.clean.clean_in_pan
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Icelandic Identity Codes
+------------------------
+
+.. automodule:: dataprep.clean.clean_is_kennitala
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Icelandic VSK Numbers
+---------------------
+
+.. automodule:: dataprep.clean.clean_is_vsk
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Italian Code For Identification Of Drugs
+----------------------------------------
+
+.. automodule:: dataprep.clean.clean_it_aic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Italian Fiscal Codes
+--------------------
+
+.. automodule:: dataprep.clean.clean_it_codicefiscale
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Italian IVA Numbers
+-------------------
+
+.. automodule:: dataprep.clean.clean_it_iva
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Japanese Corporate Numbers
+--------------------------
+
+.. automodule:: dataprep.clean.clean_jp_cn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+South Korea Business Registration Numbers
+-----------------------------------------
+
+.. automodule:: dataprep.clean.clean_kr_brn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+South Korean Resident Registration Numbers
+------------------------------------------
+
+.. automodule:: dataprep.clean.clean_kr_rrn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Liechtenstein Tax Code For Individuals And Entities
+---------------------------------------------------
+
+.. automodule:: dataprep.clean.clean_li_peid
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Lithuanian Personal Numbers
+---------------------------
+
+.. automodule:: dataprep.clean.clean_lt_asmens
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Lithuanian PVM Numbers
+----------------------
+
+.. automodule:: dataprep.clean.clean_lt_pvm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Luxembourgian TVA Numbers
+-------------------------
+
+.. automodule:: dataprep.clean.clean_lu_tva
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Latvian PVN (VAT) Numbers
+-------------------------
+
+.. automodule:: dataprep.clean.clean_lv_pvn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Monacan TVA Numbers
+-------------------
+
+.. automodule:: dataprep.clean.clean_mc_tva
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Moldavian Company Identification Numbers
+----------------------------------------
+
+.. automodule:: dataprep.clean.clean_md_idno
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Montenegro IBANs
+----------------
+
+.. automodule:: dataprep.clean.clean_me_iban
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Maltese VAT Numbers
+-------------------
+
+.. automodule:: dataprep.clean.clean_mt_vat
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Mauritian National ID Numbers
+-----------------------------
+
+.. automodule:: dataprep.clean.clean_mu_nid
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Mexican Personal Identifiers
+----------------------------
+
+.. automodule:: dataprep.clean.clean_mx_curp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Mexican Tax Numbers
+-------------------
+
+.. automodule:: dataprep.clean.clean_mx_rfc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Malaysian National Registration Identity Card Numbers
+-----------------------------------------------------
+
+.. automodule:: dataprep.clean.clean_my_nric
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+BRIN Numbers
+------------
+
+.. automodule:: dataprep.clean.clean_nl_brin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Dutch BTW Numbers
+-----------------
+
+.. automodule:: dataprep.clean.clean_nl_btw
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Norwegian IBANs
+---------------
+
+.. automodule:: dataprep.clean.clean_no_iban
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Norwegian Bank Account Numbers
+------------------------------
+
+.. automodule:: dataprep.clean.clean_no_kontonr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Norwegian VAT Numbers
+---------------------
+
+.. automodule:: dataprep.clean.clean_no_mva
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Norwegian Organisation Numbers
+------------------------------
+
+.. automodule:: dataprep.clean.clean_no_orgnr
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+New Zealand IRD Numbers
+-----------------------
+
+.. automodule:: dataprep.clean.clean_nz_ird
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Peruvian Personal Numbers
+-------------------------
+
+.. automodule:: dataprep.clean.clean_pe_cui
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Peruvian Fiscal Numbers
+-----------------------
+
+.. automodule:: dataprep.clean.clean_pe_ruc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Polish VAT Numbers
+------------------
+
+.. automodule:: dataprep.clean.clean_pl_nip
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Polish National Identification Numbers
+--------------------------------------
+
+.. automodule:: dataprep.clean.clean_pl_pesel
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Polish Register Of Economic Units
+---------------------------------
+
+.. automodule:: dataprep.clean.clean_pl_regon
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Portuguese NIF Numbers
+----------------------
+
+.. automodule:: dataprep.clean.clean_pt_nif
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Paraguay RUC Numbers
+--------------------
+
+.. automodule:: dataprep.clean.clean_py_ruc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Romanian CF (VAT) Numbers
+-------------------------
+
+.. automodule:: dataprep.clean.clean_ro_cf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Romanian Numerical Personal Codes
+---------------------------------
+
+.. automodule:: dataprep.clean.clean_ro_cnp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Romanian Company Identifiers
+----------------------------
+
+.. automodule:: dataprep.clean.clean_ro_cui
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Romanian Trade Register Identifiers
+-----------------------------------
+
+.. automodule:: dataprep.clean.clean_ro_onrc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+French Company Establishment Identification Numbers
+---------------------------------------------------
+
+.. automodule:: dataprep.clean.clean_fr_siret
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+United Kingdom National Health Service Patient Identifiers
+----------------------------------------------------------
+
+.. automodule:: dataprep.clean.clean_gb_nhs
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Dutch Citizen Identification Numbers
+------------------------------------
+
+.. automodule:: dataprep.clean.clean_nl_bsn
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Dutch Student Identification Numbers
+------------------------------------
+
+.. automodule:: dataprep.clean.clean_nl_onderwijsnummer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Belgian IBANs
+-------------
+
+.. automodule:: dataprep.clean.clean_be_iban
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Bulgarian Personal Numbers
+--------------------------
+
+.. automodule:: dataprep.clean.clean_bg_pnf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Brazilian Company Identifiers
+-----------------------------
+
+.. automodule:: dataprep.clean.clean_br_cnpj
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Brazilian National Identifiers
+------------------------------
+
+.. automodule:: dataprep.clean.clean_br_cpf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Canadian Social Insurance Numbers
+---------------------------------
+
+.. automodule:: dataprep.clean.clean_ca_sin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Chinese Unified Social Credit Codes
+-----------------------------------
+
+.. automodule:: dataprep.clean.clean_cn_uscc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Estonian Organisation Registration Codes
+----------------------------------------
+
+.. automodule:: dataprep.clean.clean_ee_registrikood
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Spanish Real State IDs
+----------------------
+
+.. automodule:: dataprep.clean.clean_es_referenciacatastral
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Euro Banknote Serial Numbers
+----------------------------
+
+.. automodule:: dataprep.clean.clean_eu_banknote
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+European Energy Identification Codes
+------------------------------------
+
+.. automodule:: dataprep.clean.clean_eu_eic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Finnish Association Registry IDs
+--------------------------------
+
+.. automodule:: dataprep.clean.clean_fi_associationid
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Finnish Individual Tax Numbers
+------------------------------
+
+.. automodule:: dataprep.clean.clean_fi_veronumero
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Dutch Postal Codes
+------------------
+
+.. automodule:: dataprep.clean.clean_nl_postcode
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Norwegian Birth Numbers
+-----------------------
+
+.. automodule:: dataprep.clean.clean_no_fodselsnummer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+New Zealand Bank Account Numbers
+--------------------------------
+
+.. automodule:: dataprep.clean.clean_nz_bankaccount
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/source/user_guide/clean/clean_au_abn.ipynb
+++ b/docs/source/user_guide/clean/clean_au_abn.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _abn_userguide:\n",
+    "\n",
+    "ABN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_au_abn() <dataprep.clean.clean_au_abn.clean_au_abn>` cleans a column containing Australian Business Number (ABN) strings, and standardizes them in a given format. The function :func:`validate_au_abn() <dataprep.clean.clean_au_abn.validate_au_abn>` validates either a single ABN strings, a column of ABN strings or a DataFrame of ABN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ABN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"51824753556\"\n",
+    "* `standard`: ABN strings with proper whitespace in the proper places, like \"51 824 753 556\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_au_abn()` and `validate_au_abn()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing ABN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"abn\": [\n",
+    "            \"83 914 571 673\",\n",
+    "            \"99 999 999 999\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_au_abn`\n",
+    "\n",
+    "By default, `clean_au_abn` will clean abn strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_au_abn\n",
+    "clean_au_abn(df, column = \"abn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_abn(df, column = \"abn\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_abn(df, column = \"abn\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned ABN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_abn(df, column=\"abn\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_abn(df, \"abn\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_abn(df, \"abn\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_au_abn()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_au_abn()` returns `True` when the input is a valid ABN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_au_abn()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_au_abn()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_au_abn()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_au_abn\n",
+    "print(validate_au_abn(\"83 914 571 673\"))\n",
+    "print(validate_au_abn(\"99 999 999 999\"))\n",
+    "print(validate_au_abn(\"51824753556\"))\n",
+    "print(validate_au_abn(\"51 824 753 556\"))\n",
+    "print(validate_au_abn(\"hello\"))\n",
+    "print(validate_au_abn(np.nan))\n",
+    "print(validate_au_abn(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_au_abn(df[\"abn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_au_abn(df, column=\"abn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_au_abn(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_au_acn.ipynb
+++ b/docs/source/user_guide/clean/clean_au_acn.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _acn_userguide:\n",
+    "\n",
+    "ACN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_au_acn() <dataprep.clean.clean_au_acn.clean_au_acn>` cleans a column containing Australian Company Number (ACN) strings, and standardizes them in a given format. The function :func:`validate_au_acn() <dataprep.clean.clean_au_acn.validate_au_acn>` validates either a single ACN strings, a column of ACN strings or a DataFrame of ACN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ACN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"004085616\"\n",
+    "* `standard`: ACN strings with proper whitespace in the proper places, like \"004 085 616\"\n",
+    "* `abn`: convert the number to an Australian Business Number (ABN) in compact format, like \"53004085616\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_au_acn()` and `validate_au_acn()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing ACN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"acn\": [\n",
+    "            \"004 085 616\",\n",
+    "            \"010 499 966\",\n",
+    "            \"999 999 999\",\n",
+    "            \"004085616\",\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_au_acn`\n",
+    "\n",
+    "By default, `clean_au_acn` will clean acn strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_au_acn\n",
+    "clean_au_acn(df, column = \"acn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_acn(df, column = \"acn\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_acn(df, column = \"acn\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `abn`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_acn(df, column = \"acn\", output_format=\"abn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned ACN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_acn(df, column=\"acn\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_acn(df, \"acn\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_acn(df, \"acn\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_au_acn()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_au_acn()` returns `True` when the input is a valid ACN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_au_acn()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_au_acn()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_au_acn()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_au_acn\n",
+    "print(validate_au_acn(\"004 085 616\"))\n",
+    "print(validate_au_acn(\"010 499 966\"))\n",
+    "print(validate_au_acn(\"999 999 999\"))\n",
+    "print(validate_au_acn(\"51824753556\"))\n",
+    "print(validate_au_acn(\"004085616\"))\n",
+    "print(validate_au_acn(\"hello\"))\n",
+    "print(validate_au_acn(np.nan))\n",
+    "print(validate_au_acn(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_au_acn(df[\"acn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_au_acn(df, column=\"acn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_au_acn(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_au_tfn.ipynb
+++ b/docs/source/user_guide/clean/clean_au_tfn.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _tfn_userguide:\n",
+    "\n",
+    "TFN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_au_tfn() <dataprep.clean.clean_au_tfn.clean_au_tfn>` cleans a column containing Australian Tax File Numbers (TFN) strings, and standardizes them in a given format. The function :func:`validate_au_tfn() <dataprep.clean.clean_au_tfn.validate_au_tfn>` validates either a single TFN strings, a column of TFN strings or a DataFrame of TFN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TFN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"123456782\"\n",
+    "* `standard`: TFN strings with proper whitespace in the proper places, like \"123 456 782\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_au_tfn()` and `validate_au_tfn()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing TFN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"tfn\": [\n",
+    "            \"123 456 782\",\n",
+    "            \"999 999 999\",\n",
+    "            \"123456782\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_au_tfn`\n",
+    "\n",
+    "By default, `clean_au_tfn` will clean tfn strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_au_tfn\n",
+    "clean_au_tfn(df, column = \"tfn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_tfn(df, column = \"tfn\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_tfn(df, column = \"tfn\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned TFN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_tfn(df, column=\"tfn\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_tfn(df, \"tfn\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_au_tfn(df, \"tfn\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_au_tfn()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_au_tfn()` returns `True` when the input is a valid TFN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_au_tfn()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_au_tfn()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_au_tfn()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_au_tfn\n",
+    "print(validate_au_tfn(\"123 456 782\"))\n",
+    "print(validate_au_tfn(\"99 999 999\"))\n",
+    "print(validate_au_tfn(\"123456782\"))\n",
+    "print(validate_au_tfn(\"51 824 753 556\"))\n",
+    "print(validate_au_tfn(\"hello\"))\n",
+    "print(validate_au_tfn(np.nan))\n",
+    "print(validate_au_tfn(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_au_tfn(df[\"tfn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_au_tfn(df, column=\"tfn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_au_tfn(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_be_iban.ipynb
+++ b/docs/source/user_guide/clean/clean_be_iban.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _be_iban_userguide:\n",
+    "\n",
+    "Belgian IBAN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_be_iban() <dataprep.clean.clean_be_iban.clean_be_iban>` cleans a column containing Belgian IBAN (International Bank Account Number) strings, and standardizes them in a given format. The function :func:`validate_be_iban() <dataprep.clean.clean_be_iban.validate_be_iban>` validates either a single Belgian IBAN strings, a column of Belgian IBAN strings or a DataFrame of Belgian IBAN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Belgian IBAN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"BE32123456789002\"\n",
+    "* `standard`: Belgian IBAN strings with proper whitespace in the proper places, like \"BE32 1234 5678 9002\"\n",
+    "* `bic`: return the BIC for the bank that this number refers to, like \"CTBKBEBX\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_be_iban()` and `validate_be_iban()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing Belgian IBAN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"be_iban\": [\n",
+    "            \"BE32 123-4567890-02\",\n",
+    "            \"BE41091811735141\",             # incorrect national check digits\n",
+    "            \"BE83138811735115\",             # unknown bank code\n",
+    "            \"GR1601101050000010547023795\",  # not a Belgian IBAN\n",
+    "            \"BE 48 3200 7018 4927\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_be_iban`\n",
+    "\n",
+    "By default, `clean_be_iban` will clean be_iban strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_be_iban\n",
+    "clean_be_iban(df, column = \"be_iban\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_be_iban(df, column = \"be_iban\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_be_iban(df, column = \"be_iban\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `bic`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_be_iban(df, column = \"be_iban\", output_format=\"bic\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned Belgian IBAN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_be_iban(df, column=\"be_iban\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_be_iban(df, \"be_iban\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_be_iban(df, \"be_iban\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_be_iban()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_be_iban()` returns `True` when the input is a valid Belgian IBAN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_be_iban()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_be_iban()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_be_iban()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_be_iban\n",
+    "print(validate_be_iban(\"BE32 123-4567890-02\"))\n",
+    "print(validate_be_iban(\"BE41091811735141\"))\n",
+    "print(validate_be_iban(\"BE83138811735115\"))\n",
+    "print(validate_be_iban(\"GR1601101050000010547023795\"))\n",
+    "print(validate_be_iban(\"004085616\"))\n",
+    "print(validate_be_iban(\"hello\"))\n",
+    "print(validate_be_iban(np.nan))\n",
+    "print(validate_be_iban(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_be_iban(df[\"be_iban\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_be_iban(df, column=\"be_iban\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_be_iban(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_be_vat.ipynb
+++ b/docs/source/user_guide/clean/clean_be_vat.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _vat_userguide:\n",
+    "\n",
+    "VAT Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_be_vat() <dataprep.clean.clean_be_vat.clean_be_vat>` cleans a column containing Belgian VAT numbers (VAT) strings, and standardizes them in a given format. The function :func:`validate_be_vat() <dataprep.clean.clean_be_vat.validate_be_vat>` validates either a single VAT strings, a column of VAT strings or a DataFrame of VAT strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "VAT strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"0403019261\"\n",
+    "* `standard`: VAT strings with proper whitespace in the proper places. Note that in the case of VAT, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_be_vat()` and `validate_be_vat()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing VAT strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"vat\": [\n",
+    "            'BE403019261',\n",
+    "            '(0)403019261',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_be_vat`\n",
+    "\n",
+    "By default, `clean_be_vat` will clean vat strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_be_vat\n",
+    "clean_be_vat(df, column = \"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_be_vat(df, column = \"vat\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_be_vat(df, column = \"vat\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned VAT strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_be_vat(df, column=\"vat\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_be_vat(df, \"vat\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_be_vat(df, \"vat\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_be_vat()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_be_vat()` returns `True` when the input is a valid VAT. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_be_vat()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_be_vat()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_be_vat()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_be_vat\n",
+    "print(validate_be_vat(\"BE403019261\"))\n",
+    "print(validate_be_vat(\"(0)403019261\"))\n",
+    "print(validate_be_vat('BE 428759497'))\n",
+    "print(validate_be_vat('BE431150351'))\n",
+    "print(validate_be_vat(\"004085616\"))\n",
+    "print(validate_be_vat(\"hello\"))\n",
+    "print(validate_be_vat(np.nan))\n",
+    "print(validate_be_vat(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_be_vat(df[\"vat\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_be_vat(df, column=\"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_be_vat(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_bg_egn.ipynb
+++ b/docs/source/user_guide/clean/clean_bg_egn.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _egn_userguide:\n",
+    "\n",
+    "EGN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_bg_egn() <dataprep.clean.clean_bg_egn.clean_bg_egn>` cleans a column containing Bulgarian national identification numbers (EGN) strings, and standardizes them in a given format. The function :func:`validate_bg_egn() <dataprep.clean.clean_bg_egn.validate_bg_egn>` validates either a single EGN strings, a column of EGN strings or a DataFrame of EGN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "EGN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"7523169263\"\n",
+    "* `standard`: EGN strings with proper whitespace in the proper places. Note that in the case of EGN, the compact format is the same as the standard one.\n",
+    "* `birthdate`: split the date parts from the number and return the birth date, like \"1875-03-16\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_bg_egn()` and `validate_bg_egn()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing EGN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"egn\": [\n",
+    "            '752316 926 3',\n",
+    "            '8032056031',\n",
+    "            '7542011030',\n",
+    "            '7552A10004',  # invalid digit\n",
+    "            '8019010008',  # invalid date\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_bg_egn`\n",
+    "\n",
+    "By default, `clean_bg_egn` will clean egn strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_bg_egn\n",
+    "clean_bg_egn(df, column = \"egn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_egn(df, column = \"egn\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_egn(df, column = \"egn\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_egn(df, column = \"egn\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned EGN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_egn(df, column=\"egn\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_egn(df, \"egn\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_egn(df, \"egn\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_bg_egn()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_bg_egn()` returns `True` when the input is a valid EGN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_bg_egn()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_bg_egn()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_bg_egn()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_bg_egn\n",
+    "print(validate_bg_egn(' 752316 926 3'))\n",
+    "print(validate_bg_egn('8032056031'))\n",
+    "print(validate_bg_egn('7542011030'))\n",
+    "print(validate_bg_egn('7552A10004'))\n",
+    "print(validate_bg_egn('8019010008'))\n",
+    "print(validate_bg_egn(\"hello\"))\n",
+    "print(validate_bg_egn(np.nan))\n",
+    "print(validate_bg_egn(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_bg_egn(df[\"egn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_bg_egn(df, column=\"egn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_bg_egn(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_bg_pnf.ipynb
+++ b/docs/source/user_guide/clean/clean_bg_pnf.ipynb
@@ -1,0 +1,318 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _pnf_userguide:\n",
+    "\n",
+    "PNF Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_bg_pnf() <dataprep.clean.clean_bg_pnf.clean_bg_pnf>` cleans a column containing Bulgarian personal number of a foreigner, and standardizes them in a given format. The function :func:`validate_bg_pnf() <dataprep.clean.clean_bg_pnf.validate_bg_pnf>` validates either a single PNF strings, a column of PNF strings or a DataFrame of PNF strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "PNF strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"7111042925\"\n",
+    "* `standard`: PNF strings with proper whitespace in the proper places. Note that in the case of PNF, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_bg_pnf()` and `validate_bg_pnf()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing PNF strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"pnf\": [\n",
+    "            '7111 042 925',\n",
+    "            '7111042922',  # invalid check digit\n",
+    "            '71110A2922',  # invalid digit\n",
+    "            \"002 724 334\", # not PNF\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_bg_pnf`\n",
+    "\n",
+    "By default, `clean_bg_pnf` will clean pnf strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_bg_pnf\n",
+    "clean_bg_pnf(df, column = \"pnf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_pnf(df, column = \"pnf\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_pnf(df, column = \"pnf\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned PNF strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_pnf(df, column=\"pnf\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_pnf(df, \"pnf\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_pnf(df, \"pnf\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_bg_pnf()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_bg_pnf()` returns `True` when the input is a valid PNF. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_bg_pnf()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_bg_pnf()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_bg_pnf()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_bg_pnf\n",
+    "print(validate_bg_pnf('7111 042 925'))\n",
+    "print(validate_bg_pnf('7111042922'))\n",
+    "print(validate_bg_pnf('71110A2922' ))\n",
+    "print(validate_bg_pnf('BE431150351'))\n",
+    "print(validate_bg_pnf(\"004085616\"))\n",
+    "print(validate_bg_pnf(\"hello\"))\n",
+    "print(validate_bg_pnf(np.nan))\n",
+    "print(validate_bg_pnf(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_bg_pnf(df[\"pnf\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_bg_pnf(df, column=\"pnf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_bg_pnf(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_bg_vat.ipynb
+++ b/docs/source/user_guide/clean/clean_bg_vat.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _vat_userguide:\n",
+    "\n",
+    "VAT Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_bg_vat() <dataprep.clean.clean_bg_vat.clean_bg_vat>` cleans a column containing Bulgarian VAT numbers (VAT) strings, and standardizes them in a given format. The function :func:`validate_bg_vat() <dataprep.clean.clean_bg_vat.validate_bg_vat>` validates either a single VAT strings, a column of VAT strings or a DataFrame of VAT strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "VAT strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"175074752\"\n",
+    "* `standard`: VAT strings with proper whitespace in the proper places. Note that in the case of VAT, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_bg_vat()` and `validate_bg_vat()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing VAT strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"vat\": [\n",
+    "            'BG 175 074 752',\n",
+    "            '175074752',\n",
+    "            '175074751',    # invalid check digit\n",
+    "            'BE431150351',  # not Bulgarian VAT\n",
+    "            \"002 724 334\",  # not VAT\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_bg_vat`\n",
+    "\n",
+    "By default, `clean_bg_vat` will clean vat strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_bg_vat\n",
+    "clean_bg_vat(df, column = \"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_vat(df, column = \"vat\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_vat(df, column = \"vat\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned VAT strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_vat(df, column=\"vat\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_vat(df, \"vat\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_bg_vat(df, \"vat\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_bg_vat()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_bg_vat()` returns `True` when the input is a valid VAT. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_bg_vat()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_bg_vat()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_bg_vat()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_bg_vat\n",
+    "print(validate_bg_vat(\"BG 175 074 752\"))\n",
+    "print(validate_bg_vat(\"175074752\"))\n",
+    "print(validate_bg_vat('175074751'))\n",
+    "print(validate_bg_vat('BE431150351'))\n",
+    "print(validate_bg_vat(\"004085616\"))\n",
+    "print(validate_bg_vat(\"hello\"))\n",
+    "print(validate_bg_vat(np.nan))\n",
+    "print(validate_bg_vat(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_bg_vat(df[\"vat\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_bg_vat(df, column=\"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_bg_vat(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_br_cnpj.ipynb
+++ b/docs/source/user_guide/clean/clean_br_cnpj.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _cnpj_userguide:\n",
+    "\n",
+    "cnpj Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_br_cnpj() <dataprep.clean.clean_br_cnpj.clean_br_cnpj>` cleans a column containing Brazilian company identifier (CNPJ) strings, and standardizes them in a given format. The function :func:`validate_br_cnpj() <dataprep.clean.clean_br_cnpj.validate_br_cnpj>` validates either a single cnpj strings, a column of CNPJ strings or a DataFrame of CNPJ strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CNPJ strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"16727230000197\"\n",
+    "* `standard`: cnpj strings with proper whitespace in the proper places, like \"16.727.230/0001-97\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_br_cnpj()` and `validate_br_cnpj()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing cnpj strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"cnpj\": [\n",
+    "            \"16.727.230/0001-97\",\n",
+    "            \"16.727.230.0001-98\",\n",
+    "            \"16.727.230/0001=97\",\n",
+    "            \"16727230000197\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_br_cnpj`\n",
+    "\n",
+    "By default, `clean_br_cnpj` will clean cnpj strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_br_cnpj\n",
+    "clean_br_cnpj(df, column = \"cnpj\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_br_cnpj(df, column = \"cnpj\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_br_cnpj(df, column = \"cnpj\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CNPJ strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_br_cnpj(df, column=\"cnpj\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_br_cnpj(df, \"cnpj\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_br_cnpj(df, \"cnpj\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_br_cnpj()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_br_cnpj()` returns `True` when the input is a valid CNPJ. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_br_cnpj()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_br_cnpj()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_br_cnpj()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_br_cnpj\n",
+    "print(validate_br_cnpj('16.727.230/0001-97'))\n",
+    "print(validate_br_cnpj('16.727.230.0001-98'))\n",
+    "print(validate_br_cnpj('16.727.230/0001=97'))\n",
+    "print(validate_br_cnpj(\"51 824 753 556\"))\n",
+    "print(validate_br_cnpj(\"hello\"))\n",
+    "print(validate_br_cnpj(np.nan))\n",
+    "print(validate_br_cnpj(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_br_cnpj(df[\"cnpj\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_br_cnpj(df, column=\"cnpj\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_br_cnpj(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_br_cpf.ipynb
+++ b/docs/source/user_guide/clean/clean_br_cpf.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _cpf_userguide:\n",
+    "\n",
+    "cpf Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_br_cpf() <dataprep.clean.clean_br_cpf.clean_br_cpf>` cleans a column containing Brazilian national identifier (CPF) strings, and standardizes them in a given format. The function :func:`validate_br_cpf() <dataprep.clean.clean_br_cpf.validate_br_cpf>` validates either a single cpf strings, a column of CPF strings or a DataFrame of CPF strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CPF strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"39053344705\"\n",
+    "* `standard`: cpf strings with proper whitespace in the proper places, like \"390.533.447-05\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_br_cpf()` and `validate_br_cpf()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing cpf strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"cpf\": [\n",
+    "            '390.533.447-05',\n",
+    "            '231.002.999-00',\n",
+    "            '390.533.447=0',\n",
+    "            '23100299900',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_br_cpf`\n",
+    "\n",
+    "By default, `clean_br_cpf` will clean cpf strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_br_cpf\n",
+    "clean_br_cpf(df, column = \"cpf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_br_cpf(df, column = \"cpf\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_br_cpf(df, column = \"cpf\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CPF strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_br_cpf(df, column=\"cpf\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_br_cpf(df, \"cpf\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_br_cpf(df, \"cpf\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_br_cpf()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_br_cpf()` returns `True` when the input is a valid CPF. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_br_cpf()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_br_cpf()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_br_cpf()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_br_cpf\n",
+    "print(validate_br_cpf('390.533.447-05'))\n",
+    "print(validate_br_cpf('231.002.999-00'))\n",
+    "print(validate_br_cpf('390.533.447=0'))\n",
+    "print(validate_br_cpf('23100299900'))\n",
+    "print(validate_br_cpf(\"hello\"))\n",
+    "print(validate_br_cpf(np.nan))\n",
+    "print(validate_br_cpf(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_br_cpf(df[\"cpf\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_br_cpf(df, column=\"cpf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_br_cpf(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_by_unp.ipynb
+++ b/docs/source/user_guide/clean/clean_by_unp.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _unp_userguide:\n",
+    "\n",
+    "UNP Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_by_unp() <dataprep.clean.clean_by_unp.clean_by_unp>` cleans a column containing Belarusian UNP numbers (UNP) strings, and standardizes them in a given format. The function :func:`validate_by_unp() <dataprep.clean.clean_by_unp.validate_by_unp>` validates either a single UNP strings, a column of UNP strings or a DataFrame of UNP strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "UNP strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"MA1953684\"\n",
+    "* `standard`: UNP strings with proper whitespace in the proper places. Note that in the case of UNP, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_by_unp()` and `validate_by_unp()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing UNP strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"unp\": [\n",
+    "            '200988541',\n",
+    "            'УНП MA1953684',\n",
+    "            '200988542',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_by_unp`\n",
+    "\n",
+    "By default, `clean_by_unp` will clean unp strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_by_unp\n",
+    "clean_by_unp(df, column = \"unp\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_by_unp(df, column = \"unp\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_by_unp(df, column = \"unp\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned UNP strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_by_unp(df, column=\"unp\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_by_unp(df, \"unp\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_by_unp(df, \"unp\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_by_unp()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_by_unp()` returns `True` when the input is a valid UNP. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_by_unp()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_by_unp()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_by_unp()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_by_unp\n",
+    "print(validate_by_unp('200988541'))\n",
+    "print(validate_by_unp('УНП MA1953684'))\n",
+    "print(validate_by_unp('200988542'))\n",
+    "print(validate_by_unp('BE431150351'))\n",
+    "print(validate_by_unp(\"004085616\"))\n",
+    "print(validate_by_unp(\"hello\"))\n",
+    "print(validate_by_unp(np.nan))\n",
+    "print(validate_by_unp(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_by_unp(df[\"unp\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_by_unp(df, column=\"unp\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_by_unp(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ca_bn.ipynb
+++ b/docs/source/user_guide/clean/clean_ca_bn.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _bn_userguide:\n",
+    "\n",
+    "BN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ca_bn() <dataprep.clean.clean_ca_bn.clean_ca_bn>` cleans a column containing Canadian Business Number (BN) strings, and standardizes them in a given format. The function :func:`validate_ca_bn() <dataprep.clean.clean_ca_bn.validate_ca_bn>` validates either a single BN strings, a column of BN strings or a DataFrame of BN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "BN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"123026635\"\n",
+    "* `standard`: BN strings with proper whitespace in the proper places. Note: in the case of BN, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ca_bn()` and `validate_ca_bn()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing BN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"bn\": [\n",
+    "            \"12302 6635\",\n",
+    "            \"12302 6635 RC 0001\",\n",
+    "            \"12345678Z\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ca_bn`\n",
+    "\n",
+    "By default, `clean_ca_bn` will clean bn strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ca_bn\n",
+    "clean_ca_bn(df, column = \"bn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ca_bn(df, column = \"bn\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ca_bn(df, column = \"bn\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned BN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ca_bn(df, column=\"bn\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ca_bn(df, \"bn\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ca_bn(df, \"bn\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ca_bn()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ca_bn()` returns `True` when the input is a valid BN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ca_bn()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ca_bn()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ca_bn()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ca_bn\n",
+    "print(validate_ca_bn(\"12302 6635\"))\n",
+    "print(validate_ca_bn(\"12302 6635 RC 0001\"))\n",
+    "print(validate_ca_bn(\"12345678Z\"))\n",
+    "print(validate_ca_bn(\"51 824 753 556\"))\n",
+    "print(validate_ca_bn(\"hello\"))\n",
+    "print(validate_ca_bn(np.nan))\n",
+    "print(validate_ca_bn(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ca_bn(df[\"bn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ca_bn(df, column=\"bn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ca_bn(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ca_sin.ipynb
+++ b/docs/source/user_guide/clean/clean_ca_sin.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _sin_userguide:\n",
+    "\n",
+    "SIN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ca_sin() <dataprep.clean.clean_ca_sin.clean_ca_sin>` cleans a column containing Canadian Social Insurance Number (SIN) strings, and standardizes them in a given format. The function :func:`validate_ca_sin() <dataprep.clean.clean_ca_sin.validate_ca_sin>` validates either a single SIN strings, a column of SIN strings or a DataFrame of SIN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "SIN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"123456782\"\n",
+    "* `standard`: SIN strings with proper whitespace in the proper places, like \"123-456-782\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ca_sin()` and `validate_ca_sin()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing SIN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"sin\": [\n",
+    "            \"123456782\",\n",
+    "            \"12345678Z\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ca_sin`\n",
+    "\n",
+    "By default, `clean_ca_sin` will clean sin strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ca_sin\n",
+    "clean_ca_sin(df, column = \"sin\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ca_sin(df, column = \"sin\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ca_sin(df, column = \"sin\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned SIN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ca_sin(df, column=\"sin\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ca_sin(df, \"sin\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ca_sin(df, \"sin\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ca_sin()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ca_sin()` returns `True` when the input is a valid SIN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ca_sin()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ca_sin()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ca_sin()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ca_sin\n",
+    "print(validate_ca_sin(\"123456782\"))\n",
+    "print(validate_ca_sin(\"12345678Z\"))\n",
+    "print(validate_ca_sin(\"51824753556\"))\n",
+    "print(validate_ca_sin(\"51 824 753 556\"))\n",
+    "print(validate_ca_sin(\"hello\"))\n",
+    "print(validate_ca_sin(np.nan))\n",
+    "print(validate_ca_sin(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ca_sin(df[\"sin\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ca_sin(df, column=\"sin\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ca_sin(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ch_esr.ipynb
+++ b/docs/source/user_guide/clean/clean_ch_esr.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _esr_userguide:\n",
+    "\n",
+    "ESR Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ch_esr() <dataprep.clean.clean_ch_esr.clean_ch_esr>` cleans a column containing Swiss EinzahlungsSchein mit Referenznummer (ESR) strings, and standardizes them in a given format. The function :func:`validate_ch_esr() <dataprep.clean.clean_ch_esr.validate_ch_esr>` validates either a single ESR strings, a column of ESR strings or a DataFrame of ESR strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ESR strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"1878583\"\n",
+    "* `standard`: ESR strings with proper whitespace in the proper places, like \"00 00000 00000 00000 00018 78583\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ch_esr()` and `validate_ch_esr()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing ESR strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"esr\": [\n",
+    "            \"18 78583\",\n",
+    "            \"210000000003139471430009016\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ch_esr`\n",
+    "\n",
+    "By default, `clean_ch_esr` will clean esr strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ch_esr\n",
+    "clean_ch_esr(df, column = \"esr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_esr(df, column = \"esr\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_esr(df, column = \"esr\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned ESR strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_esr(df, column=\"esr\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_esr(df, \"esr\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_esr(df, \"esr\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ch_esr()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ch_esr()` returns `True` when the input is a valid ESR. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ch_esr()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ch_esr()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ch_esr()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ch_esr\n",
+    "print(validate_ch_esr(\"18 78583\"))\n",
+    "print(validate_ch_esr(\"210000000003139471430009016\"))\n",
+    "print(validate_ch_esr(\"51824753556\"))\n",
+    "print(validate_ch_esr(\"51 824 753 556\"))\n",
+    "print(validate_ch_esr(\"hello\"))\n",
+    "print(validate_ch_esr(np.nan))\n",
+    "print(validate_ch_esr(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ch_esr(df[\"esr\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ch_esr(df, column=\"esr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ch_esr(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ch_ssn.ipynb
+++ b/docs/source/user_guide/clean/clean_ch_ssn.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _ssn_userguide:\n",
+    "\n",
+    "SSN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ch_ssn() <dataprep.clean.clean_ch_ssn.clean_ch_ssn>` cleans a column containing Swiss social security number (SSN) strings, and standardizes them in a given format. The function :func:`validate_ch_ssn() <dataprep.clean.clean_ch_ssn.validate_ch_ssn>` validates either a single SSN strings, a column of SSN strings or a DataFrame of SSN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "SSN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"7569217076985\"\n",
+    "* `standard`: SSN strings with proper whitespace in the proper places, like \"756.9217.0769.85\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ch_ssn()` and `validate_ch_ssn()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing SSN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"ssn\": [\n",
+    "            \"7569217076985\",\n",
+    "            \"756.9217.0769.84\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ch_ssn`\n",
+    "\n",
+    "By default, `clean_ch_ssn` will clean ssn strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ch_ssn\n",
+    "clean_ch_ssn(df, column = \"ssn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_ssn(df, column = \"ssn\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_ssn(df, column = \"ssn\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned SSN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_ssn(df, column=\"ssn\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_ssn(df, \"ssn\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_ssn(df, \"ssn\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ch_ssn()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ch_ssn()` returns `True` when the input is a valid SSN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ch_ssn()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ch_ssn()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ch_ssn()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ch_ssn\n",
+    "print(validate_ch_ssn(\"7569217076985\"))\n",
+    "print(validate_ch_ssn(\"756.9217.0769.84\"))\n",
+    "print(validate_ch_ssn(\"51824753556\"))\n",
+    "print(validate_ch_ssn(\"51 824 753 556\"))\n",
+    "print(validate_ch_ssn(\"hello\"))\n",
+    "print(validate_ch_ssn(np.nan))\n",
+    "print(validate_ch_ssn(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ch_ssn(df[\"ssn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ch_ssn(df, column=\"ssn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ch_ssn(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ch_uid.ipynb
+++ b/docs/source/user_guide/clean/clean_ch_uid.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _uid_userguide:\n",
+    "\n",
+    "UID Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ch_uid() <dataprep.clean.clean_ch_uid.clean_ch_uid>` cleans a column containing Swiss business identifier (UID) strings, and standardizes them in a given format. The function :func:`validate_ch_uid() <dataprep.clean.clean_ch_uid.validate_ch_uid>` validates either a single UID strings, a column of UID strings or a DataFrame of UID strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "UID strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"CHE100155212\"\n",
+    "* `standard`: UID strings with proper whitespace in the proper places, like \"CHE-100.155.212\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ch_uid()` and `validate_ch_uid()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing UID strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"uid\": [\n",
+    "            \"CHE100155212\",\n",
+    "            \"CHE-100.155.213\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ch_uid`\n",
+    "\n",
+    "By default, `clean_ch_uid` will clean uid strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ch_uid\n",
+    "clean_ch_uid(df, column = \"uid\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_uid(df, column = \"uid\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_uid(df, column = \"uid\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned UID strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_uid(df, column=\"uid\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_uid(df, \"uid\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_uid(df, \"uid\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ch_uid()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ch_uid()` returns `True` when the input is a valid UID. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ch_uid()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ch_uid()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ch_uid()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ch_uid\n",
+    "print(validate_ch_uid(\"CHE100155212\"))\n",
+    "print(validate_ch_uid(\"CHE-100.155.213\"))\n",
+    "print(validate_ch_uid(\"51824753556\"))\n",
+    "print(validate_ch_uid(\"51 824 753 556\"))\n",
+    "print(validate_ch_uid(\"hello\"))\n",
+    "print(validate_ch_uid(np.nan))\n",
+    "print(validate_ch_uid(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ch_uid(df[\"uid\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ch_uid(df, column=\"uid\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ch_uid(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ch_vat.ipynb
+++ b/docs/source/user_guide/clean/clean_ch_vat.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _vat_userguide:\n",
+    "\n",
+    "VAT Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ch_vat() <dataprep.clean.clean_ch_vat.clean_ch_vat>` cleans a column containing Swiss VAT number (VAT) strings, and standardizes them in a given format. The function :func:`validate_ch_vat() <dataprep.clean.clean_ch_vat.validate_ch_vat>` validates either a single VAT strings, a column of VAT strings or a DataFrame of VAT strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "VAT strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"CHE107787577IVA'\"\n",
+    "* `standard`: VAT strings with proper whitespace in the proper places, like \"CHE-107.787.577 IVA\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ch_vat()` and `validate_ch_vat()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing VAT strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"vat\": [\n",
+    "            'CHE107787577IVA',\n",
+    "            'CHE-107.787.578 IVA',\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ch_vat`\n",
+    "\n",
+    "By default, `clean_ch_vat` will clean vat strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ch_vat\n",
+    "clean_ch_vat(df, column = \"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_vat(df, column = \"vat\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_vat(df, column = \"vat\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned VAT strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_vat(df, column=\"vat\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_vat(df, \"vat\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ch_vat(df, \"vat\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ch_vat()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ch_vat()` returns `True` when the input is a valid VAT. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ch_vat()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ch_vat()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ch_vat()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ch_vat\n",
+    "print(validate_ch_vat(\"CHE107787577IVA\"))\n",
+    "print(validate_ch_vat(\"CHE-107.787.578 IVA\"))\n",
+    "print(validate_ch_vat(\"51824753556\"))\n",
+    "print(validate_ch_vat(\"51 824 753 556\"))\n",
+    "print(validate_ch_vat(\"hello\"))\n",
+    "print(validate_ch_vat(np.nan))\n",
+    "print(validate_ch_vat(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ch_vat(df[\"vat\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ch_vat(df, column=\"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ch_vat(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_cl_rut.ipynb
+++ b/docs/source/user_guide/clean/clean_cl_rut.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _rut_userguide:\n",
+    "\n",
+    "RUT Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_cl_rut() <dataprep.clean.clean_cl_rut.clean_cl_rut>` cleans a column containing Chile RUT/RUN number (RUT) strings, and standardizes them in a given format. The function :func:`validate_cl_rut() <dataprep.clean.clean_cl_rut.validate_cl_rut>` validates either a single RUT strings, a column of RUT strings or a DataFrame of RUT strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RUT strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"125319092\"\n",
+    "* `standard`: RUT strings with proper whitespace in the proper places, like \"12.531.909-2\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_cl_rut()` and `validate_cl_rut()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing RUT strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"rut\": [\n",
+    "            \"125319092\",\n",
+    "            \"76086A28-5\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_cl_rut`\n",
+    "\n",
+    "By default, `clean_cl_rut` will clean rut strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_cl_rut\n",
+    "clean_cl_rut(df, column = \"rut\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cl_rut(df, column = \"rut\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cl_rut(df, column = \"rut\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned RUT strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cl_rut(df, column=\"rut\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cl_rut(df, \"rut\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cl_rut(df, \"rut\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_cl_rut()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_cl_rut()` returns `True` when the input is a valid RUT. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_cl_rut()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_cl_rut()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_cl_rut()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_cl_rut\n",
+    "print(validate_cl_rut(\"125319092\"))\n",
+    "print(validate_cl_rut(\"76086A28-5\"))\n",
+    "print(validate_cl_rut(\"51824753556\"))\n",
+    "print(validate_cl_rut(\"51 824 753 556\"))\n",
+    "print(validate_cl_rut(\"hello\"))\n",
+    "print(validate_cl_rut(np.nan))\n",
+    "print(validate_cl_rut(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cl_rut(df[\"rut\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cl_rut(df, column=\"rut\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cl_rut(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_cn_ric.ipynb
+++ b/docs/source/user_guide/clean/clean_cn_ric.ipynb
@@ -1,0 +1,351 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _ric_userguide:\n",
+    "\n",
+    "RIC Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_cn_ric() <dataprep.clean.clean_cn_ric.clean_cn_ric>` cleans a column containing Chinese Resident Identity Card Number (RIC) strings, and standardizes them in a given format. The function :func:`validate_cn_ric() <dataprep.clean.clean_cn_ric.validate_cn_ric>` validates either a single RIC strings, a column of RIC strings or a DataFrame of RIC strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RIC strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"360426199101010071\"\n",
+    "* `standard`: RIC strings with proper whitespace in the proper places. Note that in the case of RIC, the compact format is the same as the standard one\n",
+    "* `birthdate`: split the date parts from the number and return the birth date\n",
+    "* `birthplace`: use the number to look up the place of birth of the person\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_cn_ric()` and `validate_cn_ric()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing RIC strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"ric\": [\n",
+    "            '360426199101010071',\n",
+    "            '230306196304054513',\n",
+    "            '230307196304054513', # invalid\n",
+    "            '110223790813697', # not a RIC\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_cn_ric`\n",
+    "\n",
+    "By default, `clean_cn_ric` will clean ric strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_cn_ric\n",
+    "clean_cn_ric(df, column = \"ric\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cn_ric(df, column = \"ric\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cn_ric(df, column = \"ric\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cn_ric(df, column = \"ric\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthplace`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cn_ric(df, column = \"ric\", output_format=\"birthplace\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned RIC strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cn_ric(df, column=\"ric\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cn_ric(df, \"ric\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cn_ric(df, \"ric\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_cn_ric()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_cn_ric()` returns `True` when the input is a valid RIC. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_cn_ric()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_cn_ric()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_cn_ric()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_cn_ric\n",
+    "print(validate_cn_ric(\"230306196304054513\"))\n",
+    "print(validate_cn_ric(\"1234567\"))\n",
+    "print(validate_cn_ric(\"360426199101010071\"))\n",
+    "print(validate_cn_ric(\"360436199101010071\")) # change a bit and become invalid\n",
+    "print(validate_cn_ric(\"hello\"))\n",
+    "print(validate_cn_ric(np.nan))\n",
+    "print(validate_cn_ric(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cn_ric(df[\"ric\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cn_ric(df, column=\"ric\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cn_ric(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_cn_uscc.ipynb
+++ b/docs/source/user_guide/clean/clean_cn_uscc.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _uscc_userguide:\n",
+    "\n",
+    "USCC Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_cn_uscc() <dataprep.clean.clean_cn_uscc.clean_cn_uscc>` cleans a column containing Chinese Unified Social Credit Code (USCC) strings, and standardizes them in a given format. The function :func:`validate_cn_uscc() <dataprep.clean.clean_cn_uscc.validate_cn_uscc>` validates either a single USCC strings, a column of USCC strings or a DataFrame of USCC strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "USCC strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"91110000600037341L\"\n",
+    "* `standard`: USCC strings with proper whitespace in the proper places. Note that in the case of USCC, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_cn_uscc()` and `validate_cn_uscc()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing USCC strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"uscc\": [\n",
+    "            \"9 1 110000 600037341L\",\n",
+    "            \"A1110000600037341L\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_cn_uscc`\n",
+    "\n",
+    "By default, `clean_cn_uscc` will clean uscc strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_cn_uscc\n",
+    "clean_cn_uscc(df, column = \"uscc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cn_uscc(df, column = \"uscc\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cn_uscc(df, column = \"uscc\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned USCC strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cn_uscc(df, column=\"uscc\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cn_uscc(df, \"uscc\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cn_uscc(df, \"uscc\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_cn_uscc()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_cn_uscc()` returns `True` when the input is a valid USCC. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_cn_uscc()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_cn_uscc()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_cn_uscc()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_cn_uscc\n",
+    "print(validate_cn_uscc(\"9 1 110000 600037341L\"))\n",
+    "print(validate_cn_uscc(\"A1110000600037341L\"))\n",
+    "print(validate_cn_uscc(\"51824753556\"))\n",
+    "print(validate_cn_uscc(\"51 824 753 556\"))\n",
+    "print(validate_cn_uscc(\"hello\"))\n",
+    "print(validate_cn_uscc(np.nan))\n",
+    "print(validate_cn_uscc(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cn_uscc(df[\"uscc\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_cn_uscc(df, column=\"uscc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cn_uscc(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_co_nit.ipynb
+++ b/docs/source/user_guide/clean/clean_co_nit.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _nit_userguide:\n",
+    "\n",
+    "NIT Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_co_nit() <dataprep.clean.clean_co_nit.clean_co_nit>` cleans a column containing Colombian identity code (NIT) strings, and standardizes them in a given format. The function :func:`validate_co_nit() <dataprep.clean.clean_co_nit.validate_co_nit>` validates either a single NIT strings, a column of NIT strings or a DataFrame of NIT strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NIT strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"2131234321\"\n",
+    "* `standard`: NIT strings with proper whitespace in the proper places, like \"213.123.432-1\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_co_nit()` and `validate_co_nit()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing NIT strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"nit\": [\n",
+    "            \"2131234321\",\n",
+    "            \"2131234325\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_co_nit`\n",
+    "\n",
+    "By default, `clean_co_nit` will clean nit strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_co_nit\n",
+    "clean_co_nit(df, column = \"nit\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_co_nit(df, column = \"nit\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_co_nit(df, column = \"nit\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned NIT strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_co_nit(df, column=\"nit\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_co_nit(df, \"nit\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_co_nit(df, \"nit\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_co_nit()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_co_nit()` returns `True` when the input is a valid NIT. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_co_nit()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_co_nit()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_co_nit()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_co_nit\n",
+    "print(validate_co_nit(\"2131234321\"))\n",
+    "print(validate_co_nit(\"2131234325\"))\n",
+    "print(validate_co_nit(\"51824753556\"))\n",
+    "print(validate_co_nit(\"51 824 753 556\"))\n",
+    "print(validate_co_nit(\"hello\"))\n",
+    "print(validate_co_nit(np.nan))\n",
+    "print(validate_co_nit(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_co_nit(df[\"nit\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_co_nit(df, column=\"nit\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_co_nit(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_cr_cpf.ipynb
+++ b/docs/source/user_guide/clean/clean_cr_cpf.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _cpf_userguide:\n",
+    "\n",
+    "CPF Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_cr_cpf() <dataprep.clean.clean_cr_cpf.clean_cr_cpf>` cleans a column containing Costa Rica physical person ID number (CPF) strings, and standardizes them in a given format. The function :func:`validate_cr_cpf() <dataprep.clean.clean_cr_cpf.validate_cr_cpf>` validates either a single CPF strings, a column of CPF strings or a DataFrame of CPF strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CPF strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"0106130584\"\n",
+    "* `standard`: CPF strings with proper whitespace in the proper places, like \"01-0613-0584\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_cr_cpf()` and `validate_cr_cpf()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing CPF strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"cpf\": [\n",
+    "            \"1-613-584\",\n",
+    "            \"30-1234-1234\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_cr_cpf`\n",
+    "\n",
+    "By default, `clean_cr_cpf` will clean cpf strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_cr_cpf\n",
+    "clean_cr_cpf(df, column = \"cpf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cr_cpf(df, column = \"cpf\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cr_cpf(df, column = \"cpf\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CPF strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cr_cpf(df, column=\"cpf\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cr_cpf(df, \"cpf\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cr_cpf(df, \"cpf\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_cr_cpf()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_cr_cpf()` returns `True` when the input is a valid CPF. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_cr_cpf()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_cr_cpf()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_cr_cpf()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_cr_cpf\n",
+    "print(validate_cr_cpf(\"1-613-584\"))\n",
+    "print(validate_cr_cpf(\"30-1234-1234\"))\n",
+    "print(validate_cr_cpf(\"51824753556\"))\n",
+    "print(validate_cr_cpf(\"51 824 753 556\"))\n",
+    "print(validate_cr_cpf(\"hello\"))\n",
+    "print(validate_cr_cpf(np.nan))\n",
+    "print(validate_cr_cpf(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cr_cpf(df[\"cpf\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cr_cpf(df, column=\"cpf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cr_cpf(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_cr_cpj.ipynb
+++ b/docs/source/user_guide/clean/clean_cr_cpj.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _cpj_userguide:\n",
+    "\n",
+    "CPJ Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_cr_cpj() <dataprep.clean.clean_cr_cpj.clean_cr_cpj>` cleans a column containing Costa Rica tax number (CPJ) strings, and standardizes them in a given format. The function :func:`validate_cr_cpj() <dataprep.clean.clean_cr_cpj.validate_cr_cpj>` validates either a single CPJ strings, a column of CPJ strings or a DataFrame of CPJ strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CPJ strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"4000042138\"\n",
+    "* `standard`: CPJ strings with proper whitespace in the proper places, like \"4-000-042138\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_cr_cpj()` and `validate_cr_cpj()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing CPJ strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"cpj\": [\n",
+    "            \"4 000 042138\",\n",
+    "            \"3-534-123559\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_cr_cpj`\n",
+    "\n",
+    "By default, `clean_cr_cpj` will clean cpj strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_cr_cpj\n",
+    "clean_cr_cpj(df, column = \"cpj\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cr_cpj(df, column = \"cpj\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cr_cpj(df, column = \"cpj\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CPJ strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cr_cpj(df, column=\"cpj\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cr_cpj(df, \"cpj\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cr_cpj(df, \"cpj\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_cr_cpj()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_cr_cpj()` returns `True` when the input is a valid CPJ. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_cr_cpj()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_cr_cpj()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_cr_cpj()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_cr_cpj\n",
+    "print(validate_cr_cpj(\"4 000 042138\"))\n",
+    "print(validate_cr_cpj(\"3-534-123559\"))\n",
+    "print(validate_cr_cpj(\"51824753556\"))\n",
+    "print(validate_cr_cpj(\"51 824 753 556\"))\n",
+    "print(validate_cr_cpj(\"hello\"))\n",
+    "print(validate_cr_cpj(np.nan))\n",
+    "print(validate_cr_cpj(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cr_cpj(df[\"cpj\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cr_cpj(df, column=\"cpj\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_cr_cpj(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_cr_cr.ipynb
+++ b/docs/source/user_guide/clean/clean_cr_cr.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _cr_userguide:\n",
+    "\n",
+    "CR Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_cr_cr() <dataprep.clean.clean_cr_cr.clean_cr_cr>` cleans a column containing Costa Rica foreigners ID number (CR) strings, and standardizes them in a given format. The function :func:`validate_cr_cr() <dataprep.clean.clean_cr_cr.validate_cr_cr>` validates either a single CR strings, a column of CR strings or a DataFrame of CR strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CR strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"122200569906\"\n",
+    "* `standard`: CR strings with proper whitespace in the proper places. Note that in the case of CR, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_cr_cr()` and `validate_cr_cr()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing CR strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"cr\": [\n",
+    "            '122200569906',\n",
+    "            '12345678',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_cr_cr`\n",
+    "\n",
+    "By default, `clean_cr_cr` will clean cr strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_cr_cr\n",
+    "clean_cr_cr(df, column = \"cr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cr_cr(df, column = \"cr\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cr_cr(df, column = \"cr\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CR strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cr_cr(df, column=\"cr\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cr_cr(df, \"cr\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cr_cr(df, \"cr\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_cr_cr()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_cr_cr()` returns `True` when the input is a valid CR. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_cr_cr()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_cr_cr()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_cr_cr()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_cr_cr\n",
+    "print(validate_cr_cr(\"122200569906\"))\n",
+    "print(validate_cr_cr(\"12345678\"))\n",
+    "print(validate_cr_cr('BE 428759497'))\n",
+    "print(validate_cr_cr('BE431150351'))\n",
+    "print(validate_cr_cr(\"004085616\"))\n",
+    "print(validate_cr_cr(\"hello\"))\n",
+    "print(validate_cr_cr(np.nan))\n",
+    "print(validate_cr_cr(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cr_cr(df[\"cr\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cr_cr(df, column=\"cr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_cr_cr(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_cu_ni.ipynb
+++ b/docs/source/user_guide/clean/clean_cu_ni.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _ni_userguide:\n",
+    "\n",
+    "NI Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_cu_ni() <dataprep.clean.clean_cu_ni.clean_cu_ni>` cleans a column containing Cuban identity card numbers (NI) strings, and standardizes them in a given format. The function :func:`validate_cu_ni() <dataprep.clean.clean_cu_ni.validate_cu_ni>` validates either a single NI strings, a column of NI strings or a DataFrame of NI strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NI strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"91021027775\"\n",
+    "* `standard`: NI strings with proper whitespace in the proper places. Note that in the case of NI, the compact format is the same as the standard one.\n",
+    "* `birthdate`: split the date parts from the number and return the birth date, like \"1991-02-10\".\n",
+    "* `gender`: return the gender (M/F) from the person's NI.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_cu_ni()` and `validate_cu_ni()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing NI strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"ni\": [\n",
+    "            '91021027775',\n",
+    "            '9102102777A',\n",
+    "            '7542011030',\n",
+    "            '7552A10004',\n",
+    "            '8019010008',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_cu_ni`\n",
+    "\n",
+    "By default, `clean_cu_ni` will clean ni strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_cu_ni\n",
+    "clean_cu_ni(df, column = \"ni\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cu_ni(df, column = \"ni\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cu_ni(df, column = \"ni\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cu_ni(df, column = \"ni\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `gender`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cu_ni(df, column = \"ni\", output_format=\"gender\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned NI strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cu_ni(df, column=\"ni\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cu_ni(df, \"ni\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cu_ni(df, \"ni\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_cu_ni()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_cu_ni()` returns `True` when the input is a valid NI. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_cu_ni()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_cu_ni()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_cu_ni()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_cu_ni\n",
+    "print(validate_cu_ni('91021027775'))\n",
+    "print(validate_cu_ni('9102102777A'))\n",
+    "print(validate_cu_ni('7542011030'))\n",
+    "print(validate_cu_ni('7552A10004'))\n",
+    "print(validate_cu_ni('8019010008'))\n",
+    "print(validate_cu_ni(\"hello\"))\n",
+    "print(validate_cu_ni(np.nan))\n",
+    "print(validate_cu_ni(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cu_ni(df[\"ni\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cu_ni(df, column=\"ni\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cu_ni(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_cy_vat.ipynb
+++ b/docs/source/user_guide/clean/clean_cy_vat.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _vat_userguide:\n",
+    "\n",
+    "VAT Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_cy_vat() <dataprep.clean.clean_cy_vat.clean_cy_vat>` cleans a column containing Cypriot VAT number (VAT) strings, and standardizes them in a given format. The function :func:`validate_cy_vat() <dataprep.clean.clean_cy_vat.validate_cy_vat>` validates either a single VAT strings, a column of VAT strings or a DataFrame of VAT strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "VAT strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"10259033P\"\n",
+    "* `standard`: VAT strings with proper whitespace in the proper places. Note that in the case of VAT, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_cy_vat()` and `validate_cy_vat()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing VAT strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"vat\": [\n",
+    "            'CY-10259033P',\n",
+    "            'CY-10259033Z',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_cy_vat`\n",
+    "\n",
+    "By default, `clean_cy_vat` will clean vat strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_cy_vat\n",
+    "clean_cy_vat(df, column = \"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cy_vat(df, column = \"vat\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cy_vat(df, column = \"vat\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned VAT strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cy_vat(df, column=\"vat\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cy_vat(df, \"vat\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cy_vat(df, \"vat\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_cy_vat()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_cy_vat()` returns `True` when the input is a valid VAT. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_cy_vat()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_cy_vat()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_cy_vat()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_cy_vat\n",
+    "print(validate_cy_vat(\"CY-10259033P\"))\n",
+    "print(validate_cy_vat(\"CY-10259033Z\"))\n",
+    "print(validate_cy_vat('BE 428759497'))\n",
+    "print(validate_cy_vat('BE431150351'))\n",
+    "print(validate_cy_vat(\"004085616\"))\n",
+    "print(validate_cy_vat(\"hello\"))\n",
+    "print(validate_cy_vat(np.nan))\n",
+    "print(validate_cy_vat(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cy_vat(df[\"vat\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cy_vat(df, column=\"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cy_vat(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_cz_dic.ipynb
+++ b/docs/source/user_guide/clean/clean_cz_dic.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _dic_userguide:\n",
+    "\n",
+    "DIC Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_cz_dic() <dataprep.clean.clean_cz_dic.clean_cz_dic>` cleans a column containing Czech DIC number (DIC) strings, and standardizes them in a given format. The function :func:`validate_cz_dic() <dataprep.clean.clean_cz_dic.validate_cz_dic>` validates either a single DIC strings, a column of DIC strings or a DataFrame of DIC strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DIC strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"25123891\"\n",
+    "* `standard`: DIC strings with proper whitespace in the proper places. Note that in the case of DIC, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_cz_dic()` and `validate_cz_dic()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing DIC strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"dic\": [\n",
+    "            'CZ 25123891',\n",
+    "            '25123890',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_cz_dic`\n",
+    "\n",
+    "By default, `clean_cz_dic` will clean dic strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_cz_dic\n",
+    "clean_cz_dic(df, column = \"dic\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "clean_cz_dic(df, column = \"dic\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cz_dic(df, column = \"dic\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned DIC strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cz_dic(df, column=\"dic\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cz_dic(df, \"dic\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cz_dic(df, \"dic\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_cz_dic()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_cz_dic()` returns `True` when the input is a valid DIC. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_cz_dic()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_cz_dic()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_cz_dic()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_cz_dic\n",
+    "print(validate_cz_dic('CZ 25123891'))\n",
+    "print(validate_cz_dic('25123890'))\n",
+    "print(validate_cz_dic('BE 428759497'))\n",
+    "print(validate_cz_dic('BE431150351'))\n",
+    "print(validate_cz_dic(\"004085616\"))\n",
+    "print(validate_cz_dic(\"hello\"))\n",
+    "print(validate_cz_dic(np.nan))\n",
+    "print(validate_cz_dic(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cz_dic(df[\"dic\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cz_dic(df, column=\"dic\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cz_dic(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_cz_rc.ipynb
+++ b/docs/source/user_guide/clean/clean_cz_rc.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _rc_userguide:\n",
+    "\n",
+    "RC Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_cz_rc() <dataprep.clean.clean_cz_rc.clean_cz_rc>` cleans a column containing Czech birth number (RC) strings, and standardizes them in a given format. The function :func:`validate_cz_rc() <dataprep.clean.clean_cz_rc.validate_cz_rc>` validates either a single RC strings, a column of RC strings or a DataFrame of RC strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RC strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"7103192745\"\n",
+    "* `standard`: RC strings with proper whitespace in the proper places, like \"710319/2745\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_cz_rc()` and `validate_cz_rc()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing RC strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"rc\": [\n",
+    "            \"7103192745\",\n",
+    "            \"7103192746\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_cz_rc`\n",
+    "\n",
+    "By default, `clean_cz_rc` will clean rc strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_cz_rc\n",
+    "clean_cz_rc(df, column = \"rc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cz_rc(df, column = \"rc\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cz_rc(df, column = \"rc\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned RC strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cz_rc(df, column=\"rc\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cz_rc(df, \"rc\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_cz_rc(df, \"rc\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_cz_rc()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_cz_rc()` returns `True` when the input is a valid RC. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_cz_rc()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_cz_rc()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_cz_rc()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_cz_rc\n",
+    "print(validate_cz_rc(\"7103192745\"))\n",
+    "print(validate_cz_rc(\"7103192746\"))\n",
+    "print(validate_cz_rc(\"51824753556\"))\n",
+    "print(validate_cz_rc(\"51 824 753 556\"))\n",
+    "print(validate_cz_rc(\"hello\"))\n",
+    "print(validate_cz_rc(np.nan))\n",
+    "print(validate_cz_rc(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cz_rc(df[\"rc\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_cz_rc(df, column=\"rc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_cz_rc(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_de_handelsregisternummer.ipynb
+++ b/docs/source/user_guide/clean/clean_de_handelsregisternummer.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _handelsregisternummer_userguide:\n",
+    "\n",
+    "handelsregisternummer Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_de_handelsregisternummer() <dataprep.clean.clean_de_handelsregisternummer.clean_de_handelsregisternummer>` cleans a column containing German company registry id (handelsregisternummer) strings, and standardizes them in a given format. The function :func:`validate_de_handelsregisternummer() <dataprep.clean.clean_de_handelsregisternummer.validate_de_handelsregisternummer>` validates either a single handelsregisternummer strings, a column of handelsregisternummer strings or a DataFrame of handelsregisternummer strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "handelsregisternummer strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"Aachen HRA 11223\"\n",
+    "* `standard`: handelsregisternummer strings with proper whitespace in the proper places. Note that in the case of handelsregisternummer, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_de_handelsregisternummer()` and `validate_de_handelsregisternummer()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing handelsregisternummer strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"handelsregisternummer\": [\n",
+    "            'Aachen HRA 11223',\n",
+    "            'Aachen HRC 44123',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_de_handelsregisternummer`\n",
+    "\n",
+    "By default, `clean_de_handelsregisternummer` will clean handelsregisternummer strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_de_handelsregisternummer\n",
+    "clean_de_handelsregisternummer(df, column = \"handelsregisternummer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_handelsregisternummer(df, column = \"handelsregisternummer\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_handelsregisternummer(df, column = \"handelsregisternummer\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned handelsregisternummer strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_handelsregisternummer(df, column=\"handelsregisternummer\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_handelsregisternummer(df, \"handelsregisternummer\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_handelsregisternummer(df, \"handelsregisternummer\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_de_handelsregisternummer()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_de_handelsregisternummer()` returns `True` when the input is a valid handelsregisternummer. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_de_handelsregisternummer()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_de_handelsregisternummer()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_de_handelsregisternummer()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_de_handelsregisternummer\n",
+    "print(validate_de_handelsregisternummer('Aachen HRA 11223'))\n",
+    "print(validate_de_handelsregisternummer('Aachen HRC 44123'))\n",
+    "print(validate_de_handelsregisternummer('BE 428759497'))\n",
+    "print(validate_de_handelsregisternummer('BE431150351'))\n",
+    "print(validate_de_handelsregisternummer(\"004085616\"))\n",
+    "print(validate_de_handelsregisternummer(\"hello\"))\n",
+    "print(validate_de_handelsregisternummer(np.nan))\n",
+    "print(validate_de_handelsregisternummer(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_handelsregisternummer(df[\"handelsregisternummer\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_handelsregisternummer(df, column=\"handelsregisternummer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_handelsregisternummer(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_de_idnr.ipynb
+++ b/docs/source/user_guide/clean/clean_de_idnr.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _idnr_userguide:\n",
+    "\n",
+    "IDNR Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_de_idnr() <dataprep.clean.clean_de_idnr.clean_de_idnr>` cleans a column containing German personal tax number (IDNR) strings, and standardizes them in a given format. The function :func:`validate_de_idnr() <dataprep.clean.clean_de_idnr.validate_de_idnr>` validates either a single IDNR strings, a column of IDNR strings or a DataFrame of IDNR strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "IDNR strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"36574261809\"\n",
+    "* `standard`: IDNR strings with proper whitespace in the proper places, like \"36 574 261 809\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_de_idnr()` and `validate_de_idnr()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing IDNR strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"idnr\": [\n",
+    "            \"36574261809\",\n",
+    "            \"36554266806\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_de_idnr`\n",
+    "\n",
+    "By default, `clean_de_idnr` will clean idnr strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_de_idnr\n",
+    "clean_de_idnr(df, column = \"idnr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_idnr(df, column = \"idnr\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "clean_de_idnr(df, column = \"idnr\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned IDNR strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_idnr(df, column=\"idnr\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_idnr(df, \"idnr\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_idnr(df, \"idnr\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_de_idnr()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_de_idnr()` returns `True` when the input is a valid IDNR. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_de_idnr()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_de_idnr()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_de_idnr()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_de_idnr\n",
+    "print(validate_de_idnr(\"36574261809\"))\n",
+    "print(validate_de_idnr(\"36554266806\"))\n",
+    "print(validate_de_idnr(\"51824753556\"))\n",
+    "print(validate_de_idnr(\"51 824 753 556\"))\n",
+    "print(validate_de_idnr(\"hello\"))\n",
+    "print(validate_de_idnr(np.nan))\n",
+    "print(validate_de_idnr(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_idnr(df[\"idnr\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_idnr(df, column=\"idnr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_idnr(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_de_stnr.ipynb
+++ b/docs/source/user_guide/clean/clean_de_stnr.ipynb
@@ -1,0 +1,349 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _stnr_userguide:\n",
+    "\n",
+    "STNR Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_de_stnr() <dataprep.clean.clean_de_stnr.clean_de_stnr>` cleans a column containing German tax numbers (STNR) strings, and standardizes them in a given format. The function :func:`validate_de_stnr() <dataprep.clean.clean_de_stnr.validate_de_stnr>` validates either a single STNR strings, a column of STNR strings or a DataFrame of STNR strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "STNR strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"18181508155\"\n",
+    "* `standard`: STNR strings with proper whitespace in the proper places, like \"181/815/0815 5\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_de_stnr()` and `validate_de_stnr()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing STNR strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"stnr\": [\n",
+    "            ' 181/815/0815 5',\n",
+    "            \"136695978\",\n",
+    "            \"201/123/12340\",\n",
+    "            \"4151081508156\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_de_stnr`\n",
+    "\n",
+    "By default, `clean_de_stnr` will clean stnr strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_de_stnr\n",
+    "clean_de_stnr(df, column = \"stnr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_stnr(df, column = \"stnr\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_stnr(df, column = \"stnr\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned STNR strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_stnr(df, column=\"stnr\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_stnr(df, \"stnr\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_stnr(df, \"stnr\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_de_stnr()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_de_stnr()` returns `True` when the input is a valid STNR. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_de_stnr()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_de_stnr()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_de_stnr()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_de_stnr\n",
+    "print(validate_de_stnr(\"181/815/0815 5\"))\n",
+    "print(validate_de_stnr(\"136695978\"))\n",
+    "print(validate_de_stnr(\"201/123/12340\"))\n",
+    "print(validate_de_stnr(\"4151081508156\"))\n",
+    "print(validate_de_stnr(\"hello\"))\n",
+    "print(validate_de_stnr(np.nan))\n",
+    "print(validate_de_stnr(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_stnr(df[\"stnr\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_stnr(df, column=\"stnr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_stnr(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `region` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Specifically, `region` can be supplied to `validate_de_stnr` to verify that the number is assigned in that region."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_stnr(df[\"stnr\"], region='Sachsen')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_stnr(df[\"stnr\"], region='Thuringen')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_de_vat.ipynb
+++ b/docs/source/user_guide/clean/clean_de_vat.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _vat_userguide:\n",
+    "\n",
+    "VAT Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_de_vat() <dataprep.clean.clean_de_vat.clean_de_vat>` cleans a column containing German VAT number (VAT) strings, and standardizes them in a given format. The function :func:`validate_de_vat() <dataprep.clean.clean_de_vat.validate_de_vat>` validates either a single VAT strings, a column of VAT strings or a DataFrame of VAT strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "VAT strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"136695976\"\n",
+    "* `standard`: VAT strings with proper whitespace in the proper places. Note that in the case of VAT, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_de_vat()` and `validate_de_vat()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing VAT strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"vat\": [\n",
+    "            'DE 136,695 976',\n",
+    "            '136695978',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_de_vat`\n",
+    "\n",
+    "By default, `clean_de_vat` will clean vat strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_de_vat\n",
+    "clean_de_vat(df, column = \"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_vat(df, column = \"vat\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_vat(df, column = \"vat\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned VAT strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_vat(df, column=\"vat\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_vat(df, \"vat\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_vat(df, \"vat\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_de_vat()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_de_vat()` returns `True` when the input is a valid VAT. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_de_vat()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_de_vat()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_de_vat()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_de_vat\n",
+    "print(validate_de_vat('DE 136,695 976'))\n",
+    "print(validate_de_vat('136695978'))\n",
+    "print(validate_de_vat('BE 428759497'))\n",
+    "print(validate_de_vat('BE431150351'))\n",
+    "print(validate_de_vat(\"004085616\"))\n",
+    "print(validate_de_vat(\"hello\"))\n",
+    "print(validate_de_vat(np.nan))\n",
+    "print(validate_de_vat(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_vat(df[\"vat\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_vat(df, column=\"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_vat(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_de_wkn.ipynb
+++ b/docs/source/user_guide/clean/clean_de_wkn.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _wkn_userguide:\n",
+    "\n",
+    "WKN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_de_wkn() <dataprep.clean.clean_de_wkn.clean_de_wkn>` cleans a column containing German Securities Identification Codes (WKN) strings, and standardizes them in a given format. The function :func:`validate_de_wkn() <dataprep.clean.clean_de_wkn.validate_de_wkn>` validates either a single WKN strings, a column of WKN strings or a DataFrame of WKN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "WKN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"A0MNRK\"\n",
+    "* `standard`: WKN strings with proper whitespace in the proper places. Note that in the case of WKN, the compact format is the same as the standard one.\n",
+    "* `isin`: convert the number to an ISIN, like \"DE000A0MNRK9\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_de_wkn()` and `validate_de_wkn()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing WKN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"wkn\": [\n",
+    "            'A0MNRK',\n",
+    "            'AOMNRK',\n",
+    "            '7542011030',\n",
+    "            '7552A10004',\n",
+    "            '8019010008',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_de_wkn`\n",
+    "\n",
+    "By default, `clean_de_wkn` will clean wkn strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_de_wkn\n",
+    "clean_de_wkn(df, column = \"wkn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_wkn(df, column = \"wkn\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_wkn(df, column = \"wkn\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `isin`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_wkn(df, column = \"wkn\", output_format=\"isin\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned WKN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_wkn(df, column=\"wkn\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_wkn(df, \"wkn\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_de_wkn(df, \"wkn\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_de_wkn()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_de_wkn()` returns `True` when the input is a valid WKN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_de_wkn()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_de_wkn()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_de_wkn()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_de_wkn\n",
+    "print(validate_de_wkn('A0MNRK'))\n",
+    "print(validate_de_wkn('AOMNRK'))\n",
+    "print(validate_de_wkn('7542011030'))\n",
+    "print(validate_de_wkn('7552A10004'))\n",
+    "print(validate_de_wkn('8019010008'))\n",
+    "print(validate_de_wkn(\"hello\"))\n",
+    "print(validate_de_wkn(np.nan))\n",
+    "print(validate_de_wkn(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_wkn(df[\"wkn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_wkn(df, column=\"wkn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_de_wkn(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_dk_cpr.ipynb
+++ b/docs/source/user_guide/clean/clean_dk_cpr.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _cpr_userguide:\n",
+    "\n",
+    "CPR Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_dk_cpr() <dataprep.clean.clean_dk_cpr.clean_dk_cpr>` cleans a column containing Danish citizen number (CPR) strings, and standardizes them in a given format. The function :func:`validate_dk_cpr() <dataprep.clean.clean_dk_cpr.validate_dk_cpr>` validates either a single CPR strings, a column of CPR strings or a DataFrame of CPR strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CPR strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"211062-5629\"\n",
+    "* `standard`: CPR strings with proper whitespace in the proper places, like \"2110625629\"\n",
+    "* `birthdate`: split the number and return the birth date, like \"1862-10-21\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_dk_cpr()` and `validate_dk_cpr()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing CPR strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"cpr\": [\n",
+    "            \"2110625629\",\n",
+    "            \"511062-5629\",\n",
+    "            \"999 999 999\",\n",
+    "            \"004085616\",\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_dk_cpr`\n",
+    "\n",
+    "By default, `clean_dk_cpr` will clean cpr strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_dk_cpr\n",
+    "clean_dk_cpr(df, column = \"cpr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_dk_cpr(df, column = \"cpr\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_dk_cpr(df, column = \"cpr\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_dk_cpr(df, column = \"cpr\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CPR strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_dk_cpr(df, column=\"cpr\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_dk_cpr(df, \"cpr\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_dk_cpr(df, \"cpr\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_dk_cpr()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_dk_cpr()` returns `True` when the input is a valid CPR. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_dk_cpr()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_dk_cpr()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_dk_cpr()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_dk_cpr\n",
+    "print(validate_dk_cpr(\"2110625629\"))\n",
+    "print(validate_dk_cpr(\"511062-5629\"))\n",
+    "print(validate_dk_cpr(\"999 999 999\"))\n",
+    "print(validate_dk_cpr(\"51824753556\"))\n",
+    "print(validate_dk_cpr(\"004085616\"))\n",
+    "print(validate_dk_cpr(\"hello\"))\n",
+    "print(validate_dk_cpr(np.nan))\n",
+    "print(validate_dk_cpr(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_dk_cpr(df[\"cpr\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_dk_cpr(df, column=\"cpr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_dk_cpr(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_dk_cvr.ipynb
+++ b/docs/source/user_guide/clean/clean_dk_cvr.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _cvr_userguide:\n",
+    "\n",
+    "CVR Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_dk_cvr() <dataprep.clean.clean_dk_cvr.clean_dk_cvr>` cleans a column containing Danish CVR number (CVR) strings, and standardizes them in a given format. The function :func:`validate_dk_cvr() <dataprep.clean.clean_dk_cvr.validate_dk_cvr>` validates either a single CVR strings, a column of CVR strings or a DataFrame of CVR strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CVR strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"13585628\"\n",
+    "* `standard`: CVR strings with proper whitespace in the proper places. Note that in the case of CVR, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_dk_cvr()` and `validate_dk_cvr()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing CVR strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"cvr\": [\n",
+    "            'DK 13585628',\n",
+    "            'DK 13585627',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_dk_cvr`\n",
+    "\n",
+    "By default, `clean_dk_cvr` will clean cvr strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_dk_cvr\n",
+    "clean_dk_cvr(df, column = \"cvr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_dk_cvr(df, column = \"cvr\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_dk_cvr(df, column = \"cvr\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CVR strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_dk_cvr(df, column=\"cvr\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_dk_cvr(df, \"cvr\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_dk_cvr(df, \"cvr\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_dk_cvr()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_dk_cvr()` returns `True` when the input is a valid CVR. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_dk_cvr()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_dk_cvr()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_dk_cvr()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_dk_cvr\n",
+    "print(validate_dk_cvr(\"DK 13585628\"))\n",
+    "print(validate_dk_cvr(\"DK 13585627\"))\n",
+    "print(validate_dk_cvr('BE 428759497'))\n",
+    "print(validate_dk_cvr('BE431150351'))\n",
+    "print(validate_dk_cvr(\"004085616\"))\n",
+    "print(validate_dk_cvr(\"hello\"))\n",
+    "print(validate_dk_cvr(np.nan))\n",
+    "print(validate_dk_cvr(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_dk_cvr(df[\"cvr\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_dk_cvr(df, column=\"cvr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_dk_cvr(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_do_cedula.ipynb
+++ b/docs/source/user_guide/clean/clean_do_cedula.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _cedula_userguide:\n",
+    "\n",
+    "Cedula Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_do_cedula() <dataprep.clean.clean_do_cedula.clean_do_cedula>` cleans a column containing Dominican Republic national identifier (Cedula) strings, and standardizes them in a given format. The function :func:`validate_do_cedula() <dataprep.clean.clean_do_cedula.validate_do_cedula>` validates either a single Cedula strings, a column of Cedula strings or a DataFrame of Cedula strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Cedula strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"22400022111\"\n",
+    "* `standard`: Cedula strings with proper whitespace in the proper places, like \"224-0002211-1\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_do_cedula()` and `validate_do_cedula()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing Cedula strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"cedula\": [\n",
+    "            \"22400022111\",\n",
+    "            \"0011391820A\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_do_cedula`\n",
+    "\n",
+    "By default, `clean_do_cedula` will clean cedula strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_do_cedula\n",
+    "clean_do_cedula(df, column = \"cedula\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_do_cedula(df, column = \"cedula\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_do_cedula(df, column = \"cedula\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned Cedula strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_do_cedula(df, column=\"cedula\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_do_cedula(df, \"cedula\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_do_cedula(df, \"cedula\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_do_cedula()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_do_cedula()` returns `True` when the input is a valid Cedula. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_do_cedula()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_do_cedula()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_do_cedula()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_do_cedula\n",
+    "print(validate_do_cedula(\"22400022111\"))\n",
+    "print(validate_do_cedula(\"0011391820A\"))\n",
+    "print(validate_do_cedula(\"51824753556\"))\n",
+    "print(validate_do_cedula(\"51 824 753 556\"))\n",
+    "print(validate_do_cedula(\"hello\"))\n",
+    "print(validate_do_cedula(np.nan))\n",
+    "print(validate_do_cedula(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_do_cedula(df[\"cedula\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_do_cedula(df, column=\"cedula\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_do_cedula(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_do_ncf.ipynb
+++ b/docs/source/user_guide/clean/clean_do_ncf.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _ncf_userguide:\n",
+    "\n",
+    "NCF Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_do_ncf() <dataprep.clean.clean_do_ncf.clean_do_ncf>` cleans a column containing Dominican Republic invoice number (NCF) strings, and standardizes them in a given format. The function :func:`validate_do_ncf() <dataprep.clean.clean_do_ncf.validate_do_ncf>` validates either a single NCF strings, a column of NCF strings or a DataFrame of NCF strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NCF strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"E310000000005\"\n",
+    "* `standard`: NCF strings with proper whitespace in the proper places. Note that in the case of NCF, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_do_ncf()` and `validate_do_ncf()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing NCF strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"ncf\": [\n",
+    "            'E310000000005',\n",
+    "            'Z0100000005',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_do_ncf`\n",
+    "\n",
+    "By default, `clean_do_ncf` will clean ncf strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_do_ncf\n",
+    "clean_do_ncf(df, column = \"ncf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_do_ncf(df, column = \"ncf\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_do_ncf(df, column = \"ncf\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned NCF strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_do_ncf(df, column=\"ncf\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_do_ncf(df, \"ncf\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_do_ncf(df, \"ncf\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_do_ncf()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_do_ncf()` returns `True` when the input is a valid NCF. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_do_ncf()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_do_ncf()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_do_ncf()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_do_ncf\n",
+    "print(validate_do_ncf(\"E310000000005\"))\n",
+    "print(validate_do_ncf(\"Z0100000005\"))\n",
+    "print(validate_do_ncf('BE 428759497'))\n",
+    "print(validate_do_ncf('BE431150351'))\n",
+    "print(validate_do_ncf(\"004085616\"))\n",
+    "print(validate_do_ncf(\"hello\"))\n",
+    "print(validate_do_ncf(np.nan))\n",
+    "print(validate_do_ncf(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_do_ncf(df[\"ncf\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_do_ncf(df, column=\"ncf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_do_ncf(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_do_rnc.ipynb
+++ b/docs/source/user_guide/clean/clean_do_rnc.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _rnc_userguide:\n",
+    "\n",
+    "RNC Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_do_rnc() <dataprep.clean.clean_do_rnc.clean_do_rnc>` cleans a column containing Dominican Republic tax registration (RNC) strings, and standardizes them in a given format. The function :func:`validate_do_rnc() <dataprep.clean.clean_do_rnc.validate_do_rnc>` validates either a single RNC strings, a column of RNC strings or a DataFrame of RNC strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RNC strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"131246796\"\n",
+    "* `standard`: RNC strings with proper whitespace in the proper places, like \"1-31-24679-6\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_do_rnc()` and `validate_do_rnc()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing RNC strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"rnc\": [\n",
+    "            \"131246796\",\n",
+    "            \"1018A0043\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_do_rnc`\n",
+    "\n",
+    "By default, `clean_do_rnc` will clean rnc strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_do_rnc\n",
+    "clean_do_rnc(df, column = \"rnc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_do_rnc(df, column = \"rnc\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_do_rnc(df, column = \"rnc\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned RNC strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_do_rnc(df, column=\"rnc\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_do_rnc(df, \"rnc\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_do_rnc(df, \"rnc\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_do_rnc()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_do_rnc()` returns `True` when the input is a valid RNC. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_do_rnc()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_do_rnc()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_do_rnc()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_do_rnc\n",
+    "print(validate_do_rnc(\"131246796\"))\n",
+    "print(validate_do_rnc(\"1018A0043\"))\n",
+    "print(validate_do_rnc(\"51824753556\"))\n",
+    "print(validate_do_rnc(\"51 824 753 556\"))\n",
+    "print(validate_do_rnc(\"hello\"))\n",
+    "print(validate_do_rnc(np.nan))\n",
+    "print(validate_do_rnc(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_do_rnc(df[\"rnc\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_do_rnc(df, column=\"rnc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_do_rnc(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ec_ci.ipynb
+++ b/docs/source/user_guide/clean/clean_ec_ci.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _ci_userguide:\n",
+    "\n",
+    "CI Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ec_ci() <dataprep.clean.clean_ec_ci.clean_ec_ci>` cleans a column containing Ecuadorian personal identity code (CI) strings, and standardizes them in a given format. The function :func:`validate_ec_ci() <dataprep.clean.clean_ec_ci.validate_ec_ci>` validates either a single CI strings, a column of CI strings or a DataFrame of CI strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CI strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"1714307103\"\n",
+    "* `standard`: CI strings with proper whitespace in the proper places. Note that in the case of CI, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ec_ci()` and `validate_ec_ci()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing CI strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"ci\": [\n",
+    "            '171430710-3',\n",
+    "            'BE431150351',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ec_ci`\n",
+    "\n",
+    "By default, `clean_ec_ci` will clean ci strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ec_ci\n",
+    "clean_ec_ci(df, column = \"ci\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ec_ci(df, column = \"ci\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ec_ci(df, column = \"ci\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CI strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ec_ci(df, column=\"ci\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ec_ci(df, \"ci\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ec_ci(df, \"ci\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ec_ci()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ec_ci()` returns `True` when the input is a valid CI. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ec_ci()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ec_ci()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ec_ci()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ec_ci\n",
+    "print(validate_ec_ci(\"171430710-3\"))\n",
+    "print(validate_ec_ci(\"BE431150351\"))\n",
+    "print(validate_ec_ci('BE 428759497'))\n",
+    "print(validate_ec_ci('BE431150351'))\n",
+    "print(validate_ec_ci(\"004085616\"))\n",
+    "print(validate_ec_ci(\"hello\"))\n",
+    "print(validate_ec_ci(np.nan))\n",
+    "print(validate_ec_ci(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ec_ci(df[\"ci\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ec_ci(df, column=\"ci\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_ec_ci(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ec_ruc.ipynb
+++ b/docs/source/user_guide/clean/clean_ec_ruc.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _ruc_userguide:\n",
+    "\n",
+    "RUC Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ec_ruc() <dataprep.clean.clean_ec_ruc.clean_ec_ruc>` cleans a column containing Ecuadorian company tax number (RUC) strings, and standardizes them in a given format. The function :func:`validate_ec_ruc() <dataprep.clean.clean_ec_ruc.validate_ec_ruc>` validates either a single RUC strings, a column of RUC strings or a DataFrame of RUC strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RUC strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"1792060346001\"\n",
+    "* `standard`: RUC strings with proper whitespace in the proper places. Note that in the case of RUC, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ec_ruc()` and `validate_ec_ruc()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing RUC strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"ruc\": [\n",
+    "            '1792060346-001',\n",
+    "            '1763154690001',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ec_ruc`\n",
+    "\n",
+    "By default, `clean_ec_ruc` will clean ruc strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ec_ruc\n",
+    "clean_ec_ruc(df, column = \"ruc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ec_ruc(df, column = \"ruc\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ec_ruc(df, column = \"ruc\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned RUC strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ec_ruc(df, column=\"ruc\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ec_ruc(df, \"ruc\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ec_ruc(df, \"ruc\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ec_ruc()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ec_ruc()` returns `True` when the input is a valid RUC. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ec_ruc()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ec_ruc()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ec_ruc()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ec_ruc\n",
+    "print(validate_ec_ruc(\"1792060346-001\"))\n",
+    "print(validate_ec_ruc(\"1763154690001\"))\n",
+    "print(validate_ec_ruc('BE 428759497'))\n",
+    "print(validate_ec_ruc('BE431150351'))\n",
+    "print(validate_ec_ruc(\"004085616\"))\n",
+    "print(validate_ec_ruc(\"hello\"))\n",
+    "print(validate_ec_ruc(np.nan))\n",
+    "print(validate_ec_ruc(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ec_ruc(df[\"ruc\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ec_ruc(df, column=\"ruc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_ec_ruc(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ee_ik.ipynb
+++ b/docs/source/user_guide/clean/clean_ee_ik.ipynb
@@ -1,0 +1,338 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _ik_userguide:\n",
+    "\n",
+    "IK Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ee_ik() <dataprep.clean.clean_ee_ik.clean_ee_ik>` cleans a column containing Estonian Personcal ID number (IK) strings, and standardizes them in a given format. The function :func:`validate_ee_ik() <dataprep.clean.clean_ee_ik.validate_ee_ik>` validates either a single IK strings, a column of IK strings or a DataFrame of IK strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "IK strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"36805280109\"\n",
+    "* `standard`: IK strings with proper whitespace in the proper places. Note that in the case of IK, the compact format is the same as the standard one.\n",
+    "* `birthdate`: split the date parts from the number and return the birth date, like \"1875-03-16\".\n",
+    "* `gender`: get the person's birth gender ('M' or 'F').\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ee_ik()` and `validate_ee_ik()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing IK strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"ik\": [\n",
+    "            '36805280109',\n",
+    "            '36805280108',\n",
+    "            '7542011030',\n",
+    "            '7552A10004',  # invalid digit\n",
+    "            '8019010008',  # invalid date\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ee_ik`\n",
+    "\n",
+    "By default, `clean_ee_ik` will clean ik strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ee_ik\n",
+    "clean_ee_ik(df, column = \"ik\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_ik(df, column = \"ik\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_ik(df, column = \"ik\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_ik(df, column = \"ik\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned IK strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_ik(df, column=\"ik\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_ik(df, \"ik\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_ik(df, \"ik\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ee_ik()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ee_ik()` returns `True` when the input is a valid IK. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ee_ik()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ee_ik()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ee_ik()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ee_ik\n",
+    "print(validate_ee_ik('36805280109'))\n",
+    "print(validate_ee_ik('36805280108'))\n",
+    "print(validate_ee_ik('7542011030'))\n",
+    "print(validate_ee_ik('7552A10004'))\n",
+    "print(validate_ee_ik('8019010008'))\n",
+    "print(validate_ee_ik(\"hello\"))\n",
+    "print(validate_ee_ik(np.nan))\n",
+    "print(validate_ee_ik(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ee_ik(df[\"ik\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ee_ik(df, column=\"ik\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ee_ik(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ee_kmkr.ipynb
+++ b/docs/source/user_guide/clean/clean_ee_kmkr.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _kmkr_userguide:\n",
+    "\n",
+    "KMKR Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ee_kmkr() <dataprep.clean.clean_ee_kmkr.clean_ee_kmkr>` cleans a column containing Estonian KMKR number (KMKR) strings, and standardizes them in a given format. The function :func:`validate_ee_kmkr() <dataprep.clean.clean_ee_kmkr.validate_ee_kmkr>` validates either a single KMKR strings, a column of KMKR strings or a DataFrame of KMKR strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "KMKR strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"100931558\"\n",
+    "* `standard`: KMKR strings with proper whitespace in the proper places. Note that in the case of KMKR, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ee_kmkr()` and `validate_ee_kmkr()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing KMKR strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"kmkr\": [\n",
+    "            'EE 100 931 558',\n",
+    "            '100594103',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ee_kmkr`\n",
+    "\n",
+    "By default, `clean_ee_kmkr` will clean kmkr strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ee_kmkr\n",
+    "clean_ee_kmkr(df, column = \"kmkr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_kmkr(df, column = \"kmkr\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_kmkr(df, column = \"kmkr\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned KMKR strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_kmkr(df, column=\"kmkr\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_kmkr(df, \"kmkr\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_kmkr(df, \"kmkr\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ee_kmkr()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ee_kmkr()` returns `True` when the input is a valid KMKR. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ee_kmkr()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ee_kmkr()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ee_kmkr()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ee_kmkr\n",
+    "print(validate_ee_kmkr(\"EE 100 931 558\"))\n",
+    "print(validate_ee_kmkr(\"100594103\"))\n",
+    "print(validate_ee_kmkr('BE 428759497'))\n",
+    "print(validate_ee_kmkr('BE431150351'))\n",
+    "print(validate_ee_kmkr(\"004085616\"))\n",
+    "print(validate_ee_kmkr(\"hello\"))\n",
+    "print(validate_ee_kmkr(np.nan))\n",
+    "print(validate_ee_kmkr(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ee_kmkr(df[\"kmkr\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ee_kmkr(df, column=\"kmkr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_ee_kmkr(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ee_registrikood.ipynb
+++ b/docs/source/user_guide/clean/clean_ee_registrikood.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _registrikood_userguide:\n",
+    "\n",
+    "Registrikood Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ee_registrikood() <dataprep.clean.clean_ee_registrikood.clean_ee_registrikood>` cleans a column containing Estonian organisation registration code (Registrikood) strings, and standardizes them in a given format. The function :func:`validate_ee_registrikood() <dataprep.clean.clean_ee_registrikood.validate_ee_registrikood>` validates either a single Registrikood strings, a column of Registrikood strings or a DataFrame of Registrikood strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Registrikood strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"12345678\"\n",
+    "* `standard`: Registrikood strings with proper whitespace in the proper places. Note that in the case of Registrikood, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ee_registrikood()` and `validate_ee_registrikood()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing Registrikood strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"registrikood\": [\n",
+    "            '12345678',\n",
+    "            '12345679',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ee_registrikood`\n",
+    "\n",
+    "By default, `clean_ee_registrikood` will clean registrikood strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ee_registrikood\n",
+    "clean_ee_registrikood(df, column = \"registrikood\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_registrikood(df, column = \"registrikood\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_registrikood(df, column = \"registrikood\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned Registrikood strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_registrikood(df, column=\"registrikood\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_registrikood(df, \"registrikood\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ee_registrikood(df, \"registrikood\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ee_registrikood()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ee_registrikood()` returns `True` when the input is a valid Registrikood. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ee_registrikood()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ee_registrikood()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ee_registrikood()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ee_registrikood\n",
+    "print(validate_ee_registrikood(\"12345678\"))\n",
+    "print(validate_ee_registrikood(\"12345679\"))\n",
+    "print(validate_ee_registrikood('BE 428759497'))\n",
+    "print(validate_ee_registrikood('BE431150351'))\n",
+    "print(validate_ee_registrikood(\"004085616\"))\n",
+    "print(validate_ee_registrikood(\"hello\"))\n",
+    "print(validate_ee_registrikood(np.nan))\n",
+    "print(validate_ee_registrikood(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ee_registrikood(df[\"registrikood\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ee_registrikood(df, column=\"registrikood\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_ee_registrikood(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_es_ccc.ipynb
+++ b/docs/source/user_guide/clean/clean_es_ccc.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _ccc_userguide:\n",
+    "\n",
+    "CCC Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_es_ccc() <dataprep.clean.clean_es_ccc.clean_es_ccc>` cleans a column containing Spanish Bank Account Code (CCC) strings, and standardizes them in a given format. The function :func:`validate_es_ccc() <dataprep.clean.clean_es_ccc.validate_es_ccc>` validates either a single CCC strings, a column of CCC strings or a DataFrame of CCC strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CCC strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"12341234161234567890\"\n",
+    "* `standard`: CCC strings with proper whitespace in the proper places, like \"1234 1234 16 12345 67890\"\n",
+    "* `iban`: convert the number to an IBAN in compact format, like \"ES7712341234161234567890\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_es_ccc()` and `validate_es_ccc()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing CCC strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"ccc\": [\n",
+    "            \"12341234161234567890\",\n",
+    "            \"134-1234-16 1234567890\",\n",
+    "            \"999 999 999\",\n",
+    "            \"004085616\",\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_es_ccc`\n",
+    "\n",
+    "By default, `clean_es_ccc` will clean ccc strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_es_ccc\n",
+    "clean_es_ccc(df, column = \"ccc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_ccc(df, column = \"ccc\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_ccc(df, column = \"ccc\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `iban`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_ccc(df, column = \"ccc\", output_format=\"iban\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CCC strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_ccc(df, column=\"ccc\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_ccc(df, \"ccc\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_ccc(df, \"ccc\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_es_ccc()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_es_ccc()` returns `True` when the input is a valid CCC. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_es_ccc()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_es_ccc()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_es_ccc()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_es_ccc\n",
+    "print(validate_es_ccc(\"12341234161234567890\"))\n",
+    "print(validate_es_ccc(\"134-1234-16 1234567890\"))\n",
+    "print(validate_es_ccc(\"999 999 999\"))\n",
+    "print(validate_es_ccc(\"51824753556\"))\n",
+    "print(validate_es_ccc(\"004085616\"))\n",
+    "print(validate_es_ccc(\"hello\"))\n",
+    "print(validate_es_ccc(np.nan))\n",
+    "print(validate_es_ccc(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_ccc(df[\"ccc\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_es_ccc(df, column=\"ccc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_ccc(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_es_cif.ipynb
+++ b/docs/source/user_guide/clean/clean_es_cif.ipynb
@@ -1,0 +1,338 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _cif_userguide:\n",
+    "\n",
+    "CIF Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_es_cif() <dataprep.clean.clean_es_cif.clean_es_cif>` cleans a column containing Spanish fiscal numbers (CIF) strings, and standardizes them in a given format. The function :func:`validate_es_cif() <dataprep.clean.clean_es_cif.validate_es_cif>` validates either a single CIF strings, a column of CIF strings or a DataFrame of CIF strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CIF strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"A13585625\"\n",
+    "* `standard`: CIF strings with proper whitespace in the proper places. Note that in the case of CIF, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_es_cif()` and `validate_es_cif()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing CIF strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"cif\": [\n",
+    "            'A13 585 625',\n",
+    "            'M-1234567-L',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_es_cif`\n",
+    "\n",
+    "By default, `clean_es_cif` will clean cif strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_es_cif\n",
+    "clean_es_cif(df, column = \"cif\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_cif(df, column = \"cif\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_cif(df, column = \"cif\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `split` parameter\n",
+    "\n",
+    "The `split` parameter adds individual columns containing the cleaned 9-digits CIF values to the given DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_cif(df, column=\"cif\", split=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CIF strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_cif(df, column=\"cif\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_cif(df, \"cif\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_cif(df, \"cif\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. `validate_es_cif()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_es_cif()` returns `True` when the input is a valid CIF. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_es_cif()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_es_cif()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_es_cif()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_es_cif\n",
+    "print(validate_es_cif(\"A13 585 625\"))\n",
+    "print(validate_es_cif(\"M-1234567-L\"))\n",
+    "print(validate_es_cif('BE 428759497'))\n",
+    "print(validate_es_cif('BE431150351'))\n",
+    "print(validate_es_cif(\"004085616\"))\n",
+    "print(validate_es_cif(\"hello\"))\n",
+    "print(validate_es_cif(np.nan))\n",
+    "print(validate_es_cif(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_cif(df[\"cif\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_cif(df, column=\"cif\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_cif(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_es_cups.ipynb
+++ b/docs/source/user_guide/clean/clean_es_cups.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _cups_userguide:\n",
+    "\n",
+    "CUPS Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_es_cups() <dataprep.clean.clean_es_cups.clean_es_cups>` cleans a column containing Spanish meter point number (CUPS) strings, and standardizes them in a given format. The function :func:`validate_es_cups() <dataprep.clean.clean_es_cups.validate_es_cups>` validates either a single CUPS strings, a column of CUPS strings or a DataFrame of CUPS strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CUPS strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"ES1234123456789012JY1F\"\n",
+    "* `standard`: CUPS strings with proper whitespace in the proper places, like \"ES 1234 1234 5678 9012 JY 1F\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_es_cups()` and `validate_es_cups()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing CUPS strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"cups\": [\n",
+    "            \"ES1234123456789012JY1F\",\n",
+    "            \"ES 1234-123456789012-XY 1F\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_es_cups`\n",
+    "\n",
+    "By default, `clean_es_cups` will clean cups strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_es_cups\n",
+    "clean_es_cups(df, column = \"cups\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_cups(df, column = \"cups\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_cups(df, column = \"cups\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CUPS strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_cups(df, column=\"cups\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_cups(df, \"cups\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_cups(df, \"cups\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_es_cups()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_es_cups()` returns `True` when the input is a valid CUPS. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_es_cups()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_es_cups()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_es_cups()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_es_cups\n",
+    "print(validate_es_cups(\"ES1234123456789012JY1F\"))\n",
+    "print(validate_es_cups(\"ES 1234-123456789012-XY 1F\"))\n",
+    "print(validate_es_cups(\"51824753556\"))\n",
+    "print(validate_es_cups(\"51 824 753 556\"))\n",
+    "print(validate_es_cups(\"hello\"))\n",
+    "print(validate_es_cups(np.nan))\n",
+    "print(validate_es_cups(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_cups(df[\"cups\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_cups(df, column=\"cups\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_es_cups(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_es_dni.ipynb
+++ b/docs/source/user_guide/clean/clean_es_dni.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _dni_userguide:\n",
+    "\n",
+    "DNI Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_es_dni() <dataprep.clean.clean_es_dni.clean_es_dni>` cleans a column containing Spanish personal identity code (DNI) strings, and standardizes them in a given format. The function :func:`validate_es_dni() <dataprep.clean.clean_es_dni.validate_es_dni>` validates either a single DNI strings, a column of DNI strings or a DataFrame of DNI strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DNI strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"54362315K\"\n",
+    "* `standard`: DNI strings with proper whitespace in the proper places. Note that in the case of DNI, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_es_dni()` and `validate_es_dni()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing DNI strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"dni\": [\n",
+    "            '54362315-K',\n",
+    "            '54362315',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_es_dni`\n",
+    "\n",
+    "By default, `clean_es_dni` will clean dni strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_es_dni\n",
+    "clean_es_dni(df, column = \"dni\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_dni(df, column = \"dni\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_dni(df, column = \"dni\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned DNI strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_dni(df, column=\"dni\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_dni(df, \"dni\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_dni(df, \"dni\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_es_dni()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_es_dni()` returns `True` when the input is a valid DNI. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_es_dni()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_es_dni()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_es_dni()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_es_dni\n",
+    "print(validate_es_dni(\"54362315-K\"))\n",
+    "print(validate_es_dni(\"54362315\"))\n",
+    "print(validate_es_dni('BE 428759497'))\n",
+    "print(validate_es_dni('BE431150351'))\n",
+    "print(validate_es_dni(\"004085616\"))\n",
+    "print(validate_es_dni(\"hello\"))\n",
+    "print(validate_es_dni(np.nan))\n",
+    "print(validate_es_dni(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_dni(df[\"dni\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_dni(df, column=\"dni\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_dni(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_es_iban.ipynb
+++ b/docs/source/user_guide/clean/clean_es_iban.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _iban_userguide:\n",
+    "\n",
+    "IBAN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_es_iban() <dataprep.clean.clean_es_iban.clean_es_iban>` cleans a column containing Spanish IBAN (IBAN) strings, and standardizes them in a given format. The function :func:`validate_es_iban() <dataprep.clean.clean_es_iban.validate_es_iban>` validates either a single IBAN strings, a column of IBAN strings or a DataFrame of IBAN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "IBAN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"ES7712341234161234567890\"\n",
+    "* `standard`: IBAN strings with proper whitespace in the proper places, like \"ES77 1234 1234 1612 3456 7890\"\n",
+    "* `ccc`: return the CCC (Código Cuenta Corriente) part of the number, like \"12341234161234567890\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_es_iban()` and `validate_es_iban()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing IBAN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"iban\": [\n",
+    "            \"ES771234-1234-16 1234567890\",\n",
+    "            \"R1601101050000010547023795\",\n",
+    "            \"999 999 999\",\n",
+    "            \"004085616\",\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_es_iban`\n",
+    "\n",
+    "By default, `clean_es_iban` will clean iban strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_es_iban\n",
+    "clean_es_iban(df, column = \"iban\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_iban(df, column = \"iban\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_iban(df, column = \"iban\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ccc`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_iban(df, column = \"iban\", output_format=\"ccc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned IBAN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_iban(df, column=\"iban\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_iban(df, \"iban\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_iban(df, \"iban\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_es_iban()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_es_iban()` returns `True` when the input is a valid IBAN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_es_iban()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_es_iban()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_es_iban()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_es_iban\n",
+    "print(validate_es_iban(\"ES771234-1234-16 1234567890\"))\n",
+    "print(validate_es_iban(\"R1601101050000010547023795\"))\n",
+    "print(validate_es_iban(\"999 999 999\"))\n",
+    "print(validate_es_iban(\"51824753556\"))\n",
+    "print(validate_es_iban(\"004085616\"))\n",
+    "print(validate_es_iban(\"hello\"))\n",
+    "print(validate_es_iban(np.nan))\n",
+    "print(validate_es_iban(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_iban(df[\"iban\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_iban(df, column=\"iban\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_es_iban(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_es_nie.ipynb
+++ b/docs/source/user_guide/clean/clean_es_nie.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _nie_userguide:\n",
+    "\n",
+    "NIE Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_es_nie() <dataprep.clean.clean_es_nie.clean_es_nie>` cleans a column containing Spanish foreigner identity code (NIE) strings, and standardizes them in a given format. The function :func:`validate_es_nie() <dataprep.clean.clean_es_nie.validate_es_nie>` validates either a single NIE strings, a column of NIE strings or a DataFrame of NIE strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NIE strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"X2482300W\"\n",
+    "* `standard`: NIE strings with proper whitespace in the proper places. Note that in the case of NIE, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_es_nie()` and `validate_es_nie()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing NIE strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"nie\": [\n",
+    "            'x-2482300w',\n",
+    "            'x-2482300a',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_es_nie`\n",
+    "\n",
+    "By default, `clean_es_nie` will clean nie strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_es_nie\n",
+    "clean_es_nie(df, column = \"nie\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_nie(df, column = \"nie\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_nie(df, column = \"nie\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned NIE strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_nie(df, column=\"nie\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_nie(df, \"nie\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_nie(df, \"nie\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_es_nie()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_es_nie()` returns `True` when the input is a valid NIE. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_es_nie()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_es_nie()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_es_nie()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_es_nie\n",
+    "print(validate_es_nie(\"x-2482300w\"))\n",
+    "print(validate_es_nie(\"x-2482300a\"))\n",
+    "print(validate_es_nie('BE 428759497'))\n",
+    "print(validate_es_nie('BE431150351'))\n",
+    "print(validate_es_nie(\"004085616\"))\n",
+    "print(validate_es_nie(\"hello\"))\n",
+    "print(validate_es_nie(np.nan))\n",
+    "print(validate_es_nie(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_nie(df[\"nie\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_nie(df, column=\"nie\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_es_nie(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_es_nif.ipynb
+++ b/docs/source/user_guide/clean/clean_es_nif.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _nif_userguide:\n",
+    "\n",
+    "NIF Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_es_nif() <dataprep.clean.clean_es_nif.clean_es_nif>` cleans a column containing Spanish NIF number (NIF) strings, and standardizes them in a given format. The function :func:`validate_es_nif() <dataprep.clean.clean_es_nif.validate_es_nif>` validates either a single NIF strings, a column of NIF strings or a DataFrame of NIF strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NIF strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"B58378431\"\n",
+    "* `standard`: NIF strings with proper whitespace in the proper places. Note that in the case of NIF, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_es_nif()` and `validate_es_nif()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing NIF strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"nif\": [\n",
+    "            'ES B-58378431',\n",
+    "            'B64717839',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_es_nif`\n",
+    "\n",
+    "By default, `clean_es_nif` will clean nif strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_es_nif\n",
+    "clean_es_nif(df, column = \"nif\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_nif(df, column = \"nif\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_nif(df, column = \"nif\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned NIF strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_nif(df, column=\"nif\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_nif(df, \"nif\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_nif(df, \"nif\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_es_nif()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_es_nif()` returns `True` when the input is a valid NIF. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_es_nif()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_es_nif()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_es_nif()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_es_nif\n",
+    "print(validate_es_nif('ES B-58378431'))\n",
+    "print(validate_es_nif('B64717839'))\n",
+    "print(validate_es_nif('BE 428759497'))\n",
+    "print(validate_es_nif('BE431150351'))\n",
+    "print(validate_es_nif(\"004085616\"))\n",
+    "print(validate_es_nif(\"hello\"))\n",
+    "print(validate_es_nif(np.nan))\n",
+    "print(validate_es_nif(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_nif(df[\"nif\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_nif(df, column=\"nif\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_nif(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_es_referenciacatastral.ipynb
+++ b/docs/source/user_guide/clean/clean_es_referenciacatastral.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _referenciacatastral_userguide:\n",
+    "\n",
+    "Referenciacatastral Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_es_referenciacatastral() <dataprep.clean.clean_es_referenciacatastral.clean_es_referenciacatastral>` cleans a column containing Spanish real state id (Referenciacatastral) strings, and standardizes them in a given format. The function :func:`validate_es_referenciacatastral() <dataprep.clean.clean_es_referenciacatastral.validate_es_referenciacatastral>` validates either a single Referenciacatastral strings, a column of Referenciacatastral strings or a DataFrame of Referenciacatastral strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Referenciacatastral strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"4A08169P03PRAT0001LR\"\n",
+    "* `standard`: Referenciacatastral strings with proper whitespace in the proper places, like \"4A08169 P03PRAT 0001 LR\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_es_referenciacatastral()` and `validate_es_referenciacatastral()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing Referenciacatastral strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"referenciacatastral\": [\n",
+    "            \"4A08169P03PRAT0001LR\",\n",
+    "            \"7837301/VG8173B 0001 TT\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_es_referenciacatastral`\n",
+    "\n",
+    "By default, `clean_es_referenciacatastral` will clean referenciacatastral strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_es_referenciacatastral\n",
+    "clean_es_referenciacatastral(df, column = \"referenciacatastral\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_referenciacatastral(df, column = \"referenciacatastral\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_referenciacatastral(df, column = \"referenciacatastral\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned Referenciacatastral strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_referenciacatastral(df, column=\"referenciacatastral\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_referenciacatastral(df, \"referenciacatastral\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_es_referenciacatastral(df, \"referenciacatastral\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_es_referenciacatastral()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_es_referenciacatastral()` returns `True` when the input is a valid Referenciacatastral. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_es_referenciacatastral()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_es_referenciacatastral()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_es_referenciacatastral()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_es_referenciacatastral\n",
+    "print(validate_es_referenciacatastral(\"4A08169P03PRAT0001LR\"))\n",
+    "print(validate_es_referenciacatastral(\"7837301/VG8173B 0001 TT\"))\n",
+    "print(validate_es_referenciacatastral(\"51824753556\"))\n",
+    "print(validate_es_referenciacatastral(\"51 824 753 556\"))\n",
+    "print(validate_es_referenciacatastral(\"hello\"))\n",
+    "print(validate_es_referenciacatastral(np.nan))\n",
+    "print(validate_es_referenciacatastral(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_referenciacatastral(df[\"referenciacatastral\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_referenciacatastral(df, column=\"referenciacatastral\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_es_referenciacatastral(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_eu_at_02.ipynb
+++ b/docs/source/user_guide/clean/clean_eu_at_02.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _eu_at_02_userguide:\n",
+    "\n",
+    "AT-02 Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_eu_at_02() <dataprep.clean.clean_eu_at_02.clean_eu_at_02>` cleans a column containing AT-02 (SEPA Creditor identifier) strings, and standardizes them in a given format. The function :func:`validate_eu_at_02() <dataprep.clean.clean_eu_at_02.validate_eu_at_02>` validates either a single AT-02 strings, a column of AT-02 strings or a DataFrame of AT-02 strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "AT-02 strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"ES23ZZZ47690558N\"\n",
+    "* `standard`: AT-02 strings with proper whitespace in the proper places. Note that in the case of AT-02, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_eu_at_02()` and `validate_eu_at_02()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing AT-02 strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"eu_at_02\": [\n",
+    "            'ES++()+23ZZZ4//7690558N',\n",
+    "            'ES2900047690558N',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_eu_at_02`\n",
+    "\n",
+    "By default, `clean_eu_at_02` will clean eu_at_02 strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_eu_at_02\n",
+    "clean_eu_at_02(df, column = \"eu_at_02\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_at_02(df, column = \"eu_at_02\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_at_02(df, column = \"eu_at_02\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned AT-02 strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_at_02(df, column=\"eu_at_02\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_at_02(df, \"eu_at_02\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_at_02(df, \"eu_at_02\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_eu_at_02()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_eu_at_02()` returns `True` when the input is a valid AT-02. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_eu_at_02()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_eu_at_02()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_eu_at_02()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_eu_at_02\n",
+    "print(validate_eu_at_02('ES++()+23ZZZ4//7690558N'))\n",
+    "print(validate_eu_at_02('ES2900047690558N'))\n",
+    "print(validate_eu_at_02('BE 428759497'))\n",
+    "print(validate_eu_at_02('BE431150351'))\n",
+    "print(validate_eu_at_02(\"004085616\"))\n",
+    "print(validate_eu_at_02(\"hello\"))\n",
+    "print(validate_eu_at_02(np.nan))\n",
+    "print(validate_eu_at_02(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_eu_at_02(df[\"eu_at_02\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_eu_at_02(df, column=\"eu_at_02\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_eu_at_02(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_eu_banknote.ipynb
+++ b/docs/source/user_guide/clean/clean_eu_banknote.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _banknote_userguide:\n",
+    "\n",
+    "Euro banknote Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_eu_banknote() <dataprep.clean.clean_eu_banknote.clean_eu_banknote>` cleans a column containing Euro banknote serial number strings, and standardizes them in a given format. The function :func:`validate_eu_banknote() <dataprep.clean.clean_eu_banknote.validate_eu_banknote>` validates either a single Euro banknote strings, a column of Euro banknote strings or a DataFrame of Euro banknote strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Euro banknote strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"P36007033744\"\n",
+    "* `standard`: Euro banknote strings with proper whitespace in the proper places. Note that in the case of Euro banknote, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_eu_banknote()` and `validate_eu_banknote()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing Euro banknote strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"banknote\": [\n",
+    "            'P36007033744',\n",
+    "            'P36007033743',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_eu_banknote`\n",
+    "\n",
+    "By default, `clean_eu_banknote` will clean banknote strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_eu_banknote\n",
+    "clean_eu_banknote(df, column = \"banknote\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_banknote(df, column = \"banknote\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_banknote(df, column = \"banknote\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned Euro banknote strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_banknote(df, column=\"banknote\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_banknote(df, \"banknote\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_banknote(df, \"banknote\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_eu_banknote()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_eu_banknote()` returns `True` when the input is a valid Euro banknote. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_eu_banknote()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_eu_banknote()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_eu_banknote()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_eu_banknote\n",
+    "print(validate_eu_banknote(\"P36007033744\"))\n",
+    "print(validate_eu_banknote(\"P36007033743\"))\n",
+    "print(validate_eu_banknote('BE 428759497'))\n",
+    "print(validate_eu_banknote('BE431150351'))\n",
+    "print(validate_eu_banknote(\"004085616\"))\n",
+    "print(validate_eu_banknote(\"hello\"))\n",
+    "print(validate_eu_banknote(np.nan))\n",
+    "print(validate_eu_banknote(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_eu_banknote(df[\"banknote\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_eu_banknote(df, column=\"banknote\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_eu_banknote(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_eu_eic.ipynb
+++ b/docs/source/user_guide/clean/clean_eu_eic.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _eic_userguide:\n",
+    "\n",
+    "EIC Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_eu_eic() <dataprep.clean.clean_eu_eic.clean_eu_eic>` cleans a column containing European Energy Identification Code (EIC) strings, and standardizes them in a given format. The function :func:`validate_eu_eic() <dataprep.clean.clean_eu_eic.validate_eu_eic>` validates either a single EIC strings, a column of EIC strings or a DataFrame of EIC strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "EIC strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"22XWATTPLUS----G\"\n",
+    "* `standard`: EIC strings with proper whitespace in the proper places. Note that in the case of EIC, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_eu_eic()` and `validate_eu_eic()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing EIC strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"eic\": [\n",
+    "            '22XWATTPLUS----G',\n",
+    "            '22XWATTPLUS----X',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_eu_eic`\n",
+    "\n",
+    "By default, `clean_eu_eic` will clean eic strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_eu_eic\n",
+    "clean_eu_eic(df, column = \"eic\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_eic(df, column = \"eic\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_eic(df, column = \"eic\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned EIC strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_eic(df, column=\"eic\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_eic(df, \"eic\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_eic(df, \"eic\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_eu_eic()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_eu_eic()` returns `True` when the input is a valid EIC. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_eu_eic()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_eu_eic()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_eu_eic()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_eu_eic\n",
+    "print(validate_eu_eic('22XWATTPLUS----G'))\n",
+    "print(validate_eu_eic('22XWATTPLUS----X'))\n",
+    "print(validate_eu_eic('BE 428759497'))\n",
+    "print(validate_eu_eic('BE431150351'))\n",
+    "print(validate_eu_eic(\"004085616\"))\n",
+    "print(validate_eu_eic(\"hello\"))\n",
+    "print(validate_eu_eic(np.nan))\n",
+    "print(validate_eu_eic(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_eu_eic(df[\"eic\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_eu_eic(df, column=\"eic\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_eu_eic(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_eu_nace.ipynb
+++ b/docs/source/user_guide/clean/clean_eu_nace.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _nace_userguide:\n",
+    "\n",
+    "NACE Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_eu_nace() <dataprep.clean.clean_eu_nace.clean_eu_nace>` cleans a column containing Classification for businesses in the European Union (NACE) strings, and standardizes them in a given format. The function :func:`validate_eu_nace() <dataprep.clean.clean_eu_nace.validate_eu_nace>` validates either a single NACE strings, a column of NACE strings or a DataFrame of NACE strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NACE strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"6201\"\n",
+    "* `standard`: NACE strings with proper whitespace in the proper places, like \"62.01\"\n",
+    "* `label`: return the category label for the number, like \"Computer programming activities\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_eu_nace()` and `validate_eu_nace()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing NACE strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"nace\": [\n",
+    "            \"6201\",\n",
+    "            \"99999999999\",\n",
+    "            \"999 999 999\",\n",
+    "            \"004085616\",\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_eu_nace`\n",
+    "\n",
+    "By default, `clean_eu_nace` will clean nace strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_eu_nace\n",
+    "clean_eu_nace(df, column = \"nace\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_nace(df, column = \"nace\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_nace(df, column = \"nace\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `label`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_nace(df, column = \"nace\", output_format=\"label\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned NACE strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_nace(df, column=\"nace\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_nace(df, \"nace\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_nace(df, \"nace\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_eu_nace()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_eu_nace()` returns `True` when the input is a valid NACE. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_eu_nace()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_eu_nace()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_eu_nace()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_eu_nace\n",
+    "print(validate_eu_nace(\"6201\"))\n",
+    "print(validate_eu_nace(\"99999999999\"))\n",
+    "print(validate_eu_nace(\"999 999 999\"))\n",
+    "print(validate_eu_nace(\"51824753556\"))\n",
+    "print(validate_eu_nace(\"004085616\"))\n",
+    "print(validate_eu_nace(\"hello\"))\n",
+    "print(validate_eu_nace(np.nan))\n",
+    "print(validate_eu_nace(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_eu_nace(df[\"nace\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_eu_nace(df, column=\"nace\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_eu_nace(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_eu_vat.ipynb
+++ b/docs/source/user_guide/clean/clean_eu_vat.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _vat_userguide:\n",
+    "\n",
+    "VAT Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_eu_vat() <dataprep.clean.clean_eu_vat.clean_eu_vat>` cleans a column containing European VAT number (VAT) strings, and standardizes them in a given format. The function :func:`validate_eu_vat() <dataprep.clean.clean_eu_vat.validate_eu_vat>` validates either a single VAT strings, a column of VAT strings or a DataFrame of VAT strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "VAT strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"ATU57194903\"\n",
+    "* `standard`: VAT strings with proper whitespace in the proper places. Note that in the case of VAT, the compact format is the same as the standard one.\n",
+    "* `country`: guess the country code based on the number and return a list of valid and lower case codes, like \"[at]\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_eu_vat()` and `validate_eu_vat()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing VAT strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"vat\": [\n",
+    "            'ATU 57194903',\n",
+    "            'FR 61 954 506 077',\n",
+    "            '7542011030',\n",
+    "            '7552A10004',\n",
+    "            '8019010008',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_eu_vat`\n",
+    "\n",
+    "By default, `clean_eu_vat` will clean vat strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_eu_vat\n",
+    "clean_eu_vat(df, column = \"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_vat(df, column = \"vat\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_vat(df, column = \"vat\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `country`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "clean_eu_vat(df, column = \"vat\", output_format=\"country\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned VAT strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_vat(df, column=\"vat\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_vat(df, \"vat\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_eu_vat(df, \"vat\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_eu_vat()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_eu_vat()` returns `True` when the input is a valid VAT. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_eu_vat()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_eu_vat()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_eu_vat()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_eu_vat\n",
+    "print(validate_eu_vat('ATU 57194903'))\n",
+    "print(validate_eu_vat('FR 61 954 506 077'))\n",
+    "print(validate_eu_vat('7542011030'))\n",
+    "print(validate_eu_vat('7552A10004'))\n",
+    "print(validate_eu_vat('8019010008'))\n",
+    "print(validate_eu_vat(\"hello\"))\n",
+    "print(validate_eu_vat(np.nan))\n",
+    "print(validate_eu_vat(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_eu_vat(df[\"vat\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_eu_vat(df, column=\"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_eu_vat(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_fi_alv.ipynb
+++ b/docs/source/user_guide/clean/clean_fi_alv.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _alv_userguide:\n",
+    "\n",
+    "ALV Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_fi_alv() <dataprep.clean.clean_fi_alv.clean_fi_alv>` cleans a column containing Finnish ALV number (ALV) strings, and standardizes them in a given format. The function :func:`validate_fi_alv() <dataprep.clean.clean_fi_alv.validate_fi_alv>` validates either a single ALV strings, a column of ALV strings or a DataFrame of ALV strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ALV strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"20774740\"\n",
+    "* `standard`: ALV strings with proper whitespace in the proper places. Note that in the case of ALV, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_fi_alv()` and `validate_fi_alv()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing ALV strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"alv\": [\n",
+    "            'FI 20774740',\n",
+    "            'FI 20774741',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_fi_alv`\n",
+    "\n",
+    "By default, `clean_fi_alv` will clean alv strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_fi_alv\n",
+    "clean_fi_alv(df, column = \"alv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_alv(df, column = \"alv\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_alv(df, column = \"alv\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned ALV strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_alv(df, column=\"alv\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_alv(df, \"alv\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_alv(df, \"alv\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_fi_alv()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_fi_alv()` returns `True` when the input is a valid ALV. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_fi_alv()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_fi_alv()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_fi_alv()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_fi_alv\n",
+    "print(validate_fi_alv('FI 20774740'))\n",
+    "print(validate_fi_alv('FI 20774741'))\n",
+    "print(validate_fi_alv('BE 428759497'))\n",
+    "print(validate_fi_alv('BE431150351'))\n",
+    "print(validate_fi_alv(\"004085616\"))\n",
+    "print(validate_fi_alv(\"hello\"))\n",
+    "print(validate_fi_alv(np.nan))\n",
+    "print(validate_fi_alv(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fi_alv(df[\"alv\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fi_alv(df, column=\"alv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fi_alv(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_fi_associationid.ipynb
+++ b/docs/source/user_guide/clean/clean_fi_associationid.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _associationid_userguide:\n",
+    "\n",
+    "associationid Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_fi_associationid() <dataprep.clean.clean_fi_associationid.clean_fi_associationid>` cleans a column containing Finnish association registry id (associationid) strings, and standardizes them in a given format. The function :func:`validate_fi_associationid() <dataprep.clean.clean_fi_associationid.validate_fi_associationid>` validates either a single associationid strings, a column of associationid strings or a DataFrame of associationid strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "associationid strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"1234\"\n",
+    "* `standard`: associationid strings with proper whitespace in the proper places, like \"1.234\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_fi_associationid()` and `validate_fi_associationid()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing Finnish association registry id strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"associationid\": [\n",
+    "            \"1234\",\n",
+    "            \"12df\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_fi_associationid`\n",
+    "\n",
+    "By default, `clean_fi_associationid` will clean Finnish association registry id strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_fi_associationid\n",
+    "clean_fi_associationid(df, column = \"associationid\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_associationid(df, column = \"associationid\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_associationid(df, column = \"associationid\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned Finnish association registry id strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_associationid(df, column=\"associationid\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_associationid(df, \"associationid\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_associationid(df, \"associationid\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_fi_associationid()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_fi_associationid()` returns `True` when the input is a valid Finnish association registry id. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_fi_associationid()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_fi_associationid()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_fi_associationid()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_fi_associationid\n",
+    "print(validate_fi_associationid(\"1234\"))\n",
+    "print(validate_fi_associationid(\"12df\"))\n",
+    "print(validate_fi_associationid(\"51824753556\"))\n",
+    "print(validate_fi_associationid(\"51 824 753 556\"))\n",
+    "print(validate_fi_associationid(\"hello\"))\n",
+    "print(validate_fi_associationid(np.nan))\n",
+    "print(validate_fi_associationid(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fi_associationid(df[\"associationid\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fi_associationid(df, column=\"associationid\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fi_associationid(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_fi_hetu.ipynb
+++ b/docs/source/user_guide/clean/clean_fi_hetu.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _hetu_userguide:\n",
+    "\n",
+    "HETU Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_fi_hetu() <dataprep.clean.clean_fi_hetu.clean_fi_hetu>` cleans a column containing Finnish personal identity code (HETU) strings, and standardizes them in a given format. The function :func:`validate_fi_hetu() <dataprep.clean.clean_fi_hetu.validate_fi_hetu>` validates either a single HETU strings, a column of HETU strings or a DataFrame of HETU strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "HETU strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"131052A308T\"\n",
+    "* `standard`: HETU strings with proper whitespace in the proper places. Note that in the case of HETU, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_fi_hetu()` and `validate_fi_hetu()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing HETU strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"hetu\": [\n",
+    "            '131052a308t',\n",
+    "            '131052-308U',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_fi_hetu`\n",
+    "\n",
+    "By default, `clean_fi_hetu` will clean hetu strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_fi_hetu\n",
+    "clean_fi_hetu(df, column = \"hetu\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_hetu(df, column = \"hetu\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_hetu(df, column = \"hetu\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned HETU strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_hetu(df, column=\"hetu\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_hetu(df, \"hetu\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_hetu(df, \"hetu\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_fi_hetu()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_fi_hetu()` returns `True` when the input is a valid HETU. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_fi_hetu()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_fi_hetu()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_fi_hetu()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_fi_hetu\n",
+    "print(validate_fi_hetu(\"131052a308t\"))\n",
+    "print(validate_fi_hetu(\"131052-308U\"))\n",
+    "print(validate_fi_hetu('BE 428759497'))\n",
+    "print(validate_fi_hetu('BE431150351'))\n",
+    "print(validate_fi_hetu(\"004085616\"))\n",
+    "print(validate_fi_hetu(\"hello\"))\n",
+    "print(validate_fi_hetu(np.nan))\n",
+    "print(validate_fi_hetu(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fi_hetu(df[\"hetu\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fi_hetu(df, column=\"hetu\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_fi_hetu(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_fi_veronumero.ipynb
+++ b/docs/source/user_guide/clean/clean_fi_veronumero.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _veronumero_userguide:\n",
+    "\n",
+    "Veronumero Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_fi_veronumero() <dataprep.clean.clean_fi_veronumero.clean_fi_veronumero>` cleans a column containing Finnish individual tax number (Veronumero) strings, and standardizes them in a given format. The function :func:`validate_fi_veronumero() <dataprep.clean.clean_fi_veronumero.validate_fi_veronumero>` validates either a single Veronumero strings, a column of Veronumero strings or a DataFrame of Veronumero strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Veronumero strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"123456789123\"\n",
+    "* `standard`: Veronumero strings with proper whitespace in the proper places. Note that in the case of Veronumero, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_fi_veronumero()` and `validate_fi_veronumero()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing Veronumero strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"veronumero\": [\n",
+    "            '123456789123',\n",
+    "            '12345678912A',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_fi_veronumero`\n",
+    "\n",
+    "By default, `clean_fi_veronumero` will clean veronumero strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_fi_veronumero\n",
+    "clean_fi_veronumero(df, column = \"veronumero\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_veronumero(df, column = \"veronumero\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_veronumero(df, column = \"veronumero\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned Veronumero strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_veronumero(df, column=\"veronumero\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_veronumero(df, \"veronumero\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_veronumero(df, \"veronumero\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_fi_veronumero()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_fi_veronumero()` returns `True` when the input is a valid Veronumero. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_fi_veronumero()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_fi_veronumero()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_fi_veronumero()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_fi_veronumero\n",
+    "print(validate_fi_veronumero(\"123456789123\"))\n",
+    "print(validate_fi_veronumero(\"12345678912A\"))\n",
+    "print(validate_fi_veronumero('BE 428759497'))\n",
+    "print(validate_fi_veronumero('BE431150351'))\n",
+    "print(validate_fi_veronumero(\"004085616\"))\n",
+    "print(validate_fi_veronumero(\"hello\"))\n",
+    "print(validate_fi_veronumero(np.nan))\n",
+    "print(validate_fi_veronumero(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fi_veronumero(df[\"veronumero\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fi_veronumero(df, column=\"veronumero\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_fi_veronumero(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_fi_ytunnus.ipynb
+++ b/docs/source/user_guide/clean/clean_fi_ytunnus.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _ytunnus_userguide:\n",
+    "\n",
+    "y-tunnus Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_fi_ytunnus() <dataprep.clean.clean_fi_ytunnus.clean_fi_ytunnus>` cleans a column containing Finnish business identifier (y-tunnus) strings, and standardizes them in a given format. The function :func:`validate_fi_ytunnus() <dataprep.clean.clean_fi_ytunnus.validate_fi_ytunnus>` validates either a single y-tunnus strings, a column of y-tunnus strings or a DataFrame of y-tunnus strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "y-tunnus strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"20774740\"\n",
+    "* `standard`: y-tunnus strings with proper whitespace in the proper places, like \"2077474-0\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_fi_ytunnus()` and `validate_fi_ytunnus()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing y-tunnus strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"ytunnus\": [\n",
+    "            \"20774740\",\n",
+    "            \"2077474-1\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_fi_ytunnus`\n",
+    "\n",
+    "By default, `clean_fi_ytunnus` will clean ytunnus strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_fi_ytunnus\n",
+    "clean_fi_ytunnus(df, column = \"ytunnus\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_ytunnus(df, column = \"ytunnus\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_ytunnus(df, column = \"ytunnus\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned y-tunnus strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_ytunnus(df, column=\"ytunnus\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_ytunnus(df, \"ytunnus\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fi_ytunnus(df, \"ytunnus\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_fi_ytunnus()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_fi_ytunnus()` returns `True` when the input is a valid y-tunnus. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_fi_ytunnus()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_fi_ytunnus()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_fi_ytunnus()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_fi_ytunnus\n",
+    "print(validate_fi_ytunnus(\"20774740\"))\n",
+    "print(validate_fi_ytunnus(\"2077474-1\"))\n",
+    "print(validate_fi_ytunnus(\"51824753556\"))\n",
+    "print(validate_fi_ytunnus(\"51 824 753 556\"))\n",
+    "print(validate_fi_ytunnus(\"hello\"))\n",
+    "print(validate_fi_ytunnus(np.nan))\n",
+    "print(validate_fi_ytunnus(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fi_ytunnus(df[\"ytunnus\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fi_ytunnus(df, column=\"ytunnus\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_fi_ytunnus(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_fr_nif.ipynb
+++ b/docs/source/user_guide/clean/clean_fr_nif.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _nif_userguide:\n",
+    "\n",
+    "NIF Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_fr_nif() <dataprep.clean.clean_fr_nif.clean_fr_nif>` cleans a column containing French tax identification number (NIF) strings, and standardizes them in a given format. The function :func:`validate_fr_nif() <dataprep.clean.clean_fr_nif.validate_fr_nif>` validates either a single NIF strings, a column of NIF strings or a DataFrame of NIF strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NIF strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"0701987765432\"\n",
+    "* `standard`: NIF strings with proper whitespace in the proper places, like \"07 01 987 765 432\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_fr_nif()` and `validate_fr_nif()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing NIF strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"nif\": [\n",
+    "            \"0701987765432\",\n",
+    "            \"070198776543\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_fr_nif`\n",
+    "\n",
+    "By default, `clean_fr_nif` will clean nif strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_fr_nif\n",
+    "clean_fr_nif(df, column = \"nif\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_nif(df, column = \"nif\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_nif(df, column = \"nif\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned NIF strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_nif(df, column=\"nif\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_nif(df, \"nif\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_nif(df, \"nif\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_fr_nif()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_fr_nif()` returns `True` when the input is a valid NIF. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_fr_nif()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_fr_nif()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_fr_nif()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_fr_nif\n",
+    "print(validate_fr_nif(\"0701987765432\"))\n",
+    "print(validate_fr_nif(\"070198776543\"))\n",
+    "print(validate_fr_nif(\"51824753556\"))\n",
+    "print(validate_fr_nif(\"51 824 753 556\"))\n",
+    "print(validate_fr_nif(\"hello\"))\n",
+    "print(validate_fr_nif(np.nan))\n",
+    "print(validate_fr_nif(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fr_nif(df[\"nif\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fr_nif(df, column=\"nif\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_fr_nif(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_fr_nir.ipynb
+++ b/docs/source/user_guide/clean/clean_fr_nir.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _nir_userguide:\n",
+    "\n",
+    "NIR Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_fr_nir() <dataprep.clean.clean_fr_nir.clean_fr_nir>` cleans a column containing French personal identification number (NIR) strings, and standardizes them in a given format. The function :func:`validate_fr_nir() <dataprep.clean.clean_fr_nir.validate_fr_nir>` validates either a single NIR strings, a column of NIR strings or a DataFrame of NIR strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NIR strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"295109912611193\"\n",
+    "* `standard`: NIR strings with proper whitespace in the proper places, like \"2 95 10 99 126 111 93\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_fr_nir()` and `validate_fr_nir()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing NIR strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"nir\": [\n",
+    "            \"295109912611193\",\n",
+    "            \"253072C07300443\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_fr_nir`\n",
+    "\n",
+    "By default, `clean_fr_nir` will clean nir strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_fr_nir\n",
+    "clean_fr_nir(df, column = \"nir\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_nir(df, column = \"nir\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_nir(df, column = \"nir\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned NIR strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_nir(df, column=\"nir\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_nir(df, \"nir\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_nir(df, \"nir\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_fr_nir()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_fr_nir()` returns `True` when the input is a valid NIR. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_fr_nir()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_fr_nir()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_fr_nir()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_fr_nir\n",
+    "print(validate_fr_nir(\"295109912611193\"))\n",
+    "print(validate_fr_nir(\"253072C07300443\"))\n",
+    "print(validate_fr_nir(\"51824753556\"))\n",
+    "print(validate_fr_nir(\"51 824 753 556\"))\n",
+    "print(validate_fr_nir(\"hello\"))\n",
+    "print(validate_fr_nir(np.nan))\n",
+    "print(validate_fr_nir(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fr_nir(df[\"nir\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fr_nir(df, column=\"nir\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_fr_nir(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_fr_siren.ipynb
+++ b/docs/source/user_guide/clean/clean_fr_siren.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _siren_userguide:\n",
+    "\n",
+    "SIREN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_fr_siren() <dataprep.clean.clean_fr_siren.clean_fr_siren>` cleans a column containing French personal identification number (SIREN) strings, and standardizes them in a given format. The function :func:`validate_fr_siren() <dataprep.clean.clean_fr_siren.validate_fr_siren>` validates either a single SIREN strings, a column of SIREN strings or a DataFrame of SIREN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "SIREN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"552008443\"\n",
+    "* `standard`: SIREN strings with proper whitespace in the proper places. Note that in the case of SIREN, the compact format is the same as the standard one.\n",
+    "* `tva`: return a TVA that preposes two extra check digits to the data, like \"19 552 008 443\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_fr_siren()` and `validate_fr_siren()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing SIREN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"siren\": [\n",
+    "            '552 008 443',\n",
+    "            '404833047',\n",
+    "            '7542011030',\n",
+    "            '7552A10004',\n",
+    "            '8019010008', \n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_fr_siren`\n",
+    "\n",
+    "By default, `clean_fr_siren` will clean siren strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_fr_siren\n",
+    "clean_fr_siren(df, column = \"siren\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_siren(df, column = \"siren\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_siren(df, column = \"siren\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `tva`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_siren(df, column = \"siren\", output_format=\"tva\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned SIREN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_siren(df, column=\"siren\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_siren(df, \"siren\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_siren(df, \"siren\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_fr_siren()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_fr_siren()` returns `True` when the input is a valid SIREN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_fr_siren()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_fr_siren()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_fr_siren()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_fr_siren\n",
+    "print(validate_fr_siren('552 008 443'))\n",
+    "print(validate_fr_siren('404833047'))\n",
+    "print(validate_fr_siren('7542011030'))\n",
+    "print(validate_fr_siren('7552A10004'))\n",
+    "print(validate_fr_siren('8019010008'))\n",
+    "print(validate_fr_siren(\"hello\"))\n",
+    "print(validate_fr_siren(np.nan))\n",
+    "print(validate_fr_siren(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fr_siren(df[\"siren\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fr_siren(df, column=\"siren\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fr_siren(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_fr_siret.ipynb
+++ b/docs/source/user_guide/clean/clean_fr_siret.ipynb
@@ -1,0 +1,356 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _siret_userguide:\n",
+    "\n",
+    "SIRET Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_fr_siret() <dataprep.clean.clean_fr_siret.clean_fr_siret>` cleans a column containing French company establishment identification number (SIRET) strings, and standardizes them in a given format. The function :func:`validate_fr_siret() <dataprep.clean.clean_fr_siret.validate_fr_siret>` validates either a single SIRET strings, a column of SIRET strings or a DataFrame of SIRET strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "SIRET strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"73282932000074\"\n",
+    "* `standard`: SIRET strings with proper whitespace in the proper places, like \"732 829 320 00074\"\n",
+    "* `siren`: convert the SIRET number to a SIREN number, like \"732829320\".\n",
+    "* `tva`: convert the SIRET number to a TVA number, like \"44732829320\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_fr_siret()` and `validate_fr_siret()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing SIRET strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"siret\": [\n",
+    "            \"73282932000074\",\n",
+    "            \"73282932000079\",\n",
+    "            \"999 999 999\",\n",
+    "            \"004085616\",\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_fr_siret`\n",
+    "\n",
+    "By default, `clean_fr_siret` will clean siret strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_fr_siret\n",
+    "clean_fr_siret(df, column = \"siret\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_siret(df, column = \"siret\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_siret(df, column = \"siret\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `siren`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_siret(df, column = \"siret\", output_format=\"siren\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `tva`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_siret(df, column = \"siret\", output_format=\"tva\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned SIRET strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_siret(df, column=\"siret\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_siret(df, \"siret\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_siret(df, \"siret\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_fr_siret()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_fr_siret()` returns `True` when the input is a valid SIRET. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_fr_siret()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_fr_siret()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_fr_siret()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_fr_siret\n",
+    "print(validate_fr_siret(\"73282932000074\"))\n",
+    "print(validate_fr_siret(\"73282932000079\"))\n",
+    "print(validate_fr_siret(\"999 999 999\"))\n",
+    "print(validate_fr_siret(\"51824753556\"))\n",
+    "print(validate_fr_siret(\"004085616\"))\n",
+    "print(validate_fr_siret(\"hello\"))\n",
+    "print(validate_fr_siret(np.nan))\n",
+    "print(validate_fr_siret(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fr_siret(df[\"siret\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fr_siret(df, column=\"siret\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_fr_siret(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_fr_tva.ipynb
+++ b/docs/source/user_guide/clean/clean_fr_tva.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _tva_userguide:\n",
+    "\n",
+    "TVA Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_fr_tva() <dataprep.clean.clean_fr_tva.clean_fr_tva>` cleans a column containing French TVA number (TVA) strings, and standardizes them in a given format. The function :func:`validate_fr_tva() <dataprep.clean.clean_fr_tva.validate_fr_tva>` validates either a single TVA strings, a column of TVA strings or a DataFrame of TVA strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TVA strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"40303265045\"\n",
+    "* `standard`: TVA strings with proper whitespace in the proper places. Note that in the case of TVA, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_fr_tva()` and `validate_fr_tva()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing TVA strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"tva\": [\n",
+    "            'Fr 40 303 265 045',\n",
+    "            '84 323 140 391',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_fr_tva`\n",
+    "\n",
+    "By default, `clean_fr_tva` will clean tva strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_fr_tva\n",
+    "clean_fr_tva(df, column = \"tva\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_tva(df, column = \"tva\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_tva(df, column = \"tva\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned TVA strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_tva(df, column=\"tva\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_tva(df, \"tva\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_fr_tva(df, \"tva\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_fr_tva()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_fr_tva()` returns `True` when the input is a valid TVA. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_fr_tva()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_fr_tva()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_fr_tva()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_fr_tva\n",
+    "print(validate_fr_tva('Fr 40 303 265 045'))\n",
+    "print(validate_fr_tva('84 323 140 391'))\n",
+    "print(validate_fr_tva('BE 428759497'))\n",
+    "print(validate_fr_tva('BE431150351'))\n",
+    "print(validate_fr_tva(\"004085616\"))\n",
+    "print(validate_fr_tva(\"hello\"))\n",
+    "print(validate_fr_tva(np.nan))\n",
+    "print(validate_fr_tva(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fr_tva(df[\"tva\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_fr_tva(df, column=\"tva\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_fr_tva(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_gb_nhs.ipynb
+++ b/docs/source/user_guide/clean/clean_gb_nhs.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _nhs_userguide:\n",
+    "\n",
+    "NHS Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_gb_nhs() <dataprep.clean.clean_gb_nhs.clean_gb_nhs>` cleans a column containing United Kingdom National Health Service patient identifier (NHS) strings, and standardizes them in a given format. The function :func:`validate_gb_nhs() <dataprep.clean.clean_gb_nhs.validate_gb_nhs>` validates either a single NHS strings, a column of NHS strings or a DataFrame of NHS strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NHS strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"9434765870\"\n",
+    "* `standard`: NHS strings with proper whitespace in the proper places, like \"943 476 5870\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_gb_nhs()` and `validate_gb_nhs()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing NHS strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"nhs\": [\n",
+    "            \"9434765870\",\n",
+    "            \"9434765871\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_gb_nhs`\n",
+    "\n",
+    "By default, `clean_gb_nhs` will clean nhs strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_gb_nhs\n",
+    "clean_gb_nhs(df, column = \"nhs\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_nhs(df, column = \"nhs\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_nhs(df, column = \"nhs\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned NHS strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_nhs(df, column=\"nhs\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_nhs(df, \"nhs\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_nhs(df, \"nhs\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_gb_nhs()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_gb_nhs()` returns `True` when the input is a valid NHS. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_gb_nhs()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_gb_nhs()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_gb_nhs()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_gb_nhs\n",
+    "print(validate_gb_nhs(\"9434765870\"))\n",
+    "print(validate_gb_nhs(\"9434765871\"))\n",
+    "print(validate_gb_nhs(\"51824753556\"))\n",
+    "print(validate_gb_nhs(\"51 824 753 556\"))\n",
+    "print(validate_gb_nhs(\"hello\"))\n",
+    "print(validate_gb_nhs(np.nan))\n",
+    "print(validate_gb_nhs(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gb_nhs(df[\"nhs\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gb_nhs(df, column=\"nhs\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_gb_nhs(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_gb_sedol.ipynb
+++ b/docs/source/user_guide/clean/clean_gb_sedol.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _sedol_userguide:\n",
+    "\n",
+    "SEDOL Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_gb_sedol() <dataprep.clean.clean_gb_sedol.clean_gb_sedol>` cleans a column containing Stock Exchange Daily Official List number (SEDOL) strings, and standardizes them in a given format. The function :func:`validate_gb_sedol() <dataprep.clean.clean_gb_sedol.validate_gb_sedol>` validates either a single SEDOL strings, a column of SEDOL strings or a DataFrame of SEDOL strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "SEDOL strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"B15KXQ8\"\n",
+    "* `standard`: SEDOL strings with proper whitespace in the proper places. Note that in the case of SEDOL, the compact format is the same as the standard one.\n",
+    "* `isin`: convert the number to an ISIN, like \"GB00B15KXQ89\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_gb_sedol()` and `validate_gb_sedol()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing SEDOL strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"sedol\": [\n",
+    "            'B15KXQ8',\n",
+    "            'B15KXQ7',\n",
+    "            '7542011030',\n",
+    "            '7552A10004',\n",
+    "            '8019010008',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_gb_sedol`\n",
+    "\n",
+    "By default, `clean_gb_sedol` will clean sedol strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_gb_sedol\n",
+    "clean_gb_sedol(df, column = \"sedol\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "clean_gb_sedol(df, column = \"sedol\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_sedol(df, column = \"sedol\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `isin`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_sedol(df, column = \"sedol\", output_format=\"isin\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned SEDOL strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_sedol(df, column=\"sedol\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_sedol(df, \"sedol\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_sedol(df, \"sedol\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_gb_sedol()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_gb_sedol()` returns `True` when the input is a valid SEDOL. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_gb_sedol()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_gb_sedol()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_gb_sedol()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_gb_sedol\n",
+    "print(validate_gb_sedol('B15KXQ8'))\n",
+    "print(validate_gb_sedol('B15KXQ7'))\n",
+    "print(validate_gb_sedol('7542011030'))\n",
+    "print(validate_gb_sedol('7552A10004'))\n",
+    "print(validate_gb_sedol('8019010008'))\n",
+    "print(validate_gb_sedol(\"hello\"))\n",
+    "print(validate_gb_sedol(np.nan))\n",
+    "print(validate_gb_sedol(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gb_sedol(df[\"sedol\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gb_sedol(df, column=\"sedol\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gb_sedol(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_gb_upn.ipynb
+++ b/docs/source/user_guide/clean/clean_gb_upn.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _upn_userguide:\n",
+    "\n",
+    "UPN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_gb_upn() <dataprep.clean.clean_gb_upn.clean_gb_upn>` cleans a column containing English Unique Pupil Number (UPN) strings, and standardizes them in a given format. The function :func:`validate_gb_upn() <dataprep.clean.clean_gb_upn.validate_gb_upn>` validates either a single UPN strings, a column of UPN strings or a DataFrame of UPN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "UPN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"B801200005001\"\n",
+    "* `standard`: UPN strings with proper whitespace in the proper places. Note that in the case of UPN, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_gb_upn()` and `validate_gb_upn()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing UPN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"upn\": [\n",
+    "            'B801200005001',\n",
+    "            'A801200005001',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_gb_upn`\n",
+    "\n",
+    "By default, `clean_gb_upn` will clean upn strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_gb_upn\n",
+    "clean_gb_upn(df, column = \"upn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_upn(df, column = \"upn\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_upn(df, column = \"upn\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned UPN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_upn(df, column=\"upn\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_upn(df, \"upn\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_upn(df, \"upn\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_gb_upn()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_gb_upn()` returns `True` when the input is a valid UPN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_gb_upn()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_gb_upn()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_gb_upn()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_gb_upn\n",
+    "print(validate_gb_upn(\"B801200005001\"))\n",
+    "print(validate_gb_upn(\"A801200005001\"))\n",
+    "print(validate_gb_upn('BE 428759497'))\n",
+    "print(validate_gb_upn('BE431150351'))\n",
+    "print(validate_gb_upn(\"004085616\"))\n",
+    "print(validate_gb_upn(\"hello\"))\n",
+    "print(validate_gb_upn(np.nan))\n",
+    "print(validate_gb_upn(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gb_upn(df[\"upn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gb_upn(df, column=\"upn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gb_upn(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_gb_utr.ipynb
+++ b/docs/source/user_guide/clean/clean_gb_utr.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _utr_userguide:\n",
+    "\n",
+    "UTR Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_gb_utr() <dataprep.clean.clean_gb_utr.clean_gb_utr>` cleans a column containing United Kingdom Unique Taxpayer Reference (UTR) strings, and standardizes them in a given format. The function :func:`validate_gb_utr() <dataprep.clean.clean_gb_utr.validate_gb_utr>` validates either a single UTR strings, a column of UTR strings or a DataFrame of UTR strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "UTR strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"1955839661\"\n",
+    "* `standard`: UTR strings with proper whitespace in the proper places. Note that in the case of UTR, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_gb_utr()` and `validate_gb_utr()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing UTR strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"utr\": [\n",
+    "            '1955839661',\n",
+    "            '2955839661',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_gb_utr`\n",
+    "\n",
+    "By default, `clean_gb_utr` will clean utr strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_gb_utr\n",
+    "clean_gb_utr(df, column = \"utr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_utr(df, column = \"utr\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_utr(df, column = \"utr\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned UTR strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_utr(df, column=\"utr\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_utr(df, \"utr\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_utr(df, \"utr\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_gb_utr()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_gb_utr()` returns `True` when the input is a valid UTR. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_gb_utr()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_gb_utr()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_gb_utr()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_gb_utr\n",
+    "print(validate_gb_utr(\"1955839661\"))\n",
+    "print(validate_gb_utr(\"2955839661\"))\n",
+    "print(validate_gb_utr('BE 428759497'))\n",
+    "print(validate_gb_utr('BE431150351'))\n",
+    "print(validate_gb_utr(\"004085616\"))\n",
+    "print(validate_gb_utr(\"hello\"))\n",
+    "print(validate_gb_utr(np.nan))\n",
+    "print(validate_gb_utr(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gb_utr(df[\"utr\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gb_utr(df, column=\"utr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gb_utr(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_gb_vat.ipynb
+++ b/docs/source/user_guide/clean/clean_gb_vat.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _vat_userguide:\n",
+    "\n",
+    "VAT Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_gb_vat() <dataprep.clean.clean_gb_vat.clean_gb_vat>` cleans a column containing United Kingdom VAT number (VAT) strings, and standardizes them in a given format. The function :func:`validate_gb_vat() <dataprep.clean.clean_gb_vat.validate_gb_vat>` validates either a single VAT strings, a column of VAT strings or a DataFrame of VAT strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "VAT strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"980780684\"\n",
+    "* `standard`: VAT strings with proper whitespace in the proper places, like \"980 7806 84\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_gb_vat()` and `validate_gb_vat()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing VAT strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"vat\": [\n",
+    "            \"980780684\",\n",
+    "            \"802311781\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_gb_vat`\n",
+    "\n",
+    "By default, `clean_gb_vat` will clean vat strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_gb_vat\n",
+    "clean_gb_vat(df, column = \"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_vat(df, column = \"vat\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_vat(df, column = \"vat\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned VAT strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_vat(df, column=\"vat\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_vat(df, \"vat\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gb_vat(df, \"vat\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_gb_vat()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_gb_vat()` returns `True` when the input is a valid VAT. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_gb_vat()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_gb_vat()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_gb_vat()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_gb_vat\n",
+    "print(validate_gb_vat(\"980780684\"))\n",
+    "print(validate_gb_vat(\"802311781\"))\n",
+    "print(validate_gb_vat(\"51824753556\"))\n",
+    "print(validate_gb_vat(\"51 824 753 556\"))\n",
+    "print(validate_gb_vat(\"hello\"))\n",
+    "print(validate_gb_vat(np.nan))\n",
+    "print(validate_gb_vat(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gb_vat(df[\"vat\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gb_vat(df, column=\"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gb_vat(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_gr_amka.ipynb
+++ b/docs/source/user_guide/clean/clean_gr_amka.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _amka_userguide:\n",
+    "\n",
+    "AMKA Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_gr_amka() <dataprep.clean.clean_gr_amka.clean_gr_amka>` cleans a column containing Greek social security number (AMKA) strings, and standardizes them in a given format. The function :func:`validate_gr_amka() <dataprep.clean.clean_gr_amka.validate_gr_amka>` validates either a single AMKA strings, a column of AMKA strings or a DataFrame of AMKA strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "AMKA strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"01013099997\"\n",
+    "* `standard`: AMKA strings with proper whitespace in the proper places. Note that in the case of AMKA, the compact format is the same as the standard one.\n",
+    "* `birthdate`: split the date parts from the number and return the birth date, like \"1930-01-01\".\n",
+    "* `gender`: get the person's birth gender ('M' or 'F').\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_gr_amka()` and `validate_gr_amka()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing AMKA strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"amka\": [\n",
+    "            '01013099997',\n",
+    "            '01013099999',\n",
+    "            '7542011030',\n",
+    "            '7552A10004',\n",
+    "            '8019010008',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_gr_amka`\n",
+    "\n",
+    "By default, `clean_gr_amka` will clean amka strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_gr_amka\n",
+    "clean_gr_amka(df, column = \"amka\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gr_amka(df, column = \"amka\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gr_amka(df, column = \"amka\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gr_amka(df, column = \"amka\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `gender`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gr_amka(df, column = \"amka\", output_format=\"gender\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned AMKA strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gr_amka(df, column=\"amka\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gr_amka(df, \"amka\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gr_amka(df, \"amka\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_gr_amka()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_gr_amka()` returns `True` when the input is a valid AMKA. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_gr_amka()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_gr_amka()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_gr_amka()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_gr_amka\n",
+    "print(validate_gr_amka('01013099997'))\n",
+    "print(validate_gr_amka('01013099999'))\n",
+    "print(validate_gr_amka('7542011030'))\n",
+    "print(validate_gr_amka('7552A10004'))\n",
+    "print(validate_gr_amka('8019010008'))\n",
+    "print(validate_gr_amka(\"hello\"))\n",
+    "print(validate_gr_amka(np.nan))\n",
+    "print(validate_gr_amka(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gr_amka(df[\"amka\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gr_amka(df, column=\"amka\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gr_amka(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_gr_vat.ipynb
+++ b/docs/source/user_guide/clean/clean_gr_vat.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _vat_userguide:\n",
+    "\n",
+    "VAT Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_gr_vat() <dataprep.clean.clean_gr_vat.clean_gr_vat>` cleans a column containing Greek VAT number (VAT) strings, and standardizes them in a given format. The function :func:`validate_gr_vat() <dataprep.clean.clean_gr_vat.validate_gr_vat>` validates either a single VAT strings, a column of VAT strings or a DataFrame of VAT strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "VAT strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"094259216\"\n",
+    "* `standard`: VAT strings with proper whitespace in the proper places. Note that in the case of VAT, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_gr_vat()` and `validate_gr_vat()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing VAT strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"vat\": [\n",
+    "            'EL 094259216',\n",
+    "            'EL 123456781',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_gr_vat`\n",
+    "\n",
+    "By default, `clean_gr_vat` will clean vat strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_gr_vat\n",
+    "clean_gr_vat(df, column = \"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gr_vat(df, column = \"vat\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gr_vat(df, column = \"vat\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned VAT strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gr_vat(df, column=\"vat\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gr_vat(df, \"vat\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gr_vat(df, \"vat\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_gr_vat()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_gr_vat()` returns `True` when the input is a valid VAT. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_gr_vat()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_gr_vat()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_gr_vat()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_gr_vat\n",
+    "print(validate_gr_vat(\"EL 094259216\"))\n",
+    "print(validate_gr_vat(\"EL 123456781\"))\n",
+    "print(validate_gr_vat('BE 428759497'))\n",
+    "print(validate_gr_vat('BE431150351'))\n",
+    "print(validate_gr_vat(\"004085616\"))\n",
+    "print(validate_gr_vat(\"hello\"))\n",
+    "print(validate_gr_vat(np.nan))\n",
+    "print(validate_gr_vat(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gr_vat(df[\"vat\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gr_vat(df, column=\"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gr_vat(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_gt_nit.ipynb
+++ b/docs/source/user_guide/clean/clean_gt_nit.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _nit_userguide:\n",
+    "\n",
+    "NIT Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_gt_nit() <dataprep.clean.clean_gt_nit.clean_gt_nit>` cleans a column containing Guatemala tax number (NIT) strings, and standardizes them in a given format. The function :func:`validate_gt_nit() <dataprep.clean.clean_gt_nit.validate_gt_nit>` validates either a single NIT strings, a column of NIT strings or a DataFrame of NIT strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NIT strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"39525503\"\n",
+    "* `standard`: NIT strings with proper whitespace in the proper places, like \"3952550-3\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_gt_nit()` and `validate_gt_nit()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing NIT strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"nit\": [\n",
+    "            \"39525503\",\n",
+    "            \"8977112-0\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_gt_nit`\n",
+    "\n",
+    "By default, `clean_gt_nit` will clean nit strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_gt_nit\n",
+    "clean_gt_nit(df, column = \"nit\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gt_nit(df, column = \"nit\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gt_nit(df, column = \"nit\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned NIT strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gt_nit(df, column=\"nit\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gt_nit(df, \"nit\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_gt_nit(df, \"nit\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_gt_nit()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_gt_nit()` returns `True` when the input is a valid NIT. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_gt_nit()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_gt_nit()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_gt_nit()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_gt_nit\n",
+    "print(validate_gt_nit(\"39525503\"))\n",
+    "print(validate_gt_nit(\"8977112-0\"))\n",
+    "print(validate_gt_nit(\"51824753556\"))\n",
+    "print(validate_gt_nit(\"51 824 753 556\"))\n",
+    "print(validate_gt_nit(\"hello\"))\n",
+    "print(validate_gt_nit(np.nan))\n",
+    "print(validate_gt_nit(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gt_nit(df[\"nit\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_gt_nit(df, column=\"nit\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_gt_nit(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_hr_oib.ipynb
+++ b/docs/source/user_guide/clean/clean_hr_oib.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _oib_userguide:\n",
+    "\n",
+    "OIB Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_hr_oib() <dataprep.clean.clean_hr_oib.clean_hr_oib>` cleans a column containing Croatian identification number (OIB) strings, and standardizes them in a given format. The function :func:`validate_hr_oib() <dataprep.clean.clean_hr_oib.validate_hr_oib>` validates either a single OIB strings, a column of OIB strings or a DataFrame of OIB strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "OIB strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"33392005961\"\n",
+    "* `standard`: OIB strings with proper whitespace in the proper places. Note that in the case of OIB, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_hr_oib()` and `validate_hr_oib()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing OIB strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"oib\": [\n",
+    "            'HR 33392005961',\n",
+    "            '33392005962',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_hr_oib`\n",
+    "\n",
+    "By default, `clean_hr_oib` will clean oib strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_hr_oib\n",
+    "clean_hr_oib(df, column = \"oib\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_hr_oib(df, column = \"oib\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_hr_oib(df, column = \"oib\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned OIB strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_hr_oib(df, column=\"oib\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_hr_oib(df, \"oib\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_hr_oib(df, \"oib\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_hr_oib()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_hr_oib()` returns `True` when the input is a valid OIB. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_hr_oib()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_hr_oib()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_hr_oib()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_hr_oib\n",
+    "print(validate_hr_oib(\"HR 33392005961\"))\n",
+    "print(validate_hr_oib(\"33392005962\"))\n",
+    "print(validate_hr_oib('BE 428759497'))\n",
+    "print(validate_hr_oib('BE431150351'))\n",
+    "print(validate_hr_oib(\"004085616\"))\n",
+    "print(validate_hr_oib(\"hello\"))\n",
+    "print(validate_hr_oib(np.nan))\n",
+    "print(validate_hr_oib(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_hr_oib(df[\"oib\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_hr_oib(df, column=\"oib\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_hr_oib(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_hu_anum.ipynb
+++ b/docs/source/user_guide/clean/clean_hu_anum.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _anum_userguide:\n",
+    "\n",
+    "ANUM Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_hu_anum() <dataprep.clean.clean_hu_anum.clean_hu_anum>` cleans a column containing Hungarian ANUM number (ANUM) strings, and standardizes them in a given format. The function :func:`validate_hu_anum() <dataprep.clean.clean_hu_anum.validate_hu_anum>` validates either a single ANUM strings, a column of ANUM strings or a DataFrame of ANUM strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ANUM strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"12892312\"\n",
+    "* `standard`: ANUM strings with proper whitespace in the proper places. Note that in the case of ANUM, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_hu_anum()` and `validate_hu_anum()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing ANUM strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"anum\": [\n",
+    "            'HU-12892312',\n",
+    "            'HU-12892313',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_hu_anum`\n",
+    "\n",
+    "By default, `clean_hu_anum` will clean anum strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_hu_anum\n",
+    "clean_hu_anum(df, column = \"anum\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_hu_anum(df, column = \"anum\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_hu_anum(df, column = \"anum\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned ANUM strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_hu_anum(df, column=\"anum\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_hu_anum(df, \"anum\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_hu_anum(df, \"anum\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_hu_anum()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_hu_anum()` returns `True` when the input is a valid ANUM. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_hu_anum()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_hu_anum()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_hu_anum()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_hu_anum\n",
+    "print(validate_hu_anum(\"HU-12892312\"))\n",
+    "print(validate_hu_anum(\"HU-12892313\"))\n",
+    "print(validate_hu_anum('BE 428759497'))\n",
+    "print(validate_hu_anum('BE431150351'))\n",
+    "print(validate_hu_anum(\"004085616\"))\n",
+    "print(validate_hu_anum(\"hello\"))\n",
+    "print(validate_hu_anum(np.nan))\n",
+    "print(validate_hu_anum(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_hu_anum(df[\"anum\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_hu_anum(df, column=\"anum\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_hu_anum(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_id_npwp.ipynb
+++ b/docs/source/user_guide/clean/clean_id_npwp.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _npwp_userguide:\n",
+    "\n",
+    "NPWP Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_id_npwp() <dataprep.clean.clean_id_npwp.clean_id_npwp>` cleans a column containing Indonesian VAT Number (NPWP) strings, and standardizes them in a given format. The function :func:`validate_id_npwp() <dataprep.clean.clean_id_npwp.validate_id_npwp>` validates either a single NPWP strings, a column of NPWP strings or a DataFrame of NPWP strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NPWP strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"013000666091000\"\n",
+    "* `standard`: NPWP strings with proper whitespace in the proper places, like \"01.300.066.6-091.000\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_id_npwp()` and `validate_id_npwp()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing NPWP strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"npwp\": [\n",
+    "            \"013000666091000\",\n",
+    "            \"123456789\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_id_npwp`\n",
+    "\n",
+    "By default, `clean_id_npwp` will clean npwp strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_id_npwp\n",
+    "clean_id_npwp(df, column = \"npwp\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_id_npwp(df, column = \"npwp\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_id_npwp(df, column = \"npwp\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned NPWP strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_id_npwp(df, column=\"npwp\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_id_npwp(df, \"npwp\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_id_npwp(df, \"npwp\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_id_npwp()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_id_npwp()` returns `True` when the input is a valid NPWP. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_id_npwp()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_id_npwp()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_id_npwp()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_id_npwp\n",
+    "print(validate_id_npwp(\"013000666091000\"))\n",
+    "print(validate_id_npwp(\"123456789\"))\n",
+    "print(validate_id_npwp(\"51824753556\"))\n",
+    "print(validate_id_npwp(\"51 824 753 556\"))\n",
+    "print(validate_id_npwp(\"hello\"))\n",
+    "print(validate_id_npwp(np.nan))\n",
+    "print(validate_id_npwp(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_id_npwp(df[\"npwp\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_id_npwp(df, column=\"npwp\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_id_npwp(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ie_pps.ipynb
+++ b/docs/source/user_guide/clean/clean_ie_pps.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _pps_userguide:\n",
+    "\n",
+    "PPS Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ie_pps() <dataprep.clean.clean_ie_pps.clean_ie_pps>` cleans a column containing Irish personal number (PPS) strings, and standardizes them in a given format. The function :func:`validate_ie_pps() <dataprep.clean.clean_ie_pps.validate_ie_pps>` validates either a single PPS strings, a column of PPS strings or a DataFrame of PPS strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "PPS strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"6433435OA\"\n",
+    "* `standard`: PPS strings with proper whitespace in the proper places. Note that in the case of PPS, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ie_pps()` and `validate_ie_pps()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing PPS strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"pps\": [\n",
+    "            '6433435OA',\n",
+    "            '6433435VH',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ie_pps`\n",
+    "\n",
+    "By default, `clean_ie_pps` will clean pps strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ie_pps\n",
+    "clean_ie_pps(df, column = \"pps\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ie_pps(df, column = \"pps\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ie_pps(df, column = \"pps\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned PPS strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ie_pps(df, column=\"pps\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ie_pps(df, \"pps\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ie_pps(df, \"pps\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ie_pps()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ie_pps()` returns `True` when the input is a valid PPS. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ie_pps()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ie_pps()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ie_pps()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ie_pps\n",
+    "print(validate_ie_pps(\"6433435OA\"))\n",
+    "print(validate_ie_pps(\"6433435VH\"))\n",
+    "print(validate_ie_pps('BE 428759497'))\n",
+    "print(validate_ie_pps('BE431150351'))\n",
+    "print(validate_ie_pps(\"004085616\"))\n",
+    "print(validate_ie_pps(\"hello\"))\n",
+    "print(validate_ie_pps(np.nan))\n",
+    "print(validate_ie_pps(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ie_pps(df[\"pps\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ie_pps(df, column=\"pps\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ie_pps(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ie_vat.ipynb
+++ b/docs/source/user_guide/clean/clean_ie_vat.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _vat_userguide:\n",
+    "\n",
+    "VAT Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ie_vat() <dataprep.clean.clean_ie_vat.clean_ie_vat>` cleans a column containing Irish VAT numbers (VAT) strings, and standardizes them in a given format. The function :func:`validate_ie_vat() <dataprep.clean.clean_ie_vat.validate_ie_vat>` validates either a single VAT strings, a column of VAT strings or a DataFrame of VAT strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "VAT strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"6433435OA\"\n",
+    "* `standard`: VAT strings with proper whitespace in the proper places. Note that in the case of VAT, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ie_vat()` and `validate_ie_vat()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing VAT strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"vat\": [\n",
+    "            'IE 6433435OA',\n",
+    "            '6433435E',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ie_vat`\n",
+    "\n",
+    "By default, `clean_ie_vat` will clean vat strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ie_vat\n",
+    "clean_ie_vat(df, column = \"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ie_vat(df, column = \"vat\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ie_vat(df, column = \"vat\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned VAT strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ie_vat(df, column=\"vat\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ie_vat(df, \"vat\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ie_vat(df, \"vat\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ie_vat()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ie_vat()` returns `True` when the input is a valid VAT. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ie_vat()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ie_vat()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ie_vat()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ie_vat\n",
+    "print(validate_ie_vat('IE 6433435OA'))\n",
+    "print(validate_ie_vat('6433435E'))\n",
+    "print(validate_ie_vat('BE 428759497'))\n",
+    "print(validate_ie_vat('BE431150351'))\n",
+    "print(validate_ie_vat(\"004085616\"))\n",
+    "print(validate_ie_vat(\"hello\"))\n",
+    "print(validate_ie_vat(np.nan))\n",
+    "print(validate_ie_vat(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ie_vat(df[\"vat\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ie_vat(df, column=\"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ie_vat(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_il_hp.ipynb
+++ b/docs/source/user_guide/clean/clean_il_hp.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _hp_userguide:\n",
+    "\n",
+    "HP Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_il_hp() <dataprep.clean.clean_il_hp.clean_il_hp>` cleans a column containing Israeli company number (HP) strings, and standardizes them in a given format. The function :func:`validate_il_hp() <dataprep.clean.clean_il_hp.validate_il_hp>` validates either a single HP strings, a column of HP strings or a DataFrame of HP strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "HP strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"516179157\"\n",
+    "* `standard`: HP strings with proper whitespace in the proper places. Note that in the case of HP, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_il_hp()` and `validate_il_hp()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing HP strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"hp\": [\n",
+    "            ' 5161 79157 ',\n",
+    "            '516179150',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_il_hp`\n",
+    "\n",
+    "By default, `clean_il_hp` will clean hp strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_il_hp\n",
+    "clean_il_hp(df, column = \"hp\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_il_hp(df, column = \"hp\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_il_hp(df, column = \"hp\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned HP strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_il_hp(df, column=\"hp\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_il_hp(df, \"hp\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_il_hp(df, \"hp\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_il_hp()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_il_hp()` returns `True` when the input is a valid HP. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_il_hp()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_il_hp()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_il_hp()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_il_hp\n",
+    "print(validate_il_hp(' 5161 79157 '))\n",
+    "print(validate_il_hp('516179150'))\n",
+    "print(validate_il_hp('BE 428759497'))\n",
+    "print(validate_il_hp('BE431150351'))\n",
+    "print(validate_il_hp(\"004085616\"))\n",
+    "print(validate_il_hp(\"hello\"))\n",
+    "print(validate_il_hp(np.nan))\n",
+    "print(validate_il_hp(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_il_hp(df[\"hp\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_il_hp(df, column=\"hp\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_il_hp(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_il_idnr.ipynb
+++ b/docs/source/user_guide/clean/clean_il_idnr.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _idnr_userguide:\n",
+    "\n",
+    "IDNR Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_il_idnr() <dataprep.clean.clean_il_idnr.clean_il_idnr>` cleans a column containing Israeli personal number (IDNR) strings, and standardizes them in a given format. The function :func:`validate_il_idnr() <dataprep.clean.clean_il_idnr.validate_il_idnr>` validates either a single IDNR strings, a column of IDNR strings or a DataFrame of IDNR strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "IDNR strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"39337423\"\n",
+    "* `standard`: IDNR strings with proper whitespace in the proper places, like \"03933742-3\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_il_idnr()` and `validate_il_idnr()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing IDNR strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"idnr\": [\n",
+    "            \"39337423\",\n",
+    "            \"3933742-2\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_il_idnr`\n",
+    "\n",
+    "By default, `clean_il_idnr` will clean idnr strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_il_idnr\n",
+    "clean_il_idnr(df, column = \"idnr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_il_idnr(df, column = \"idnr\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_il_idnr(df, column = \"idnr\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned IDNR strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_il_idnr(df, column=\"idnr\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_il_idnr(df, \"idnr\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_il_idnr(df, \"idnr\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_il_idnr()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_il_idnr()` returns `True` when the input is a valid IDNR. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_il_idnr()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_il_idnr()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_il_idnr()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_il_idnr\n",
+    "print(validate_il_idnr(\"39337423\"))\n",
+    "print(validate_il_idnr(\"3933742-2\"))\n",
+    "print(validate_il_idnr(\"51824753556\"))\n",
+    "print(validate_il_idnr(\"51 824 753 556\"))\n",
+    "print(validate_il_idnr(\"hello\"))\n",
+    "print(validate_il_idnr(np.nan))\n",
+    "print(validate_il_idnr(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_il_idnr(df[\"idnr\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_il_idnr(df, column=\"idnr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_il_idnr(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_in_aadhaar.ipynb
+++ b/docs/source/user_guide/clean/clean_in_aadhaar.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _aadhaar_userguide:\n",
+    "\n",
+    "Aadhaar Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_in_aadhaar() <dataprep.clean.clean_in_aadhaar.clean_in_aadhaar>` cleans a column containing Indian digital resident personal identity number (Aadhaar) strings, and standardizes them in a given format. The function :func:`validate_in_aadhaar() <dataprep.clean.clean_in_aadhaar.validate_in_aadhaar>` validates either a single Aadhaar strings, a column of Aadhaar strings or a DataFrame of Aadhaar strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Aadhaar strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"234123412346\"\n",
+    "* `standard`: Aadhaar strings with proper whitespace in the proper places, like \"2341 2341 2346\"\n",
+    "* `mask`: mask the first 8 digits as per MeitY guidelines for securing identity information and Sensitive personal data, like \"XXXX XXXX 2346\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_in_aadhaar()` and `validate_in_aadhaar()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing Aadhaar strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"aadhaar\": [\n",
+    "            \"234123412346\",\n",
+    "            \"643343121\",\n",
+    "            \"999 999 999\",\n",
+    "            \"004085616\",\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_in_aadhaar`\n",
+    "\n",
+    "By default, `clean_in_aadhaar` will clean aadhaar strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_in_aadhaar\n",
+    "clean_in_aadhaar(df, column = \"aadhaar\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_in_aadhaar(df, column = \"aadhaar\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_in_aadhaar(df, column = \"aadhaar\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `mask`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_in_aadhaar(df, column = \"aadhaar\", output_format=\"mask\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned Aadhaar strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_in_aadhaar(df, column=\"aadhaar\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_in_aadhaar(df, \"aadhaar\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_in_aadhaar(df, \"aadhaar\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_in_aadhaar()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_in_aadhaar()` returns `True` when the input is a valid Aadhaar. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_in_aadhaar()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_in_aadhaar()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_in_aadhaar()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_in_aadhaar\n",
+    "print(validate_in_aadhaar(\"234123412346\"))\n",
+    "print(validate_in_aadhaar(\"643343121\"))\n",
+    "print(validate_in_aadhaar(\"999 999 999\"))\n",
+    "print(validate_in_aadhaar(\"51824753556\"))\n",
+    "print(validate_in_aadhaar(\"004085616\"))\n",
+    "print(validate_in_aadhaar(\"hello\"))\n",
+    "print(validate_in_aadhaar(np.nan))\n",
+    "print(validate_in_aadhaar(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_in_aadhaar(df[\"aadhaar\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_in_aadhaar(df, column=\"aadhaar\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_in_aadhaar(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_in_pan.ipynb
+++ b/docs/source/user_guide/clean/clean_in_pan.ipynb
@@ -1,0 +1,356 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _pan_userguide:\n",
+    "\n",
+    "PAN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_in_pan() <dataprep.clean.clean_in_pan.clean_in_pan>` cleans a column containing Indian Permanent Account number (PAN) strings, and standardizes them in a given format. The function :func:`validate_in_pan() <dataprep.clean.clean_in_pan.validate_in_pan>` validates either a single PAN strings, a column of PAN strings or a DataFrame of PAN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "PAN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"ACUPA7085R\"\n",
+    "* `standard`: PAN strings with proper whitespace in the proper places. Note that in the case of PAN, the compact format is the same as the standard one.\n",
+    "* `info`: return a dictionary containing information that can be decoded from the PAN, like {'card_holder_type': 'Individual', 'initial': 'A'}.\n",
+    "* `mask`: mask the PAN as per CBDT masking standard, like \"ACUPAXXXXR\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_in_pan()` and `validate_in_pan()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing PAN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"pan\": [\n",
+    "            'ACUPA7085R',\n",
+    "            '234123412347',\n",
+    "            '7542011030',\n",
+    "            '7552A10004',\n",
+    "            '8019010008',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_in_pan`\n",
+    "\n",
+    "By default, `clean_in_pan` will clean pan strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_in_pan\n",
+    "clean_in_pan(df, column = \"pan\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "clean_in_pan(df, column = \"pan\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_in_pan(df, column = \"pan\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `info`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_in_pan(df, column = \"pan\", output_format=\"info\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `mask`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_in_pan(df, column = \"pan\", output_format=\"mask\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned PAN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_in_pan(df, column=\"pan\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_in_pan(df, \"pan\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_in_pan(df, \"pan\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_in_pan()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_in_pan()` returns `True` when the input is a valid PAN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_in_pan()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_in_pan()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_in_pan()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_in_pan\n",
+    "print(validate_in_pan('ACUPA7085R'))\n",
+    "print(validate_in_pan('234123412347'))\n",
+    "print(validate_in_pan('7542011030'))\n",
+    "print(validate_in_pan('7552A10004'))\n",
+    "print(validate_in_pan('8019010008'))\n",
+    "print(validate_in_pan(\"hello\"))\n",
+    "print(validate_in_pan(np.nan))\n",
+    "print(validate_in_pan(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_in_pan(df[\"pan\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_in_pan(df, column=\"pan\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_in_pan(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_is_kennitala.ipynb
+++ b/docs/source/user_guide/clean/clean_is_kennitala.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _kennitala_userguide:\n",
+    "\n",
+    "Kennitala Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_is_kennitala() <dataprep.clean.clean_is_kennitala.clean_is_kennitala>` cleans a column containing Icelandic identity code (Kennitala) strings, and standardizes them in a given format. The function :func:`validate_is_kennitala() <dataprep.clean.clean_is_kennitala.validate_is_kennitala>` validates either a single Kennitala strings, a column of Kennitala strings or a DataFrame of Kennitala strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Kennitala strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"1201743399\"\n",
+    "* `standard`: Kennitala strings with proper whitespace in the proper places, like \"120174-3399\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_is_kennitala()` and `validate_is_kennitala()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing Kennitala strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"kennitala\": [\n",
+    "            \"1201743399\",\n",
+    "            \"320174-3399\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_is_kennitala`\n",
+    "\n",
+    "By default, `clean_is_kennitala` will clean kennitala strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_is_kennitala\n",
+    "clean_is_kennitala(df, column = \"kennitala\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_is_kennitala(df, column = \"kennitala\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_is_kennitala(df, column = \"kennitala\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned Kennitala strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_is_kennitala(df, column=\"kennitala\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_is_kennitala(df, \"kennitala\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_is_kennitala(df, \"kennitala\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_is_kennitala()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_is_kennitala()` returns `True` when the input is a valid Kennitala. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_is_kennitala()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_is_kennitala()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_is_kennitala()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_is_kennitala\n",
+    "print(validate_is_kennitala(\"1201743399\"))\n",
+    "print(validate_is_kennitala(\"320174-3399\"))\n",
+    "print(validate_is_kennitala(\"51824753556\"))\n",
+    "print(validate_is_kennitala(\"51 824 753 556\"))\n",
+    "print(validate_is_kennitala(\"hello\"))\n",
+    "print(validate_is_kennitala(np.nan))\n",
+    "print(validate_is_kennitala(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_is_kennitala(df[\"kennitala\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_is_kennitala(df, column=\"kennitala\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_is_kennitala(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_is_vsk.ipynb
+++ b/docs/source/user_guide/clean/clean_is_vsk.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _vsk_userguide:\n",
+    "\n",
+    "VSK Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_is_vsk() <dataprep.clean.clean_is_vsk.clean_is_vsk>` cleans a column containing Icelandic VSK number (VSK) strings, and standardizes them in a given format. The function :func:`validate_is_vsk() <dataprep.clean.clean_is_vsk.validate_is_vsk>` validates either a single VSK strings, a column of VSK strings or a DataFrame of VSK strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "VSK strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"00621\"\n",
+    "* `standard`: VSK strings with proper whitespace in the proper places. Note that in the case of VSK, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_is_vsk()` and `validate_is_vsk()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing VSK strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"vsk\": [\n",
+    "            'IS 00621',\n",
+    "            'IS 0062199',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_is_vsk`\n",
+    "\n",
+    "By default, `clean_is_vsk` will clean vsk strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_is_vsk\n",
+    "clean_is_vsk(df, column = \"vsk\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_is_vsk(df, column = \"vsk\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_is_vsk(df, column = \"vsk\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned VSK strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_is_vsk(df, column=\"vsk\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_is_vsk(df, \"vsk\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_is_vsk(df, \"vsk\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_is_vsk()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_is_vsk()` returns `True` when the input is a valid VSK. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_is_vsk()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_is_vsk()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_is_vsk()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_is_vsk\n",
+    "print(validate_is_vsk('IS 00621'))\n",
+    "print(validate_is_vsk('IS 0062199'))\n",
+    "print(validate_is_vsk('BE 428759497'))\n",
+    "print(validate_is_vsk('BE431150351'))\n",
+    "print(validate_is_vsk(\"004085616\"))\n",
+    "print(validate_is_vsk(\"hello\"))\n",
+    "print(validate_is_vsk(np.nan))\n",
+    "print(validate_is_vsk(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_is_vsk(df[\"vsk\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_is_vsk(df, column=\"vsk\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_is_vsk(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_it_aic.ipynb
+++ b/docs/source/user_guide/clean/clean_it_aic.ipynb
@@ -1,0 +1,356 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _aic_userguide:\n",
+    "\n",
+    "AIC Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_it_aic() <dataprep.clean.clean_it_aic.clean_it_aic>` cleans a column containing Italian code for identification of drug (AIC) strings, and standardizes them in a given format. The function :func:`validate_it_aic() <dataprep.clean.clean_it_aic.validate_it_aic>` validates either a single AIC strings, a column of AIC strings or a DataFrame of AIC strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "AIC strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"000307052\"\n",
+    "* `standard`: AIC strings with proper whitespace in the proper places. Note that in the case of AIC, the compact format is the same as the standard one.\n",
+    "* `base10`: convert a BASE32 representation to a BASE10 one, like \"000307052\".\n",
+    "* `base32`: convert a BASE10 representation to a BASE32 one, like \"009CVD\". Note 'compact' may contain both BASE10 and BASE32 represatation.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_it_aic()` and `validate_it_aic()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing AIC strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"aic\": [\n",
+    "            '000307052',\n",
+    "            '999999',\n",
+    "            '7542011030',\n",
+    "            '7552A10004',\n",
+    "            '8019010008',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_it_aic`\n",
+    "\n",
+    "By default, `clean_it_aic` will clean aic strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_it_aic\n",
+    "clean_it_aic(df, column = \"aic\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_aic(df, column = \"aic\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_aic(df, column = \"aic\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `base10`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_aic(df, column = \"aic\", output_format=\"base10\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `base32`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_aic(df, column = \"aic\", output_format=\"base32\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned AIC strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_aic(df, column=\"aic\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_aic(df, \"aic\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_aic(df, \"aic\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_it_aic()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_it_aic()` returns `True` when the input is a valid AIC. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_it_aic()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_it_aic()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_it_aic()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_it_aic\n",
+    "print(validate_it_aic('000307052'))\n",
+    "print(validate_it_aic('999999'))\n",
+    "print(validate_it_aic('7542011030'))\n",
+    "print(validate_it_aic('7552A10004'))\n",
+    "print(validate_it_aic('8019010008'))\n",
+    "print(validate_it_aic(\"hello\"))\n",
+    "print(validate_it_aic(np.nan))\n",
+    "print(validate_it_aic(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_it_aic(df[\"aic\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_it_aic(df, column=\"aic\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_it_aic(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_it_codicefiscale.ipynb
+++ b/docs/source/user_guide/clean/clean_it_codicefiscale.ipynb
@@ -1,0 +1,356 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _codicefiscale_userguide:\n",
+    "\n",
+    "Codice Fiscale Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_it_codicefiscale() <dataprep.clean.clean_it_codicefiscale.clean_it_codicefiscale>` cleans a column containing Italian fiscal codes (Codice Fiscale) strings, and standardizes them in a given format. The function :func:`validate_it_codicefiscale() <dataprep.clean.clean_it_codicefiscale.validate_it_codicefiscale>` validates either a single Codice Fiscale strings, a column of Codice Fiscale strings or a DataFrame of Codice Fiscale strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Codice Fiscale strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"RCCMNL83S18D969H\"\n",
+    "* `standard`: Codice Fiscale strings with proper whitespace in the proper places. Note that in the case of Codice Fiscale, the compact format is the same as the standard one.\n",
+    "* `birthdate`: split the date parts from the number and return the birth date, like \"1875-03-16\".\n",
+    "* `gender`: get the person's birth gender ('M' or 'F').\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_it_codicefiscale()` and `validate_it_codicefiscale()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing Codice Fiscale strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"codicefiscale\": [\n",
+    "            'RCCMNL83S18D969H',\n",
+    "            'RCCMNL83S18D969',\n",
+    "            '7542011030',\n",
+    "            '7552A10004',\n",
+    "            '8019010008',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_it_codicefiscale`\n",
+    "\n",
+    "By default, `clean_it_codicefiscale` will clean codicefiscale strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_it_codicefiscale\n",
+    "clean_it_codicefiscale(df, column = \"codicefiscale\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_codicefiscale(df, column = \"codicefiscale\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_codicefiscale(df, column = \"codicefiscale\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_codicefiscale(df, column = \"codicefiscale\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `gender`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_codicefiscale(df, column = \"codicefiscale\", output_format=\"gender\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned Codice Fiscale strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_codicefiscale(df, column=\"codicefiscale\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_codicefiscale(df, \"codicefiscale\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_codicefiscale(df, \"codicefiscale\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_it_codicefiscale()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_it_codicefiscale()` returns `True` when the input is a valid Codice Fiscale. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_it_codicefiscale()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_it_codicefiscale()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_it_codicefiscale()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_it_codicefiscale\n",
+    "print(validate_it_codicefiscale('RCCMNL83S18D969H'))\n",
+    "print(validate_it_codicefiscale('RCCMNL83S18D969'))\n",
+    "print(validate_it_codicefiscale('7542011030'))\n",
+    "print(validate_it_codicefiscale('7552A10004'))\n",
+    "print(validate_it_codicefiscale('8019010008'))\n",
+    "print(validate_it_codicefiscale(\"hello\"))\n",
+    "print(validate_it_codicefiscale(np.nan))\n",
+    "print(validate_it_codicefiscale(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_it_codicefiscale(df[\"codicefiscale\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_it_codicefiscale(df, column=\"codicefiscale\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_it_codicefiscale(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_it_iva.ipynb
+++ b/docs/source/user_guide/clean/clean_it_iva.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _iva_userguide:\n",
+    "\n",
+    "IVA Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_it_iva() <dataprep.clean.clean_it_iva.clean_it_iva>` cleans a column containing Italian IVA number (IVA) strings, and standardizes them in a given format. The function :func:`validate_it_iva() <dataprep.clean.clean_it_iva.validate_it_iva>` validates either a single IVA strings, a column of IVA strings or a DataFrame of IVA strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "IVA strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"00743110157\"\n",
+    "* `standard`: IVA strings with proper whitespace in the proper places. Note that in the case of IVA, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_it_iva()` and `validate_it_iva()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing IVA strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"iva\": [\n",
+    "            'IT 00743110157',\n",
+    "            '00743110158',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_it_iva`\n",
+    "\n",
+    "By default, `clean_it_iva` will clean iva strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_it_iva\n",
+    "clean_it_iva(df, column = \"iva\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_iva(df, column = \"iva\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_iva(df, column = \"iva\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned IVA strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_iva(df, column=\"iva\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_iva(df, \"iva\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_it_iva(df, \"iva\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_it_iva()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_it_iva()` returns `True` when the input is a valid IVA. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_it_iva()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_it_iva()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_it_iva()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_it_iva\n",
+    "print(validate_it_iva(\"IT 00743110157\"))\n",
+    "print(validate_it_iva(\"00743110158\"))\n",
+    "print(validate_it_iva('BE 428759497'))\n",
+    "print(validate_it_iva('BE431150351'))\n",
+    "print(validate_it_iva(\"004085616\"))\n",
+    "print(validate_it_iva(\"hello\"))\n",
+    "print(validate_it_iva(np.nan))\n",
+    "print(validate_it_iva(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_it_iva(df[\"iva\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_it_iva(df, column=\"iva\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_it_iva(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_jp_cn.ipynb
+++ b/docs/source/user_guide/clean/clean_jp_cn.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _cn_userguide:\n",
+    "\n",
+    "CN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_jp_cn() <dataprep.clean.clean_jp_cn.clean_jp_cn>` cleans a column containing Japanese Corporate Number (CN) strings, and standardizes them in a given format. The function :func:`validate_jp_cn() <dataprep.clean.clean_jp_cn.validate_jp_cn>` validates either a single CN strings, a column of CN strings or a DataFrame of CN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"5835678256246\"\n",
+    "* `standard`: CN strings with proper whitespace in the proper places, like \"5-8356-7825-6246\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_jp_cn()` and `validate_jp_cn()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing CN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"cn\": [\n",
+    "            \"5835678256246\",\n",
+    "            \"2-8356-7825-6246\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_jp_cn`\n",
+    "\n",
+    "By default, `clean_jp_cn` will clean cn strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_jp_cn\n",
+    "clean_jp_cn(df, column = \"cn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_jp_cn(df, column = \"cn\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_jp_cn(df, column = \"cn\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_jp_cn(df, column=\"cn\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_jp_cn(df, \"cn\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_jp_cn(df, \"cn\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_jp_cn()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_jp_cn()` returns `True` when the input is a valid CN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_jp_cn()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_jp_cn()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_jp_cn()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_jp_cn\n",
+    "print(validate_jp_cn(\"5835678256246\"))\n",
+    "print(validate_jp_cn(\"2-8356-7825-6246\"))\n",
+    "print(validate_jp_cn(\"51824753556\"))\n",
+    "print(validate_jp_cn(\"51 824 753 556\"))\n",
+    "print(validate_jp_cn(\"hello\"))\n",
+    "print(validate_jp_cn(np.nan))\n",
+    "print(validate_jp_cn(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_jp_cn(df[\"cn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_jp_cn(df, column=\"cn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_jp_cn(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_kr_brn.ipynb
+++ b/docs/source/user_guide/clean/clean_kr_brn.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _brn_userguide:\n",
+    "\n",
+    "BRN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_kr_brn() <dataprep.clean.clean_kr_brn.clean_kr_brn>` cleans a column containing South Korea Business Registration Number (BRN) strings, and standardizes them in a given format. The function :func:`validate_kr_brn() <dataprep.clean.clean_kr_brn.validate_kr_brn>` validates either a single BRN strings, a column of BRN strings or a DataFrame of BRN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "BRN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"1348672683\"\n",
+    "* `standard`: BRN strings with proper whitespace in the proper places, like \"134-86-72683\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_kr_brn()` and `validate_kr_brn()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing BRN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"brn\": [\n",
+    "            \"1348672683\",\n",
+    "            \"123456789\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_kr_brn`\n",
+    "\n",
+    "By default, `clean_kr_brn` will clean brn strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_kr_brn\n",
+    "clean_kr_brn(df, column = \"brn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_kr_brn(df, column = \"brn\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_kr_brn(df, column = \"brn\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned BRN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_kr_brn(df, column=\"brn\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_kr_brn(df, \"brn\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_kr_brn(df, \"brn\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_kr_brn()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_kr_brn()` returns `True` when the input is a valid BRN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_kr_brn()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_kr_brn()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_kr_brn()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_kr_brn\n",
+    "print(validate_kr_brn(\"1348672683\"))\n",
+    "print(validate_kr_brn(\"123456789\"))\n",
+    "print(validate_kr_brn(\"51824753556\"))\n",
+    "print(validate_kr_brn(\"51 824 753 556\"))\n",
+    "print(validate_kr_brn(\"hello\"))\n",
+    "print(validate_kr_brn(np.nan))\n",
+    "print(validate_kr_brn(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_kr_brn(df[\"brn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_kr_brn(df, column=\"brn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_kr_brn(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_kr_rrn.ipynb
+++ b/docs/source/user_guide/clean/clean_kr_rrn.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _rrn_userguide:\n",
+    "\n",
+    "RRN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_kr_rrn() <dataprep.clean.clean_kr_rrn.clean_kr_rrn>` cleans a column containing South Korean resident registration number (RRN) strings, and standardizes them in a given format. The function :func:`validate_kr_rrn() <dataprep.clean.clean_kr_rrn.validate_kr_rrn>` validates either a single RRN strings, a column of RRN strings or a DataFrame of RRN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RRN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"9710139019902\"\n",
+    "* `standard`: RRN strings with proper whitespace in the proper places, like \"971013-9019902\"\n",
+    "* `birthdate`: get the person's birthdate, like \"1897-10-13\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_kr_rrn()` and `validate_kr_rrn()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing RRN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"rrn\": [\n",
+    "            \"971013-9019902\",\n",
+    "            \"971013-9019903\",\n",
+    "            \"999 999 999\",\n",
+    "            \"004085616\",\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_kr_rrn`\n",
+    "\n",
+    "By default, `clean_kr_rrn` will clean rrn strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_kr_rrn\n",
+    "clean_kr_rrn(df, column = \"rrn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_kr_rrn(df, column = \"rrn\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_kr_rrn(df, column = \"rrn\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_kr_rrn(df, column = \"rrn\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned RRN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_kr_rrn(df, column=\"rrn\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_kr_rrn(df, \"rrn\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_kr_rrn(df, \"rrn\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_kr_rrn()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_kr_rrn()` returns `True` when the input is a valid RRN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_kr_rrn()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_kr_rrn()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_kr_rrn()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_kr_rrn\n",
+    "print(validate_kr_rrn(\"971013-9019902\"))\n",
+    "print(validate_kr_rrn(\"971013-9019903\"))\n",
+    "print(validate_kr_rrn(\"999 999 999\"))\n",
+    "print(validate_kr_rrn(\"51824753556\"))\n",
+    "print(validate_kr_rrn(\"004085616\"))\n",
+    "print(validate_kr_rrn(\"hello\"))\n",
+    "print(validate_kr_rrn(np.nan))\n",
+    "print(validate_kr_rrn(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_kr_rrn(df[\"rrn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_kr_rrn(df, column=\"rrn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_kr_rrn(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_li_peid.ipynb
+++ b/docs/source/user_guide/clean/clean_li_peid.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _peid_userguide:\n",
+    "\n",
+    "PEID Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_li_peid() <dataprep.clean.clean_li_peid.clean_li_peid>` cleans a column containing Liechtenstein tax code for individuals and entity (PEID) strings, and standardizes them in a given format. The function :func:`validate_li_peid() <dataprep.clean.clean_li_peid.validate_li_peid>` validates either a single PEID strings, a column of PEID strings or a DataFrame of PEID strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "PEID strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"1234567\"\n",
+    "* `standard`: PEID strings with proper whitespace in the proper places. Note that in the case of PEID, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_li_peid()` and `validate_li_peid()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing PEID strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"peid\": [\n",
+    "            '00001234567',\n",
+    "            '00001234568913454545',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_li_peid`\n",
+    "\n",
+    "By default, `clean_li_peid` will clean peid strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_li_peid\n",
+    "clean_li_peid(df, column = \"peid\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_li_peid(df, column = \"peid\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_li_peid(df, column = \"peid\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned PEID strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_li_peid(df, column=\"peid\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_li_peid(df, \"peid\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_li_peid(df, \"peid\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_li_peid()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_li_peid()` returns `True` when the input is a valid PEID. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_li_peid()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_li_peid()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_li_peid()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_li_peid\n",
+    "print(validate_li_peid(\"00001234567\"))\n",
+    "print(validate_li_peid(\"00001234568913454545\"))\n",
+    "print(validate_li_peid('BE 428759497'))\n",
+    "print(validate_li_peid('BE431150351'))\n",
+    "print(validate_li_peid(\"004085616\"))\n",
+    "print(validate_li_peid(\"hello\"))\n",
+    "print(validate_li_peid(np.nan))\n",
+    "print(validate_li_peid(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_li_peid(df[\"peid\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_li_peid(df, column=\"peid\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_li_peid(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_lt_asmens.ipynb
+++ b/docs/source/user_guide/clean/clean_lt_asmens.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _asmens_userguide:\n",
+    "\n",
+    "Asmens koda Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_lt_asmens() <dataprep.clean.clean_lt_asmens.clean_lt_asmens>` cleans a column containing Lithuanian personal number (Asmens koda) strings, and standardizes them in a given format. The function :func:`validate_lt_asmens() <dataprep.clean.clean_lt_asmens.validate_lt_asmens>` validates either a single Asmens koda strings, a column of Asmens koda strings or a DataFrame of Asmens koda strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Asmens koda strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"33309240064\"\n",
+    "* `standard`: Asmens koda strings with proper whitespace in the proper places. Note that in the case of Asmens koda, the compact format is the same as the standard one.\n",
+    "* `birthdate`: split the date parts from the number and return the birth date, like \"1933-09-24\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_lt_asmens()` and `validate_lt_asmens()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing Asmens koda strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"asmens\": [\n",
+    "            '33309240064',\n",
+    "            '33309240164',\n",
+    "            '7542011030',\n",
+    "            '7552A10004',\n",
+    "            '8019010008',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_lt_asmens`\n",
+    "\n",
+    "By default, `clean_lt_asmens` will clean asmens strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_lt_asmens\n",
+    "clean_lt_asmens(df, column = \"asmens\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lt_asmens(df, column = \"asmens\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lt_asmens(df, column = \"asmens\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lt_asmens(df, column = \"asmens\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned Asmens koda strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lt_asmens(df, column=\"asmens\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lt_asmens(df, \"asmens\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lt_asmens(df, \"asmens\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_lt_asmens()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_lt_asmens()` returns `True` when the input is a valid Asmens koda. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_lt_asmens()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_lt_asmens()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_lt_asmens()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_lt_asmens\n",
+    "print(validate_lt_asmens('33309240064'))\n",
+    "print(validate_lt_asmens('33309240164'))\n",
+    "print(validate_lt_asmens('7542011030'))\n",
+    "print(validate_lt_asmens('7552A10004'))\n",
+    "print(validate_lt_asmens('8019010008'))\n",
+    "print(validate_lt_asmens(\"hello\"))\n",
+    "print(validate_lt_asmens(np.nan))\n",
+    "print(validate_lt_asmens(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_lt_asmens(df[\"asmens\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_lt_asmens(df, column=\"asmens\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_lt_asmens(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_lt_pvm.ipynb
+++ b/docs/source/user_guide/clean/clean_lt_pvm.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _pvm_userguide:\n",
+    "\n",
+    "PVM Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_lt_pvm() <dataprep.clean.clean_lt_pvm.clean_lt_pvm>` cleans a column containing Lithuanian PVM number (PVM) strings, and standardizes them in a given format. The function :func:`validate_lt_pvm() <dataprep.clean.clean_lt_pvm.validate_lt_pvm>` validates either a single PVM strings, a column of PVM strings or a DataFrame of PVM strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "PVM strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"119511515\"\n",
+    "* `standard`: PVM strings with proper whitespace in the proper places. Note that in the case of PVM, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_lt_pvm()` and `validate_lt_pvm()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing PVM strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"pvm\": [\n",
+    "            '119511515',\n",
+    "            '100001919018',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_lt_pvm`\n",
+    "\n",
+    "By default, `clean_lt_pvm` will clean pvm strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_lt_pvm\n",
+    "clean_lt_pvm(df, column = \"pvm\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lt_pvm(df, column = \"pvm\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lt_pvm(df, column = \"pvm\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned PVM strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lt_pvm(df, column=\"pvm\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lt_pvm(df, \"pvm\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lt_pvm(df, \"pvm\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_lt_pvm()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_lt_pvm()` returns `True` when the input is a valid PVM. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_lt_pvm()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_lt_pvm()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_lt_pvm()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_lt_pvm\n",
+    "print(validate_lt_pvm(\"119511515\"))\n",
+    "print(validate_lt_pvm(\"100001919018\"))\n",
+    "print(validate_lt_pvm('BE 428759497'))\n",
+    "print(validate_lt_pvm('BE431150351'))\n",
+    "print(validate_lt_pvm(\"004085616\"))\n",
+    "print(validate_lt_pvm(\"hello\"))\n",
+    "print(validate_lt_pvm(np.nan))\n",
+    "print(validate_lt_pvm(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_lt_pvm(df[\"pvm\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_lt_pvm(df, column=\"pvm\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_lt_pvm(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_lu_tva.ipynb
+++ b/docs/source/user_guide/clean/clean_lu_tva.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _tva_userguide:\n",
+    "\n",
+    "TVA Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_lu_tva() <dataprep.clean.clean_lu_tva.clean_lu_tva>` cleans a column containing Luxembourgian TVA number (TVA) strings, and standardizes them in a given format. The function :func:`validate_lu_tva() <dataprep.clean.clean_lu_tva.validate_lu_tva>` validates either a single TVA strings, a column of TVA strings or a DataFrame of TVA strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TVA strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"15027442\"\n",
+    "* `standard`: TVA strings with proper whitespace in the proper places. Note that in the case of TVA, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_lu_tva()` and `validate_lu_tva()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing TVA strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"tva\": [\n",
+    "            'LU 150 274 42',\n",
+    "            '150 274 43',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_lu_tva`\n",
+    "\n",
+    "By default, `clean_lu_tva` will clean tva strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_lu_tva\n",
+    "clean_lu_tva(df, column = \"tva\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lu_tva(df, column = \"tva\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lu_tva(df, column = \"tva\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned TVA strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lu_tva(df, column=\"tva\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lu_tva(df, \"tva\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lu_tva(df, \"tva\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_lu_tva()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_lu_tva()` returns `True` when the input is a valid TVA. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_lu_tva()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_lu_tva()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_lu_tva()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_lu_tva\n",
+    "print(validate_lu_tva('LU 150 274 42'))\n",
+    "print(validate_lu_tva('150 274 43'))\n",
+    "print(validate_lu_tva('BE 428759497'))\n",
+    "print(validate_lu_tva('BE431150351'))\n",
+    "print(validate_lu_tva(\"004085616\"))\n",
+    "print(validate_lu_tva(\"hello\"))\n",
+    "print(validate_lu_tva(np.nan))\n",
+    "print(validate_lu_tva(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_lu_tva(df[\"tva\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_lu_tva(df, column=\"tva\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_lu_tva(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_lv_pvn.ipynb
+++ b/docs/source/user_guide/clean/clean_lv_pvn.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _pvn_userguide:\n",
+    "\n",
+    "PVN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_lv_pvn() <dataprep.clean.clean_lv_pvn.clean_lv_pvn>` cleans a column containing Latvian PVN (VAT) number (PVN) strings, and standardizes them in a given format. The function :func:`validate_lv_pvn() <dataprep.clean.clean_lv_pvn.validate_lv_pvn>` validates either a single PVN strings, a column of PVN strings or a DataFrame of PVN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "PVN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"16117519997\"\n",
+    "* `standard`: PVN strings with proper whitespace in the proper places. Note that in the case of PVN, the compact format is the same as the standard one.\n",
+    "* `birthdate`: split the date parts from the number and return the birth date, like \"1975-11-16\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_lv_pvn()` and `validate_lv_pvn()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing PVN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"pvn\": [\n",
+    "            '161175-19997',\n",
+    "            '40003521601',\n",
+    "            '7542011030',\n",
+    "            '7552A10004',\n",
+    "            '8019010008',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_lv_pvn`\n",
+    "\n",
+    "By default, `clean_lv_pvn` will clean pvn strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_lv_pvn\n",
+    "clean_lv_pvn(df, column = \"pvn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lv_pvn(df, column = \"pvn\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lv_pvn(df, column = \"pvn\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lv_pvn(df, column = \"pvn\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned PVN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lv_pvn(df, column=\"pvn\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lv_pvn(df, \"pvn\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_lv_pvn(df, \"pvn\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_lv_pvn()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_lv_pvn()` returns `True` when the input is a valid PVN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_lv_pvn()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_lv_pvn()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_lv_pvn()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_lv_pvn\n",
+    "print(validate_lv_pvn('161175-19997'))\n",
+    "print(validate_lv_pvn('40003521601'))\n",
+    "print(validate_lv_pvn('7542011030'))\n",
+    "print(validate_lv_pvn('7552A10004'))\n",
+    "print(validate_lv_pvn('8019010008'))\n",
+    "print(validate_lv_pvn(\"hello\"))\n",
+    "print(validate_lv_pvn(np.nan))\n",
+    "print(validate_lv_pvn(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_lv_pvn(df[\"pvn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_lv_pvn(df, column=\"pvn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_lv_pvn(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_mc_tva.ipynb
+++ b/docs/source/user_guide/clean/clean_mc_tva.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _tva_userguide:\n",
+    "\n",
+    "TVA Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_mc_tva() <dataprep.clean.clean_mc_tva.clean_mc_tva>` cleans a column containing Monacan TVA number (TVA) strings, and standardizes them in a given format. The function :func:`validate_mc_tva() <dataprep.clean.clean_mc_tva.validate_mc_tva>` validates either a single TVA strings, a column of TVA strings or a DataFrame of TVA strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TVA strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"FR53000004605\"\n",
+    "* `standard`: TVA strings with proper whitespace in the proper places. Note that in the case of TVA, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_mc_tva()` and `validate_mc_tva()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing TVA strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"tva\": [\n",
+    "            '53 0000 04605',\n",
+    "            'FR 61 954 506 077',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_mc_tva`\n",
+    "\n",
+    "By default, `clean_mc_tva` will clean tva strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_mc_tva\n",
+    "clean_mc_tva(df, column = \"tva\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mc_tva(df, column = \"tva\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mc_tva(df, column = \"tva\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned TVA strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mc_tva(df, column=\"tva\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mc_tva(df, \"tva\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mc_tva(df, \"tva\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_mc_tva()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_mc_tva()` returns `True` when the input is a valid TVA. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_mc_tva()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_mc_tva()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_mc_tva()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_mc_tva\n",
+    "print(validate_mc_tva(\"53 0000 04605\"))\n",
+    "print(validate_mc_tva(\"FR 61 954 506 077\"))\n",
+    "print(validate_mc_tva('BE 428759497'))\n",
+    "print(validate_mc_tva('BE431150351'))\n",
+    "print(validate_mc_tva(\"004085616\"))\n",
+    "print(validate_mc_tva(\"hello\"))\n",
+    "print(validate_mc_tva(np.nan))\n",
+    "print(validate_mc_tva(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_mc_tva(df[\"tva\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_mc_tva(df, column=\"tva\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_mc_tva(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_md_idno.ipynb
+++ b/docs/source/user_guide/clean/clean_md_idno.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _idno_userguide:\n",
+    "\n",
+    "IDNO Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_md_idno() <dataprep.clean.clean_md_idno.clean_md_idno>` cleans a column containing Moldavian company identification number (IDNO) strings, and standardizes them in a given format. The function :func:`validate_md_idno() <dataprep.clean.clean_md_idno.validate_md_idno>` validates either a single IDNO strings, a column of IDNO strings or a DataFrame of IDNO strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "IDNO strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"1008600038413\"\n",
+    "* `standard`: IDNO strings with proper whitespace in the proper places. Note that in the case of IDNO, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_md_idno()` and `validate_md_idno()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing IDNO strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"idno\": [\n",
+    "            '1008600038413',\n",
+    "            '1008600038412',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_md_idno`\n",
+    "\n",
+    "By default, `clean_md_idno` will clean idno strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_md_idno\n",
+    "clean_md_idno(df, column = \"idno\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_md_idno(df, column = \"idno\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_md_idno(df, column = \"idno\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned IDNO strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_md_idno(df, column=\"idno\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_md_idno(df, \"idno\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_md_idno(df, \"idno\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_md_idno()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_md_idno()` returns `True` when the input is a valid IDNO. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_md_idno()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_md_idno()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_md_idno()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_md_idno\n",
+    "print(validate_md_idno(\"1008600038413\"))\n",
+    "print(validate_md_idno(\"1008600038412\"))\n",
+    "print(validate_md_idno('BE 428759497'))\n",
+    "print(validate_md_idno('BE431150351'))\n",
+    "print(validate_md_idno(\"004085616\"))\n",
+    "print(validate_md_idno(\"hello\"))\n",
+    "print(validate_md_idno(np.nan))\n",
+    "print(validate_md_idno(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_md_idno(df[\"idno\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_md_idno(df, column=\"idno\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_md_idno(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_me_iban.ipynb
+++ b/docs/source/user_guide/clean/clean_me_iban.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _iban_userguide:\n",
+    "\n",
+    "IBAN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_me_iban() <dataprep.clean.clean_me_iban.clean_me_iban>` cleans a column containing Montenegro IBAN (IBAN) strings, and standardizes them in a given format. The function :func:`validate_me_iban() <dataprep.clean.clean_me_iban.validate_me_iban>` validates either a single IBAN strings, a column of IBAN strings or a DataFrame of IBAN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "IBAN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"ME25510000000006234133\"\n",
+    "* `standard`: IBAN strings with proper whitespace in the proper places, like \"ME 2551 0000 0000 0623 4133\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_me_iban()` and `validate_me_iban()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing IBAN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"iban\": [\n",
+    "            \"ME25510000000006234133\",\n",
+    "            \"ME52510000000006234132\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_me_iban`\n",
+    "\n",
+    "By default, `clean_me_iban` will clean iban strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_me_iban\n",
+    "clean_me_iban(df, column = \"iban\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_me_iban(df, column = \"iban\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_me_iban(df, column = \"iban\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned IBAN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_me_iban(df, column=\"iban\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_me_iban(df, \"iban\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_me_iban(df, \"iban\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_me_iban()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_me_iban()` returns `True` when the input is a valid IBAN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_me_iban()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_me_iban()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_me_iban()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_me_iban\n",
+    "print(validate_me_iban(\"ME25510000000006234133\"))\n",
+    "print(validate_me_iban(\"ME52510000000006234132\"))\n",
+    "print(validate_me_iban(\"51824753556\"))\n",
+    "print(validate_me_iban(\"51 824 753 556\"))\n",
+    "print(validate_me_iban(\"hello\"))\n",
+    "print(validate_me_iban(np.nan))\n",
+    "print(validate_me_iban(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_me_iban(df[\"iban\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_me_iban(df, column=\"iban\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_me_iban(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_mt_vat.ipynb
+++ b/docs/source/user_guide/clean/clean_mt_vat.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _vat_userguide:\n",
+    "\n",
+    "VAT Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_mt_vat() <dataprep.clean.clean_mt_vat.clean_mt_vat>` cleans a column containing Maltese VAT number (VAT) strings, and standardizes them in a given format. The function :func:`validate_mt_vat() <dataprep.clean.clean_mt_vat.validate_mt_vat>` validates either a single VAT strings, a column of VAT strings or a DataFrame of VAT strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "VAT strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"11679112\"\n",
+    "* `standard`: VAT strings with proper whitespace in the proper places. Note that in the case of VAT, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_mt_vat()` and `validate_mt_vat()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing VAT strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"vat\": [\n",
+    "            'MT 1167-9112',\n",
+    "            '1167-9113',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_mt_vat`\n",
+    "\n",
+    "By default, `clean_mt_vat` will clean vat strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_mt_vat\n",
+    "clean_mt_vat(df, column = \"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mt_vat(df, column = \"vat\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mt_vat(df, column = \"vat\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned VAT strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mt_vat(df, column=\"vat\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mt_vat(df, \"vat\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mt_vat(df, \"vat\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_mt_vat()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_mt_vat()` returns `True` when the input is a valid VAT. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_mt_vat()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_mt_vat()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_mt_vat()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_mt_vat\n",
+    "print(validate_mt_vat(\"MT 1167-9112\"))\n",
+    "print(validate_mt_vat(\"1167-9113\"))\n",
+    "print(validate_mt_vat('BE 428759497'))\n",
+    "print(validate_mt_vat('BE431150351'))\n",
+    "print(validate_mt_vat(\"004085616\"))\n",
+    "print(validate_mt_vat(\"hello\"))\n",
+    "print(validate_mt_vat(np.nan))\n",
+    "print(validate_mt_vat(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_mt_vat(df[\"vat\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_mt_vat(df, column=\"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_mt_vat(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_mu_nid.ipynb
+++ b/docs/source/user_guide/clean/clean_mu_nid.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _nid_userguide:\n",
+    "\n",
+    "NID Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_mu_nid() <dataprep.clean.clean_mu_nid.clean_mu_nid>` cleans a column containing Mauritian national ID number (NID) strings, and standardizes them in a given format. The function :func:`validate_mu_nid() <dataprep.clean.clean_mu_nid.validate_mu_nid>` validates either a single NID strings, a column of NID strings or a DataFrame of NID strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NID strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"J2906201304089\"\n",
+    "* `standard`: NID strings with proper whitespace in the proper places. Note that in the case of NID, the compact format is the same as the standard one.\n",
+    "* `birthdate`: split the date parts from the number and return the birth date, like \"2020-06-29\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_mu_nid()` and `validate_mu_nid()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing NID strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"nid\": [\n",
+    "            'J2906201304089',\n",
+    "            'J2906201304088',\n",
+    "            '7542011030',\n",
+    "            '7552A10004',\n",
+    "            '8019010008', \n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_mu_nid`\n",
+    "\n",
+    "By default, `clean_mu_nid` will clean nid strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_mu_nid\n",
+    "clean_mu_nid(df, column = \"nid\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mu_nid(df, column = \"nid\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mu_nid(df, column = \"nid\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mu_nid(df, column = \"nid\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned NID strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mu_nid(df, column=\"nid\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mu_nid(df, \"nid\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mu_nid(df, \"nid\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_mu_nid()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_mu_nid()` returns `True` when the input is a valid NID. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_mu_nid()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_mu_nid()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_mu_nid()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_mu_nid\n",
+    "print(validate_mu_nid('J2906201304089'))\n",
+    "print(validate_mu_nid('J2906201304088'))\n",
+    "print(validate_mu_nid('7542011030'))\n",
+    "print(validate_mu_nid('7552A10004'))\n",
+    "print(validate_mu_nid('8019010008'))\n",
+    "print(validate_mu_nid(\"hello\"))\n",
+    "print(validate_mu_nid(np.nan))\n",
+    "print(validate_mu_nid(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_mu_nid(df[\"nid\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_mu_nid(df, column=\"nid\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_mu_nid(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_mx_curp.ipynb
+++ b/docs/source/user_guide/clean/clean_mx_curp.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _curp_userguide:\n",
+    "\n",
+    "CURP Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_mx_curp() <dataprep.clean.clean_mx_curp.clean_mx_curp>` cleans a column containing Mexican personal identifier (CURP) strings, and standardizes them in a given format. The function :func:`validate_mx_curp() <dataprep.clean.clean_mx_curp.validate_mx_curp>` validates either a single CURP strings, a column of CURP strings or a DataFrame of CURP strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CURP strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"BOXW310820HNERXN09\"\n",
+    "* `standard`: CURP strings with proper whitespace in the proper places. Note that in the case of CURP, the compact format is the same as the standard one.\n",
+    "* `birthdate`: split the date parts from the number and return the birth date, like \"1875-03-16\".\n",
+    "* `gender`: get the person's birth gender ('M' or 'F').\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_mx_curp()` and `validate_mx_curp()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing CURP strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"curp\": [\n",
+    "            'BOXW310820HNERXN09',\n",
+    "            'BOXW310820HNERXN08',\n",
+    "            '7542011030',\n",
+    "            '7552A10004',\n",
+    "            '8019010008',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_mx_curp`\n",
+    "\n",
+    "By default, `clean_mx_curp` will clean curp strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_mx_curp\n",
+    "clean_mx_curp(df, column = \"curp\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mx_curp(df, column = \"curp\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mx_curp(df, column = \"curp\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mx_curp(df, column = \"curp\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `gender`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mx_curp(df, column = \"curp\", output_format=\"gender\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CURP strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mx_curp(df, column=\"curp\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mx_curp(df, \"curp\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mx_curp(df, \"curp\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_mx_curp()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_mx_curp()` returns `True` when the input is a valid CURP. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_mx_curp()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_mx_curp()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_mx_curp()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_mx_curp\n",
+    "print(validate_mx_curp('BOXW310820HNERXN09'))\n",
+    "print(validate_mx_curp('BOXW310820HNERXN08'))\n",
+    "print(validate_mx_curp('7542011030'))\n",
+    "print(validate_mx_curp('7552A10004'))\n",
+    "print(validate_mx_curp('8019010008'))\n",
+    "print(validate_mx_curp(\"hello\"))\n",
+    "print(validate_mx_curp(np.nan))\n",
+    "print(validate_mx_curp(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_mx_curp(df[\"curp\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_mx_curp(df, column=\"curp\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_mx_curp(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_mx_rfc.ipynb
+++ b/docs/source/user_guide/clean/clean_mx_rfc.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _rfc_userguide:\n",
+    "\n",
+    "RFC Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_mx_rfc() <dataprep.clean.clean_mx_rfc.clean_mx_rfc>` cleans a column containing Mexican tax number (RFC) strings, and standardizes them in a given format. The function :func:`validate_mx_rfc() <dataprep.clean.clean_mx_rfc.validate_mx_rfc>` validates either a single RFC strings, a column of RFC strings or a DataFrame of RFC strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RFC strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"GODE561231GR8\"\n",
+    "* `standard`: RFC strings with proper whitespace in the proper places, like \"GODE 561231 GR8\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_mx_rfc()` and `validate_mx_rfc()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing RFC strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"rfc\": [\n",
+    "            \"GODE561231GR8\",\n",
+    "            \"BUEI591231GH9\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_mx_rfc`\n",
+    "\n",
+    "By default, `clean_mx_rfc` will clean rfc strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_mx_rfc\n",
+    "clean_mx_rfc(df, column = \"rfc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mx_rfc(df, column = \"rfc\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mx_rfc(df, column = \"rfc\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned RFC strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mx_rfc(df, column=\"rfc\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mx_rfc(df, \"rfc\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_mx_rfc(df, \"rfc\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_mx_rfc()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_mx_rfc()` returns `True` when the input is a valid RFC. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_mx_rfc()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_mx_rfc()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_mx_rfc()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_mx_rfc\n",
+    "print(validate_mx_rfc(\"GODE561231GR8\"))\n",
+    "print(validate_mx_rfc(\"BUEI591231GH9\"))\n",
+    "print(validate_mx_rfc(\"51824753556\"))\n",
+    "print(validate_mx_rfc(\"51 824 753 556\"))\n",
+    "print(validate_mx_rfc(\"hello\"))\n",
+    "print(validate_mx_rfc(np.nan))\n",
+    "print(validate_mx_rfc(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_mx_rfc(df[\"rfc\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_mx_rfc(df, column=\"rfc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_mx_rfc(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_my_nric.ipynb
+++ b/docs/source/user_guide/clean/clean_my_nric.ipynb
@@ -1,0 +1,356 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _nric_userguide:\n",
+    "\n",
+    "NRIC Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_my_nric() <dataprep.clean.clean_my_nric.clean_my_nric>` cleans a column containing Malaysian National Registration Identity Card Number (NRIC) strings, and standardizes them in a given format. The function :func:`validate_my_nric() <dataprep.clean.clean_my_nric.validate_my_nric>` validates either a single NRIC strings, a column of NRIC strings or a DataFrame of NRIC strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NRIC strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"770305021234\"\n",
+    "* `standard`: NRIC strings with proper whitespace in the proper places, like \"770305-02-1234\"\n",
+    "* `birthdate`: return the registration date or the birth date, like \"1977-03-05\".\n",
+    "* `birthplace`: return a dict containing the birthplace of the person, like {'state': 'Kedah', 'country': 'Malaysia', 'countries': 'Malaysia'}.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_my_nric()` and `validate_my_nric()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing NRIC strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"nric\": [\n",
+    "            \"770305021234\",\n",
+    "            \"771305-02-1234\",\n",
+    "            \"999 999 999\",\n",
+    "            \"004085616\",\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_my_nric`\n",
+    "\n",
+    "By default, `clean_my_nric` will clean nric strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_my_nric\n",
+    "clean_my_nric(df, column = \"nric\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_my_nric(df, column = \"nric\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_my_nric(df, column = \"nric\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_my_nric(df, column = \"nric\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthplace`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_my_nric(df, column = \"nric\", output_format=\"birthplace\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned NRIC strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_my_nric(df, column=\"nric\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_my_nric(df, \"nric\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_my_nric(df, \"nric\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_my_nric()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_my_nric()` returns `True` when the input is a valid NRIC. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_my_nric()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_my_nric()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_my_nric()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_my_nric\n",
+    "print(validate_my_nric(\"770305021234\"))\n",
+    "print(validate_my_nric(\"771305-02-1234\"))\n",
+    "print(validate_my_nric(\"999 999 999\"))\n",
+    "print(validate_my_nric(\"51824753556\"))\n",
+    "print(validate_my_nric(\"004085616\"))\n",
+    "print(validate_my_nric(\"hello\"))\n",
+    "print(validate_my_nric(np.nan))\n",
+    "print(validate_my_nric(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_my_nric(df[\"nric\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_my_nric(df, column=\"nric\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_my_nric(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_nl_brin.ipynb
+++ b/docs/source/user_guide/clean/clean_nl_brin.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _brin_userguide:\n",
+    "\n",
+    "BRIN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_nl_brin() <dataprep.clean.clean_nl_brin.clean_nl_brin>` cleans a column containing Brin numbers (BRIN) strings, and standardizes them in a given format. The function :func:`validate_nl_brin() <dataprep.clean.clean_nl_brin.validate_nl_brin>` validates either a single BRIN strings, a column of BRIN strings or a DataFrame of BRIN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "BRIN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"05KO\"\n",
+    "* `standard`: BRIN strings with proper whitespace in the proper places. Note that in the case of BRIN, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_nl_brin()` and `validate_nl_brin()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing BRIN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"brin\": [\n",
+    "            '05 KO',\n",
+    "            '30AJ0A',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_nl_brin`\n",
+    "\n",
+    "By default, `clean_nl_brin` will clean brin strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_nl_brin\n",
+    "clean_nl_brin(df, column = \"brin\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_brin(df, column = \"brin\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_brin(df, column = \"brin\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned BRIN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_brin(df, column=\"brin\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_brin(df, \"brin\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_brin(df, \"brin\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_nl_brin()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_nl_brin()` returns `True` when the input is a valid BRIN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_nl_brin()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_nl_brin()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_nl_brin()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_nl_brin\n",
+    "print(validate_nl_brin('05 KO'))\n",
+    "print(validate_nl_brin('30AJ0A'))\n",
+    "print(validate_nl_brin('BE 428759497'))\n",
+    "print(validate_nl_brin('BE431150351'))\n",
+    "print(validate_nl_brin(\"004085616\"))\n",
+    "print(validate_nl_brin(\"hello\"))\n",
+    "print(validate_nl_brin(np.nan))\n",
+    "print(validate_nl_brin(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nl_brin(df[\"brin\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nl_brin(df, column=\"brin\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nl_brin(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_nl_bsn.ipynb
+++ b/docs/source/user_guide/clean/clean_nl_bsn.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _bsn_userguide:\n",
+    "\n",
+    "BSN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_nl_bsn() <dataprep.clean.clean_nl_bsn.clean_nl_bsn>` cleans a column containing Burgerservicenummer (BSN, the Dutch citizen identification number) strings, and standardizes them in a given format. The function :func:`validate_nl_bsn() <dataprep.clean.clean_nl_bsn.validate_nl_bsn>` validates either a single BSN strings, a column of BSN strings or a DataFrame of BSN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "BSN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"111222333\"\n",
+    "* `standard`: BSN strings with proper whitespace in the proper places, like \"1112.22.333\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_nl_bsn()` and `validate_nl_bsn()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing BSN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"bsn\": [\n",
+    "            \"111222333\",\n",
+    "            \"1112223334\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_nl_bsn`\n",
+    "\n",
+    "By default, `clean_nl_bsn` will clean bsn strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_nl_bsn\n",
+    "clean_nl_bsn(df, column = \"bsn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_bsn(df, column = \"bsn\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_bsn(df, column = \"bsn\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned BSN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_bsn(df, column=\"bsn\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_bsn(df, \"bsn\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_bsn(df, \"bsn\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_nl_bsn()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_nl_bsn()` returns `True` when the input is a valid BSN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_nl_bsn()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_nl_bsn()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_nl_bsn()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_nl_bsn\n",
+    "print(validate_nl_bsn(\"111222333\"))\n",
+    "print(validate_nl_bsn(\"1112223334\"))\n",
+    "print(validate_nl_bsn(\"51824753556\"))\n",
+    "print(validate_nl_bsn(\"51 824 753 556\"))\n",
+    "print(validate_nl_bsn(\"hello\"))\n",
+    "print(validate_nl_bsn(np.nan))\n",
+    "print(validate_nl_bsn(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nl_bsn(df[\"bsn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nl_bsn(df, column=\"bsn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nl_bsn(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_nl_btw.ipynb
+++ b/docs/source/user_guide/clean/clean_nl_btw.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _btw_userguide:\n",
+    "\n",
+    "BTW Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_nl_btw() <dataprep.clean.clean_nl_btw.clean_nl_btw>` cleans a column containing Dutch BTW numbers (BTW) strings, and standardizes them in a given format. The function :func:`validate_nl_btw() <dataprep.clean.clean_nl_btw.validate_nl_btw>` validates either a single BTW strings, a column of BTW strings or a DataFrame of BTW strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "BTW strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"004495445B01\"\n",
+    "* `standard`: BTW strings with proper whitespace in the proper places. Note that in the case of BTW, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_nl_btw()` and `validate_nl_btw()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing BTW strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"btw\": [\n",
+    "            '004495445B01',\n",
+    "            '123456789B90',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_nl_btw`\n",
+    "\n",
+    "By default, `clean_nl_btw` will clean btw strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_nl_btw\n",
+    "clean_nl_btw(df, column = \"btw\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_btw(df, column = \"btw\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_btw(df, column = \"btw\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned BTW strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_btw(df, column=\"btw\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_btw(df, \"btw\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_btw(df, \"btw\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_nl_btw()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_nl_btw()` returns `True` when the input is a valid BTW. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_nl_btw()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_nl_btw()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_nl_btw()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_nl_btw\n",
+    "print(validate_nl_btw(\"004495445B01\"))\n",
+    "print(validate_nl_btw(\"123456789B90\"))\n",
+    "print(validate_nl_btw('BE 428759497'))\n",
+    "print(validate_nl_btw('BE431150351'))\n",
+    "print(validate_nl_btw(\"004085616\"))\n",
+    "print(validate_nl_btw(\"hello\"))\n",
+    "print(validate_nl_btw(np.nan))\n",
+    "print(validate_nl_btw(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nl_btw(df[\"btw\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nl_btw(df, column=\"btw\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nl_btw(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_nl_onderwijsnummer.ipynb
+++ b/docs/source/user_guide/clean/clean_nl_onderwijsnummer.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _vat_userguide:\n",
+    "\n",
+    "Onderwijsnummer Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_nl_onderwijsnummer() <dataprep.clean.clean_nl_onderwijsnummer.clean_nl_onderwijsnummer>` cleans a column containing Onderwijsnummer (the Dutch student identification number) strings, and standardizes them in a given format. The function :func:`validate_nl_onderwijsnummer() <dataprep.clean.clean_nl_onderwijsnummer.validate_nl_onderwijsnummer>` validates either a single Onderwijsnummer strings, a column of Onderwijsnummer strings or a DataFrame of Onderwijsnummer strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Onderwijsnummer strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"101222331\"\n",
+    "* `standard`: Onderwijsnummer strings with proper whitespace in the proper places. Note that in the case of Onderwijsnummer, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_nl_onderwijsnummer()` and `validate_nl_onderwijsnummer()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing Onderwijsnummer strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"vat\": [\n",
+    "            '1012.22.331',\n",
+    "            '2112.22.337',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_nl_onderwijsnummer`\n",
+    "\n",
+    "By default, `clean_nl_onderwijsnummer` will clean vat strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_nl_onderwijsnummer\n",
+    "clean_nl_onderwijsnummer(df, column = \"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_onderwijsnummer(df, column = \"vat\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_onderwijsnummer(df, column = \"vat\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned Onderwijsnummer strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_onderwijsnummer(df, column=\"vat\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_onderwijsnummer(df, \"vat\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_onderwijsnummer(df, \"vat\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_nl_onderwijsnummer()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_nl_onderwijsnummer()` returns `True` when the input is a valid Onderwijsnummer. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_nl_onderwijsnummer()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_nl_onderwijsnummer()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_nl_onderwijsnummer()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_nl_onderwijsnummer\n",
+    "print(validate_nl_onderwijsnummer(\"1012.22.331\"))\n",
+    "print(validate_nl_onderwijsnummer(\"2112.22.337\"))\n",
+    "print(validate_nl_onderwijsnummer('BE 428759497'))\n",
+    "print(validate_nl_onderwijsnummer('BE431150351'))\n",
+    "print(validate_nl_onderwijsnummer(\"004085616\"))\n",
+    "print(validate_nl_onderwijsnummer(\"hello\"))\n",
+    "print(validate_nl_onderwijsnummer(np.nan))\n",
+    "print(validate_nl_onderwijsnummer(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nl_onderwijsnummer(df[\"vat\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nl_onderwijsnummer(df, column=\"vat\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nl_onderwijsnummer(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_nl_postcode.ipynb
+++ b/docs/source/user_guide/clean/clean_nl_postcode.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _postcode_userguide:\n",
+    "\n",
+    "postcode Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_nl_postcode() <dataprep.clean.clean_nl_postcode.clean_nl_postcode>` cleans a column containing Dutch postal codes strings, and standardizes them in a given format. The function :func:`validate_nl_postcode() <dataprep.clean.clean_nl_postcode.validate_nl_postcode>` validates either a single postcode strings, a column of postcode strings or a DataFrame of postcode strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "postcode strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"2611ET\"\n",
+    "* `standard`: postcode strings with proper whitespace in the proper places. Note that in the case of postcode, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_nl_postcode()` and `validate_nl_postcode()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing postcode strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"postcode\": [\n",
+    "            'NL-2611ET',\n",
+    "            '26112 ET',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_nl_postcode`\n",
+    "\n",
+    "By default, `clean_nl_postcode` will clean postcode strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_nl_postcode\n",
+    "clean_nl_postcode(df, column = \"postcode\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_postcode(df, column = \"postcode\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_postcode(df, column = \"postcode\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned postcode strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_postcode(df, column=\"postcode\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_postcode(df, \"postcode\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nl_postcode(df, \"postcode\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_nl_postcode()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_nl_postcode()` returns `True` when the input is a valid postcode. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_nl_postcode()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_nl_postcode()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_nl_postcode()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_nl_postcode\n",
+    "print(validate_nl_postcode(\"NL-2611ET\"))\n",
+    "print(validate_nl_postcode(\"26112 ET\"))\n",
+    "print(validate_nl_postcode('BE 428759497'))\n",
+    "print(validate_nl_postcode('BE431150351'))\n",
+    "print(validate_nl_postcode(\"004085616\"))\n",
+    "print(validate_nl_postcode(\"hello\"))\n",
+    "print(validate_nl_postcode(np.nan))\n",
+    "print(validate_nl_postcode(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nl_postcode(df[\"postcode\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nl_postcode(df, column=\"postcode\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nl_postcode(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_no_fodselsnummer.ipynb
+++ b/docs/source/user_guide/clean/clean_no_fodselsnummer.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _fodselsnummer_userguide:\n",
+    "\n",
+    "fodselsnummer Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_no_fodselsnummer() <dataprep.clean.clean_no_fodselsnummer.clean_no_fodselsnummer>` cleans a column containing Norwegian birth number (fodselsnummer) strings, and standardizes them in a given format. The function :func:`validate_no_fodselsnummer() <dataprep.clean.clean_no_fodselsnummer.validate_no_fodselsnummer>` validates either a single fodselsnummer strings, a column of fodselsnummer strings or a DataFrame of fodselsnummer strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "fodselsnummer strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"15108695088\"\n",
+    "* `standard`: fodselsnummer strings with proper whitespace in the proper places, like \"151086 95088\"\n",
+    "* `birthdate`: get the person's birthdate, like \"1986-10-15\".\n",
+    "* `gender`: get the person's birth gender ('M' or 'F').\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_no_fodselsnummer()` and `validate_no_fodselsnummer()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing fodselsnummer strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"fodselsnummer\": [\n",
+    "            '15108695088',\n",
+    "            '15108695077',\n",
+    "            \"999 999 999\",\n",
+    "            \"004085616\",\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_no_fodselsnummer`\n",
+    "\n",
+    "By default, `clean_no_fodselsnummer` will clean fodselsnummer strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_no_fodselsnummer\n",
+    "clean_no_fodselsnummer(df, column = \"fodselsnummer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_fodselsnummer(df, column = \"fodselsnummer\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_fodselsnummer(df, column = \"fodselsnummer\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_fodselsnummer(df, column = \"fodselsnummer\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `gender`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_fodselsnummer(df, column = \"fodselsnummer\", output_format=\"gender\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned fodselsnummer strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_fodselsnummer(df, column=\"fodselsnummer\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_fodselsnummer(df, \"fodselsnummer\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_fodselsnummer(df, \"fodselsnummer\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_no_fodselsnummer()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_no_fodselsnummer()` returns `True` when the input is a valid fodselsnummer. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_no_fodselsnummer()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_no_fodselsnummer()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_no_fodselsnummer()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_no_fodselsnummer\n",
+    "print(validate_no_fodselsnummer(\"15108695088\"))\n",
+    "print(validate_no_fodselsnummer(\"15108695077\"))\n",
+    "print(validate_no_fodselsnummer(\"999 999 999\"))\n",
+    "print(validate_no_fodselsnummer(\"51824753556\"))\n",
+    "print(validate_no_fodselsnummer(\"004085616\"))\n",
+    "print(validate_no_fodselsnummer(\"hello\"))\n",
+    "print(validate_no_fodselsnummer(np.nan))\n",
+    "print(validate_no_fodselsnummer(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_no_fodselsnummer(df[\"fodselsnummer\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_no_fodselsnummer(df, column=\"fodselsnummer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_no_fodselsnummer(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_no_iban.ipynb
+++ b/docs/source/user_guide/clean/clean_no_iban.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _iban_userguide:\n",
+    "\n",
+    "IBAN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_no_iban() <dataprep.clean.clean_no_iban.clean_no_iban>` cleans a column containing Norwegian IBAN (IBAN) strings, and standardizes them in a given format. The function :func:`validate_no_iban() <dataprep.clean.clean_no_iban.validate_no_iban>` validates either a single IBAN strings, a column of IBAN strings or a DataFrame of IBAN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "IBAN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"NO9386011117947\"\n",
+    "* `standard`: IBAN strings with proper whitespace in the proper places, like \"NO93 8601 1117 947\"\n",
+    "* `kontonr`: return the Norwegian bank account part of the number, like \"86011117947\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_no_iban()` and `validate_no_iban()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing IBAN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"iban\": [\n",
+    "            'NO9386011117947',\n",
+    "            'NO92 8601 1117 947',\n",
+    "            \"999 999 999\",\n",
+    "            \"004085616\",\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_no_iban`\n",
+    "\n",
+    "By default, `clean_no_iban` will clean iban strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_no_iban\n",
+    "clean_no_iban(df, column = \"iban\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_iban(df, column = \"iban\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_iban(df, column = \"iban\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `kontonr`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_iban(df, column = \"iban\", output_format=\"kontonr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned IBAN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_iban(df, column=\"iban\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_iban(df, \"iban\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_iban(df, \"iban\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_no_iban()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_no_iban()` returns `True` when the input is a valid IBAN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_no_iban()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_no_iban()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_no_iban()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_no_iban\n",
+    "print(validate_no_iban(\"NO9386011117947\"))\n",
+    "print(validate_no_iban(\"NO92 8601 1117 947\"))\n",
+    "print(validate_no_iban(\"999 999 999\"))\n",
+    "print(validate_no_iban(\"51824753556\"))\n",
+    "print(validate_no_iban(\"004085616\"))\n",
+    "print(validate_no_iban(\"hello\"))\n",
+    "print(validate_no_iban(np.nan))\n",
+    "print(validate_no_iban(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_no_iban(df[\"iban\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_no_iban(df, column=\"iban\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_no_iban(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_no_kontonr.ipynb
+++ b/docs/source/user_guide/clean/clean_no_kontonr.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _kontonr_userguide:\n",
+    "\n",
+    "kontonr Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_no_kontonr() <dataprep.clean.clean_no_kontonr.clean_no_kontonr>` cleans a column containing Norwegian bank account number (kontonr) strings, and standardizes them in a given format. The function :func:`validate_no_kontonr() <dataprep.clean.clean_no_kontonr.validate_no_kontonr>` validates either a single kontonr strings, a column of kontonr strings or a DataFrame of kontonr strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "kontonr strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"86011117947\"\n",
+    "* `standard`: kontonr strings with proper whitespace in the proper places, like \"8601.11.17947\"\n",
+    "* `iban`: convert the number to an IBAN, like \"NO93 8601 11 17947\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_no_kontonr()` and `validate_no_kontonr()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing kontonr strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"kontonr\": [\n",
+    "            \"8601 11 17947\",\n",
+    "            \"8601 11 17949\",\n",
+    "            \"999 999 999\",\n",
+    "            \"004085616\",\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_no_kontonr`\n",
+    "\n",
+    "By default, `clean_no_kontonr` will clean kontonr strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_no_kontonr\n",
+    "clean_no_kontonr(df, column = \"kontonr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_kontonr(df, column = \"kontonr\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_kontonr(df, column = \"kontonr\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `iban`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_kontonr(df, column = \"kontonr\", output_format=\"iban\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned kontonr strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_kontonr(df, column=\"kontonr\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_kontonr(df, \"kontonr\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_kontonr(df, \"kontonr\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_no_kontonr()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_no_kontonr()` returns `True` when the input is a valid kontonr. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_no_kontonr()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_no_kontonr()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_no_kontonr()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_no_kontonr\n",
+    "print(validate_no_kontonr(\"8601 11 17947\"))\n",
+    "print(validate_no_kontonr(\"8601 11 17949\"))\n",
+    "print(validate_no_kontonr(\"999 999 999\"))\n",
+    "print(validate_no_kontonr(\"51824753556\"))\n",
+    "print(validate_no_kontonr(\"004085616\"))\n",
+    "print(validate_no_kontonr(\"hello\"))\n",
+    "print(validate_no_kontonr(np.nan))\n",
+    "print(validate_no_kontonr(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_no_kontonr(df[\"kontonr\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_no_kontonr(df, column=\"kontonr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_no_kontonr(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_no_mva.ipynb
+++ b/docs/source/user_guide/clean/clean_no_mva.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _abn_userguide:\n",
+    "\n",
+    "ABN Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_no_mva() <dataprep.clean.clean_no_mva.clean_no_mva>` cleans a column containing Norwegian VAT number (ABN) strings, and standardizes them in a given format. The function :func:`validate_no_mva() <dataprep.clean.clean_no_mva.validate_no_mva>` validates either a single ABN strings, a column of ABN strings or a DataFrame of ABN strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ABN strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"995525828MVA\"\n",
+    "* `standard`: ABN strings with proper whitespace in the proper places, like \"NO 995 525 828 MVA\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_no_mva()` and `validate_no_mva()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing ABN strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"abn\": [\n",
+    "            \"995525828MVA\",\n",
+    "            \"NO 995 525 829 MVA\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_no_mva`\n",
+    "\n",
+    "By default, `clean_no_mva` will clean abn strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_no_mva\n",
+    "clean_no_mva(df, column = \"abn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_mva(df, column = \"abn\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_mva(df, column = \"abn\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned ABN strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_mva(df, column=\"abn\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_mva(df, \"abn\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_mva(df, \"abn\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_no_mva()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_no_mva()` returns `True` when the input is a valid ABN. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_no_mva()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_no_mva()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_no_mva()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_no_mva\n",
+    "print(validate_no_mva(\"995525828MVA\"))\n",
+    "print(validate_no_mva(\"NO 995 525 829 MVA\"))\n",
+    "print(validate_no_mva(\"51824753556\"))\n",
+    "print(validate_no_mva(\"51 824 753 556\"))\n",
+    "print(validate_no_mva(\"hello\"))\n",
+    "print(validate_no_mva(np.nan))\n",
+    "print(validate_no_mva(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_no_mva(df[\"abn\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_no_mva(df, column=\"abn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_no_mva(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_no_orgnr.ipynb
+++ b/docs/source/user_guide/clean/clean_no_orgnr.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _orgnr_userguide:\n",
+    "\n",
+    "Orgnr Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_no_orgnr() <dataprep.clean.clean_no_orgnr.clean_no_orgnr>` cleans a column containing Norwegian organisation number (Orgnr) strings, and standardizes them in a given format. The function :func:`validate_no_orgnr() <dataprep.clean.clean_no_orgnr.validate_no_orgnr>` validates either a single Orgnr strings, a column of Orgnr strings or a DataFrame of Orgnr strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Orgnr strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"988077917\"\n",
+    "* `standard`: Orgnr strings with proper whitespace in the proper places, like \"988 077 917\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_no_orgnr()` and `validate_no_orgnr()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing Orgnr strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"orgnr\": [\n",
+    "            \"988077917\",\n",
+    "            \"988 077 918\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_no_orgnr`\n",
+    "\n",
+    "By default, `clean_no_orgnr` will clean orgnr strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_no_orgnr\n",
+    "clean_no_orgnr(df, column = \"orgnr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_orgnr(df, column = \"orgnr\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_orgnr(df, column = \"orgnr\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned Orgnr strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_orgnr(df, column=\"orgnr\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_orgnr(df, \"orgnr\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_no_orgnr(df, \"orgnr\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_no_orgnr()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_no_orgnr()` returns `True` when the input is a valid Orgnr. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_no_orgnr()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_no_orgnr()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_no_orgnr()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_no_orgnr\n",
+    "print(validate_no_orgnr(\"988077917\"))\n",
+    "print(validate_no_orgnr(\"988 077 918\"))\n",
+    "print(validate_no_orgnr(\"51824753556\"))\n",
+    "print(validate_no_orgnr(\"51 824 753 556\"))\n",
+    "print(validate_no_orgnr(\"hello\"))\n",
+    "print(validate_no_orgnr(np.nan))\n",
+    "print(validate_no_orgnr(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_no_orgnr(df[\"orgnr\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_no_orgnr(df, column=\"orgnr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_no_orgnr(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_nz_bankaccount.ipynb
+++ b/docs/source/user_guide/clean/clean_nz_bankaccount.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _bankaccount_userguide:\n",
+    "\n",
+    "bankaccount Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_nz_bankaccount() <dataprep.clean.clean_nz_bankaccount.clean_nz_bankaccount>` cleans a column containing New Zealand bank account number (bankaccount) strings, and standardizes them in a given format. The function :func:`validate_nz_bankaccount() <dataprep.clean.clean_nz_bankaccount.validate_nz_bankaccount>` validates either a single bankaccount strings, a column of bankaccount strings or a DataFrame of bankaccount strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "bankaccount strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"0102420100194000\"\n",
+    "* `standard`: bankaccount strings with proper whitespace in the proper places, like \"01-0242-0100194-000\"\n",
+    "* `info`: return a dictionary of data about the supplied number, like {'bank': 'ANZ Bank New Zealand', 'branch': 'ANZ Retail'}. This typically returns the name of the bank and branch and a BIC if it is valid.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_nz_bankaccount()` and `validate_nz_bankaccount()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing bankaccount strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"bankaccount\": [\n",
+    "            \"0102420100194000\",\n",
+    "            \"01-0242-0100195-00\",\n",
+    "            \"999 999 999\",\n",
+    "            \"004085616\",\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_nz_bankaccount`\n",
+    "\n",
+    "By default, `clean_nz_bankaccount` will clean bankaccount strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_nz_bankaccount\n",
+    "clean_nz_bankaccount(df, column = \"bankaccount\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nz_bankaccount(df, column = \"bankaccount\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nz_bankaccount(df, column = \"bankaccount\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `info`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nz_bankaccount(df, column = \"bankaccount\", output_format=\"info\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned bankaccount strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nz_bankaccount(df, column=\"bankaccount\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nz_bankaccount(df, \"bankaccount\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nz_bankaccount(df, \"bankaccount\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_nz_bankaccount()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_nz_bankaccount()` returns `True` when the input is a valid bankaccount. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_nz_bankaccount()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_nz_bankaccount()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_nz_bankaccount()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_nz_bankaccount\n",
+    "print(validate_nz_bankaccount(\"0102420100194000\"))\n",
+    "print(validate_nz_bankaccount(\"01-0242-0100195-00\"))\n",
+    "print(validate_nz_bankaccount(\"999 999 999\"))\n",
+    "print(validate_nz_bankaccount(\"51824753556\"))\n",
+    "print(validate_nz_bankaccount(\"004085616\"))\n",
+    "print(validate_nz_bankaccount(\"hello\"))\n",
+    "print(validate_nz_bankaccount(np.nan))\n",
+    "print(validate_nz_bankaccount(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nz_bankaccount(df[\"bankaccount\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nz_bankaccount(df, column=\"bankaccount\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nz_bankaccount(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_nz_ird.ipynb
+++ b/docs/source/user_guide/clean/clean_nz_ird.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _ird_userguide:\n",
+    "\n",
+    "IRD Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_nz_ird() <dataprep.clean.clean_nz_ird.clean_nz_ird>` cleans a column containing New Zealand IRD number (IRD) strings, and standardizes them in a given format. The function :func:`validate_nz_ird() <dataprep.clean.clean_nz_ird.validate_nz_ird>` validates either a single IRD strings, a column of IRD strings or a DataFrame of IRD strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "IRD strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"49091850\"\n",
+    "* `standard`: IRD strings with proper whitespace in the proper places, like \"49-091-850\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_nz_ird()` and `validate_nz_ird()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing IRD strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"ird\": [\n",
+    "            \"49091850\",\n",
+    "            \"136410133\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_nz_ird`\n",
+    "\n",
+    "By default, `clean_nz_ird` will clean ird strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_nz_ird\n",
+    "clean_nz_ird(df, column = \"ird\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nz_ird(df, column = \"ird\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nz_ird(df, column = \"ird\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned IRD strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nz_ird(df, column=\"ird\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nz_ird(df, \"ird\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_nz_ird(df, \"ird\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_nz_ird()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_nz_ird()` returns `True` when the input is a valid IRD. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_nz_ird()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_nz_ird()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_nz_ird()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_nz_ird\n",
+    "print(validate_nz_ird(\"49091850\"))\n",
+    "print(validate_nz_ird(\"136410133\"))\n",
+    "print(validate_nz_ird(\"51824753556\"))\n",
+    "print(validate_nz_ird(\"51 824 753 556\"))\n",
+    "print(validate_nz_ird(\"hello\"))\n",
+    "print(validate_nz_ird(np.nan))\n",
+    "print(validate_nz_ird(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nz_ird(df[\"ird\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nz_ird(df, column=\"ird\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_nz_ird(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_pe_cui.ipynb
+++ b/docs/source/user_guide/clean/clean_pe_cui.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _cui_userguide:\n",
+    "\n",
+    "CUI Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_pe_cui() <dataprep.clean.clean_pe_cui.clean_pe_cui>` cleans a column containing Peruvian personal number (CUI) strings, and standardizes them in a given format. The function :func:`validate_pe_cui() <dataprep.clean.clean_pe_cui.validate_pe_cui>` validates either a single CUI strings, a column of CUI strings or a DataFrame of CUI strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CUI strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"10117410\"\n",
+    "* `standard`: CUI strings with proper whitespace in the proper places. Note that in the case of CUI, the compact format is the same as the standard one.\n",
+    "* `ruc`: convert the number to a valid RUC, like \"10101174102\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_pe_cui()` and `validate_pe_cui()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing CUI strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"cui\": [\n",
+    "            \"10117410\",\n",
+    "            \"10117410-3\",\n",
+    "            '7542011030',\n",
+    "            '7552A10004',\n",
+    "            '8019010008',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_pe_cui`\n",
+    "\n",
+    "By default, `clean_pe_cui` will clean cui strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_pe_cui\n",
+    "clean_pe_cui(df, column = \"cui\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pe_cui(df, column = \"cui\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pe_cui(df, column = \"cui\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ruc`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pe_cui(df, column = \"cui\", output_format=\"ruc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CUI strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pe_cui(df, column=\"cui\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pe_cui(df, \"cui\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pe_cui(df, \"cui\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_pe_cui()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_pe_cui()` returns `True` when the input is a valid CUI. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_pe_cui()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_pe_cui()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_pe_cui()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_pe_cui\n",
+    "print(validate_pe_cui('10117410'))\n",
+    "print(validate_pe_cui('10117410-3'))\n",
+    "print(validate_pe_cui('7542011030'))\n",
+    "print(validate_pe_cui('7552A10004'))\n",
+    "print(validate_pe_cui('8019010008'))\n",
+    "print(validate_pe_cui(\"hello\"))\n",
+    "print(validate_pe_cui(np.nan))\n",
+    "print(validate_pe_cui(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pe_cui(df[\"cui\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pe_cui(df, column=\"cui\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pe_cui(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_pe_ruc.ipynb
+++ b/docs/source/user_guide/clean/clean_pe_ruc.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _ruc_userguide:\n",
+    "\n",
+    "RUC Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_pe_ruc() <dataprep.clean.clean_pe_ruc.clean_pe_ruc>` cleans a column containing Peruvian fiscal number (RUC) strings, and standardizes them in a given format. The function :func:`validate_pe_ruc() <dataprep.clean.clean_pe_ruc.validate_pe_ruc>` validates either a single RUC strings, a column of RUC strings or a DataFrame of RUC strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RUC strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"20512333797\".\n",
+    "* `standard`: RUC strings with proper whitespace in the proper places. Note that in the case of RUC, the compact format is the same as the standard one.\n",
+    "* `dni`: return the DNI (CUI) part of the number for natural persons. Note if the RUC is not for natural persons, return NaN.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_pe_ruc()` and `validate_pe_ruc()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing RUC strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"ruc\": [\n",
+    "            \"20512333797\",\n",
+    "            \"20512333798\",\n",
+    "            '7542011030',\n",
+    "            '7552A10004',\n",
+    "            '8019010008',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_pe_ruc`\n",
+    "\n",
+    "By default, `clean_pe_ruc` will clean ruc strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_pe_ruc\n",
+    "clean_pe_ruc(df, column = \"ruc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pe_ruc(df, column = \"ruc\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pe_ruc(df, column = \"ruc\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `dni`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pe_ruc(df, column = \"ruc\", output_format=\"dni\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned RUC strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pe_ruc(df, column=\"ruc\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pe_ruc(df, \"ruc\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pe_ruc(df, \"ruc\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_pe_ruc()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_pe_ruc()` returns `True` when the input is a valid RUC. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_pe_ruc()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_pe_ruc()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_pe_ruc()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_pe_ruc\n",
+    "print(validate_pe_ruc('20512333797'))\n",
+    "print(validate_pe_ruc('20512333798'))\n",
+    "print(validate_pe_ruc('7542011030'))\n",
+    "print(validate_pe_ruc('7552A10004'))\n",
+    "print(validate_pe_ruc('8019010008'))\n",
+    "print(validate_pe_ruc(\"hello\"))\n",
+    "print(validate_pe_ruc(np.nan))\n",
+    "print(validate_pe_ruc(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pe_ruc(df[\"ruc\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pe_ruc(df, column=\"ruc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pe_ruc(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_pl_nip.ipynb
+++ b/docs/source/user_guide/clean/clean_pl_nip.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _nip_userguide:\n",
+    "\n",
+    "NIP Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_pl_nip() <dataprep.clean.clean_pl_nip.clean_pl_nip>` cleans a column containing Polish VAT number (NIP) strings, and standardizes them in a given format. The function :func:`validate_pl_nip() <dataprep.clean.clean_pl_nip.validate_pl_nip>` validates either a single NIP strings, a column of NIP strings or a DataFrame of NIP strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NIP strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"8567346215\"\n",
+    "* `standard`: NIP strings with proper whitespace in the proper places, like \"856-734-62-15\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_pl_nip()` and `validate_pl_nip()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing NIP strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"nip\": [\n",
+    "            \"PL 8567346215\",\n",
+    "            \"PL 8567346216\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_pl_nip`\n",
+    "\n",
+    "By default, `clean_pl_nip` will clean nip strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_pl_nip\n",
+    "clean_pl_nip(df, column = \"nip\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_nip(df, column = \"nip\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_nip(df, column = \"nip\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned NIP strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_nip(df, column=\"nip\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_nip(df, \"nip\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_nip(df, \"nip\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_pl_nip()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_pl_nip()` returns `True` when the input is a valid NIP. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_pl_nip()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_pl_nip()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_pl_nip()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_pl_nip\n",
+    "print(validate_pl_nip(\"PL 8567346215\"))\n",
+    "print(validate_pl_nip(\"PL 8567346216\"))\n",
+    "print(validate_pl_nip(\"51824753556\"))\n",
+    "print(validate_pl_nip(\"51 824 753 556\"))\n",
+    "print(validate_pl_nip(\"hello\"))\n",
+    "print(validate_pl_nip(np.nan))\n",
+    "print(validate_pl_nip(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pl_nip(df[\"nip\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pl_nip(df, column=\"nip\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_pl_nip(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_pl_pesel.ipynb
+++ b/docs/source/user_guide/clean/clean_pl_pesel.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _pesel_userguide:\n",
+    "\n",
+    "PESEL Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_pl_pesel() <dataprep.clean.clean_pl_pesel.clean_pl_pesel>` cleans a column containing Polish national identification number (PESEL) strings, and standardizes them in a given format. The function :func:`validate_pl_pesel() <dataprep.clean.clean_pl_pesel.validate_pl_pesel>` validates either a single PESEL strings, a column of PESEL strings or a DataFrame of PESEL strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "PESEL strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"44051401359\"\n",
+    "* `standard`: PESEL strings with proper whitespace in the proper places. Note that in the case of PESEL, the compact format is the same as the standard one.\n",
+    "* `birthdate`: split the date parts from the number and return the birth date, like \"1944-05-14\".\n",
+    "* `gender`: get the person's birth gender ('M' or 'F').\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_pl_pesel()` and `validate_pl_pesel()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing PESEL strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"pesel\": [\n",
+    "            \"44051401359\",\n",
+    "            \"44051401358\",\n",
+    "            '7542011030',\n",
+    "            '7552A10004', \n",
+    "            '8019010008',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_pl_pesel`\n",
+    "\n",
+    "By default, `clean_pl_pesel` will clean pesel strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_pl_pesel\n",
+    "clean_pl_pesel(df, column = \"pesel\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_pesel(df, column = \"pesel\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_pesel(df, column = \"pesel\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_pesel(df, column = \"pesel\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `gender`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_pesel(df, column = \"pesel\", output_format=\"gender\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned PESEL strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_pesel(df, column=\"pesel\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_pesel(df, \"pesel\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_pesel(df, \"pesel\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_pl_pesel()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_pl_pesel()` returns `True` when the input is a valid PESEL. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_pl_pesel()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_pl_pesel()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_pl_pesel()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_pl_pesel\n",
+    "print(validate_pl_pesel('44051401359'))\n",
+    "print(validate_pl_pesel('44051401358'))\n",
+    "print(validate_pl_pesel('7542011030'))\n",
+    "print(validate_pl_pesel('7552A10004'))\n",
+    "print(validate_pl_pesel('8019010008'))\n",
+    "print(validate_pl_pesel(\"hello\"))\n",
+    "print(validate_pl_pesel(np.nan))\n",
+    "print(validate_pl_pesel(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pl_pesel(df[\"pesel\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pl_pesel(df, column=\"pesel\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pl_pesel(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_pl_regon.ipynb
+++ b/docs/source/user_guide/clean/clean_pl_regon.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _regon_userguide:\n",
+    "\n",
+    "REGON Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_pl_regon() <dataprep.clean.clean_pl_regon.clean_pl_regon>` cleans a column containing Polish register of economic units (REGON) strings, and standardizes them in a given format. The function :func:`validate_pl_regon() <dataprep.clean.clean_pl_regon.validate_pl_regon>` validates either a single REGON strings, a column of REGON strings or a DataFrame of REGON strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "REGON strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"192598184\"\n",
+    "* `standard`: REGON strings with proper whitespace in the proper places. Note that in the case of REGON, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_pl_regon()` and `validate_pl_regon()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing REGON strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"regon\": [\n",
+    "            '192598184',\n",
+    "            '192598183',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_pl_regon`\n",
+    "\n",
+    "By default, `clean_pl_regon` will clean regon strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_pl_regon\n",
+    "clean_pl_regon(df, column = \"regon\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_regon(df, column = \"regon\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_regon(df, column = \"regon\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned REGON strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_regon(df, column=\"regon\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_regon(df, \"regon\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pl_regon(df, \"regon\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_pl_regon()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_pl_regon()` returns `True` when the input is a valid REGON. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_pl_regon()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_pl_regon()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_pl_regon()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_pl_regon\n",
+    "print(validate_pl_regon(\"192598184\"))\n",
+    "print(validate_pl_regon(\"192598183\"))\n",
+    "print(validate_pl_regon('BE 428759497'))\n",
+    "print(validate_pl_regon('BE431150351'))\n",
+    "print(validate_pl_regon(\"004085616\"))\n",
+    "print(validate_pl_regon(\"hello\"))\n",
+    "print(validate_pl_regon(np.nan))\n",
+    "print(validate_pl_regon(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pl_regon(df[\"regon\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pl_regon(df, column=\"regon\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pl_regon(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_pt_nif.ipynb
+++ b/docs/source/user_guide/clean/clean_pt_nif.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _nif_userguide:\n",
+    "\n",
+    "NIF Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_pt_nif() <dataprep.clean.clean_pt_nif.clean_pt_nif>` cleans a column containing Portuguese NIF number (NIF) strings, and standardizes them in a given format. The function :func:`validate_pt_nif() <dataprep.clean.clean_pt_nif.validate_pt_nif>` validates either a single NIF strings, a column of NIF strings or a DataFrame of NIF strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NIF strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"501964843\"\n",
+    "* `standard`: NIF strings with proper whitespace in the proper places. Note that in the case of NIF, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_pt_nif()` and `validate_pt_nif()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing NIF strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"nif\": [\n",
+    "            'PT 501 964 843',\n",
+    "            'PT 501 964 842',\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_pt_nif`\n",
+    "\n",
+    "By default, `clean_pt_nif` will clean nif strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_pt_nif\n",
+    "clean_pt_nif(df, column = \"nif\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pt_nif(df, column = \"nif\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pt_nif(df, column = \"nif\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned NIF strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pt_nif(df, column=\"nif\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pt_nif(df, \"nif\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_pt_nif(df, \"nif\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_pt_nif()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_pt_nif()` returns `True` when the input is a valid NIF. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_pt_nif()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_pt_nif()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_pt_nif()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_pt_nif\n",
+    "print(validate_pt_nif(\"PT 501 964 843\"))\n",
+    "print(validate_pt_nif(\"PT 501 964 842\"))\n",
+    "print(validate_pt_nif('BE 428759497'))\n",
+    "print(validate_pt_nif('BE431150351'))\n",
+    "print(validate_pt_nif(\"004085616\"))\n",
+    "print(validate_pt_nif(\"hello\"))\n",
+    "print(validate_pt_nif(np.nan))\n",
+    "print(validate_pt_nif(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pt_nif(df[\"nif\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pt_nif(df, column=\"nif\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_pt_nif(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_py_ruc.ipynb
+++ b/docs/source/user_guide/clean/clean_py_ruc.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _ruc_userguide:\n",
+    "\n",
+    "RUC Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_py_ruc() <dataprep.clean.clean_py_ruc.clean_py_ruc>` cleans a column containing Paraguay RUC number (RUC) strings, and standardizes them in a given format. The function :func:`validate_py_ruc() <dataprep.clean.clean_py_ruc.validate_py_ruc>` validates either a single RUC strings, a column of RUC strings or a DataFrame of RUC strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RUC strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"800000358\"\n",
+    "* `standard`: RUC strings with proper whitespace in the proper places, like \"80000035-8\"\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_py_ruc()` and `validate_py_ruc()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing RUC strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"ruc\": [\n",
+    "            \"800000358\",\n",
+    "            \"80123456789\",\n",
+    "            \"51824753556\",\n",
+    "            \"51 824 753 556\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\"\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_py_ruc`\n",
+    "\n",
+    "By default, `clean_py_ruc` will clean ruc strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_py_ruc\n",
+    "clean_py_ruc(df, column = \"ruc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_py_ruc(df, column = \"ruc\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_py_ruc(df, column = \"ruc\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned RUC strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_py_ruc(df, column=\"ruc\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_py_ruc(df, \"ruc\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_py_ruc(df, \"ruc\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_py_ruc()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_py_ruc()` returns `True` when the input is a valid RUC. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_py_ruc()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_py_ruc()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_py_ruc()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_py_ruc\n",
+    "print(validate_py_ruc(\"800000358\"))\n",
+    "print(validate_py_ruc(\"80123456789\"))\n",
+    "print(validate_py_ruc(\"51824753556\"))\n",
+    "print(validate_py_ruc(\"51 824 753 556\"))\n",
+    "print(validate_py_ruc(\"hello\"))\n",
+    "print(validate_py_ruc(np.nan))\n",
+    "print(validate_py_ruc(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_py_ruc(df[\"ruc\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_py_ruc(df, column=\"ruc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_py_ruc(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ro_cf.ipynb
+++ b/docs/source/user_guide/clean/clean_ro_cf.ipynb
@@ -1,0 +1,321 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _cf_userguide:\n",
+    "\n",
+    "CF Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ro_cf() <dataprep.clean.clean_ro_cf.clean_ro_cf>` cleans a column containing Romanian CF (CF) number (CF) strings, and standardizes them in a given format. The function :func:`validate_ro_cf() <dataprep.clean.clean_ro_cf.validate_ro_cf>` validates either a single CF strings, a column of CF strings or a DataFrame of CF strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CF strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"RO18547290\n",
+    "\"\n",
+    "* `standard`: CF strings with proper whitespace in the proper places. Note that in the case of CF, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ro_cf()` and `validate_ro_cf()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing CF strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"cf\": [\n",
+    "            \"RO 185 472 90\",\n",
+    "            \"RO 185 472 903333\",\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ro_cf`\n",
+    "\n",
+    "By default, `clean_ro_cf` will clean cf strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ro_cf\n",
+    "clean_ro_cf(df, column = \"cf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cf(df, column = \"cf\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cf(df, column = \"cf\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CF strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cf(df, column=\"cf\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cf(df, \"cf\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cf(df, \"cf\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ro_cf()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ro_cf()` returns `True` when the input is a valid CF. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ro_cf()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ro_cf()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ro_cf()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ro_cf\n",
+    "print(validate_ro_cf(\"RO 185 472 90\"))\n",
+    "print(validate_ro_cf(\"RO 185 472 903333\"))\n",
+    "print(validate_ro_cf('BE 428759497'))\n",
+    "print(validate_ro_cf('BE431150351'))\n",
+    "print(validate_ro_cf(\"004085616\"))\n",
+    "print(validate_ro_cf(\"hello\"))\n",
+    "print(validate_ro_cf(np.nan))\n",
+    "print(validate_ro_cf(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ro_cf(df[\"cf\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ro_cf(df, column=\"cf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ro_cf(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ro_cnp.ipynb
+++ b/docs/source/user_guide/clean/clean_ro_cnp.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _cnp_userguide:\n",
+    "\n",
+    "CNP Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ro_cnp() <dataprep.clean.clean_ro_cnp.clean_ro_cnp>` cleans a column containing Romanian Numerical Personal Code (CNP) strings, and standardizes them in a given format. The function :func:`validate_ro_cnp() <dataprep.clean.clean_ro_cnp.validate_ro_cnp>` validates either a single CNP strings, a column of CNP strings or a DataFrame of CNP strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CNP strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"1630615123457\"\n",
+    "* `standard`: CNP strings with proper whitespace in the proper places. Note that in the case of CNP, the compact format is the same as the standard one.\n",
+    "* `birthdate`: split the date parts from the number and return the birth date, like \"1875-03-16\".\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ro_cnp()` and `validate_ro_cnp()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing CNP strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"cnp\": [\n",
+    "            \"1630615123457\",\n",
+    "            \"0800101221142\",\n",
+    "            '7542011030',\n",
+    "            '7552A10004', \n",
+    "            '8019010008',\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ro_cnp`\n",
+    "\n",
+    "By default, `clean_ro_cnp` will clean cnp strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ro_cnp\n",
+    "clean_ro_cnp(df, column = \"cnp\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cnp(df, column = \"cnp\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cnp(df, column = \"cnp\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `birthdate`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cnp(df, column = \"cnp\", output_format=\"birthdate\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CNP strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cnp(df, column=\"cnp\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cnp(df, \"cnp\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cnp(df, \"cnp\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ro_cnp()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ro_cnp()` returns `True` when the input is a valid CNP. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ro_cnp()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ro_cnp()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ro_cnp()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ro_cnp\n",
+    "print(validate_ro_cnp('1630615123457'))\n",
+    "print(validate_ro_cnp('0800101221142'))\n",
+    "print(validate_ro_cnp('7542011030'))\n",
+    "print(validate_ro_cnp('7552A10004'))\n",
+    "print(validate_ro_cnp('8019010008'))\n",
+    "print(validate_ro_cnp(\"hello\"))\n",
+    "print(validate_ro_cnp(np.nan))\n",
+    "print(validate_ro_cnp(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ro_cnp(df[\"cnp\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ro_cnp(df, column=\"cnp\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ro_cnp(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ro_cui.ipynb
+++ b/docs/source/user_guide/clean/clean_ro_cui.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _cui_userguide:\n",
+    "\n",
+    "CUI Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ro_cui() <dataprep.clean.clean_ro_cui.clean_ro_cui>` cleans a column containing Romanian company identifier (CUI) strings, and standardizes them in a given format. The function :func:`validate_ro_cui() <dataprep.clean.clean_ro_cui.validate_ro_cui>` validates either a single CUI strings, a column of CUI strings or a DataFrame of CUI strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CUI strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"18547290\"\n",
+    "* `standard`: CUI strings with proper whitespace in the proper places. Note that in the case of CUI, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ro_cui()` and `validate_ro_cui()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing CUI strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"cui\": [\n",
+    "            \"185 472 90\",\n",
+    "            \"185 472 91\",\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ro_cui`\n",
+    "\n",
+    "By default, `clean_ro_cui` will clean cui strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ro_cui\n",
+    "clean_ro_cui(df, column = \"cui\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cui(df, column = \"cui\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cui(df, column = \"cui\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned CUI strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cui(df, column=\"cui\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cui(df, \"cui\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_cui(df, \"cui\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ro_cui()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ro_cui()` returns `True` when the input is a valid CUI. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ro_cui()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ro_cui()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ro_cui()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ro_cui\n",
+    "print(validate_ro_cui(\"185 472 90\"))\n",
+    "print(validate_ro_cui(\"185 472 91\"))\n",
+    "print(validate_ro_cui('BE 428759497'))\n",
+    "print(validate_ro_cui('BE431150351'))\n",
+    "print(validate_ro_cui(\"004085616\"))\n",
+    "print(validate_ro_cui(\"hello\"))\n",
+    "print(validate_ro_cui(np.nan))\n",
+    "print(validate_ro_cui(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ro_cui(df[\"cui\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ro_cui(df, column=\"cui\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ro_cui(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/user_guide/clean/clean_ro_onrc.ipynb
+++ b/docs/source/user_guide/clean/clean_ro_onrc.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. _onrc_userguide:\n",
+    "\n",
+    "ONRC Strings\n",
+    "============"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Introduction\n",
+    "------------\n",
+    "\n",
+    "The function :func:`clean_ro_onrc() <dataprep.clean.clean_ro_onrc.clean_ro_onrc>` cleans a column containing Romanian Trade Register identifier (ONRC) strings, and standardizes them in a given format. The function :func:`validate_ro_onrc() <dataprep.clean.clean_ro_onrc.validate_ro_onrc>` validates either a single ONRC strings, a column of ONRC strings or a DataFrame of ONRC strings, returning `True` if the value is valid, and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ONRC strings can be converted to the following formats via the `output_format` parameter:\n",
+    "\n",
+    "* `compact`: only number strings without any seperators or whitespace, like \"J52/750/2012\"\n",
+    "* `standard`: ONRC strings with proper whitespace in the proper places. Note that in the case of ONRC, the compact format is the same as the standard one.\n",
+    "\n",
+    "Invalid parsing is handled with the `errors` parameter:\n",
+    "\n",
+    "* `coerce` (default): invalid parsing will be set to NaN\n",
+    "* `ignore`: invalid parsing will return the input\n",
+    "* `raise`: invalid parsing will raise an exception\n",
+    "\n",
+    "The following sections demonstrate the functionality of `clean_ro_onrc()` and `validate_ro_onrc()`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An example dataset containing ONRC strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"onrc\": [\n",
+    "            \"J52/750/2012\",\n",
+    "            \"X52/750/2012\",\n",
+    "            'BE 428759497',\n",
+    "            'BE431150351',\n",
+    "            \"002 724 334\",\n",
+    "            \"hello\",\n",
+    "            np.nan,\n",
+    "            \"NULL\",\n",
+    "        ], \n",
+    "        \"address\": [\n",
+    "            \"123 Pine Ave.\",\n",
+    "            \"main st\",\n",
+    "            \"1234 west main heights 57033\",\n",
+    "            \"apt 1 789 s maple rd manhattan\",\n",
+    "            \"robie house, 789 north main street\",\n",
+    "            \"1111 S Figueroa St, Los Angeles, CA 90015\",\n",
+    "            \"(staples center) 1111 S Figueroa St, Los Angeles\",\n",
+    "            \"hello\",\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Default `clean_ro_onrc`\n",
+    "\n",
+    "By default, `clean_ro_onrc` will clean onrc strings and output them in the standard format with proper separators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import clean_ro_onrc\n",
+    "clean_ro_onrc(df, column = \"onrc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Output formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This section demonstrates the output parameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `standard` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_onrc(df, column = \"onrc\", output_format=\"standard\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `compact`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_onrc(df, column = \"onrc\", output_format=\"compact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `inplace` parameter\n",
+    "\n",
+    "This deletes the given column from the returned DataFrame. \n",
+    "A new column containing cleaned ONRC strings is added with a title in the format `\"{original title}_clean\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_onrc(df, column=\"onrc\", inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `errors` parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `coerce` (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_onrc(df, \"onrc\", errors=\"coerce\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `ignore`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_ro_onrc(df, \"onrc\", errors=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `validate_ro_onrc()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`validate_ro_onrc()` returns `True` when the input is a valid ONRC. Otherwise it returns `False`.\n",
+    "\n",
+    "The input of `validate_ro_onrc()` can be a string, a Pandas DataSeries, a Dask DataSeries, a Pandas DataFrame and a dask DataFrame.\n",
+    "\n",
+    "When the input is a string, a Pandas DataSeries or a Dask DataSeries, user doesn't need to specify a column name to be validated. \n",
+    "\n",
+    "When the input is a Pandas DataFrame or a dask DataFrame, user can both specify or not specify a column name to be validated. If user specify the column name, `validate_ro_onrc()` only returns the validation result for the specified column. If user doesn't specify the column name, `validate_ro_onrc()` returns the validation result for the whole DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataprep.clean import validate_ro_onrc\n",
+    "print(validate_ro_onrc(\"J52/750/2012\"))\n",
+    "print(validate_ro_onrc(\"X52/750/2012\"))\n",
+    "print(validate_ro_onrc('BE 428759497'))\n",
+    "print(validate_ro_onrc('BE431150351'))\n",
+    "print(validate_ro_onrc(\"004085616\"))\n",
+    "print(validate_ro_onrc(\"hello\"))\n",
+    "print(validate_ro_onrc(np.nan))\n",
+    "print(validate_ro_onrc(\"NULL\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ro_onrc(df[\"onrc\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### DataFrame + Specify Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_ro_onrc(df, column=\"onrc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Only DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "validate_ro_onrc(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Description

Add documentation for clean functions mentioned in #668 , and fix some typos in the code.

# Snapshots:
![image](https://user-images.githubusercontent.com/66409637/132148017-b1721f20-4ba2-4e20-bad5-28d5b9cb9680.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
