### PR TITLE
docs(eda): scattter.sample_rate added to documentation

### DIFF
--- a/docs/source/user_guide/eda/parameter_configurations.ipynb
+++ b/docs/source/user_guide/eda/parameter_configurations.ipynb
@@ -107,6 +107,7 @@
     "| `line.unit`| str | \"auto\" | Defines the time unit to group values over for a datetime column. It can be \"year\", \"quarter\", \"month\", \"week\", \"day\", \"hour\", \"minute\", \"second\". With default value \"auto\", it will use the time unit such that the resulting number of groups is closest to 15 in the `Line Chart` |\n",
     "| `line.agg`| str | \"mean\" | Specify the aggregate to use when aggregating over a numeric column in the `Line Chart` |\n",
     "| `scatter.sample_size`| int | 1000 | Number of points to randomly sample per partition in the `Scatter Plot` |\n",
+    "| `scatter.sample_rate`| float | \"None\" | Defines the sample rate per partition in the `Scatter Plot`. Cannot be used with sample_size. Set it to 1.0 for no sampling |\n",
     "| `hexbin.tile_size` | float | \"auto\" | The size of the tile in the hexbin plot. Measured from the middle of a hexagon to its left or right corner in the `Hexbin Plot`.|\n",
     "| `nested.ngroups`| int | 10 | Maximum number of most frequent values from the first column to display in the `Nested Bar Chart` |\n",
     "| `nested.nsubgroups`| int | 5 | Maximum number of most frequent values from the second column to display (computed on the filtered data consisting of the most frequent values from the first column) in the `Nested Bar Chart` |\n",
@@ -152,7 +153,8 @@
     "\n",
     "| Local Parameter | Type |Default | Description |\n",
     "| --- | --- | --- | --- |\n",
-    "| `scatter.sample_size`| int | 1000 | Number of points to randomly sample per partition in the `Scatter Plot` in `plot_correlation(df, x, y)`|"
+    "| `scatter.sample_size`| int | 1000 | Number of points to randomly sample per partition in the `Scatter Plot` in `plot_correlation(df, x, y)`|",
+    "| `scatter.sample_rate`| float | \"None\" | Defines the sample rate per partition in the `Scatter Plot`. Cannot be used with sample_size. Set it to 1.0 for no sampling |\n",
    ]
   },
   {


### PR DESCRIPTION
I have added scatter.sample_rate to both plot_correlation() and plot() parameter descriptions.
