### PR TITLE
fix(eda): changed report save method to accept one path parameter as …

### DIFF
--- a/dataprep/eda/create_report/report.py
+++ b/dataprep/eda/create_report/report.py
@@ -6,6 +6,7 @@ import webbrowser
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Optional
+import os
 
 from ...utils import is_notebook
 
@@ -39,11 +40,7 @@ class Report:
         """
         return ""
 
-    def save(
-        self,
-        filename: Optional[str] = "report",
-        to: Optional[str] = None,
-    ) -> None:
+    def save(self, path: Optional[str] = None) -> None:
         """
         Save report to current working directory.
 
@@ -54,18 +51,37 @@ class Report:
         to: Optional[str], default Path.cwd()
             The path to where the report will be saved.
         """
-        # pylint: disable=invalid-name
-        if to:
-            path = Path(to).expanduser()
+
+        saved_file_path = None
+
+        if path:
+            extension = os.path.splitext(path)[1]
+            posix_path = Path(path).expanduser()
+
+            if posix_path.is_dir():
+                if path.endswith("/"):
+                    path += "report.html"
+                else:
+                    path += "/report.html"
+
+            elif extension:
+                if extension != ".html":
+                    raise ValueError(
+                        "Format '{extension}' is not supported (supported formats: html)"
+                    )
+
+            else:
+                path += ".html"
+
+            saved_file_path = Path(path).expanduser()
+
         else:
-            path = Path.cwd()
+            path = str(Path.cwd()) + "/report.html"
+            saved_file_path = Path(path).expanduser()
 
-        if not path.is_dir():
-            raise ValueError("The second parameter is not a valid path.")
-
-        with open(path / f"{filename}.html", "w", encoding="utf-8") as file:
+        with open(saved_file_path, "w", encoding="utf-8") as file:
             file.write(self.report)
-        print(f"Report has been saved to {path}/{filename}.html!")
+        print(f"Report has been saved to {saved_file_path}!")
 
     def show_browser(self) -> None:
         """


### PR DESCRIPTION
…opposed to two

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Addresses Issue #685. Changed input parameter of the save function to accept only one path parameter. No dependencies required for this change. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Wrote some manual tests of my own to test the functionality of the method.

# Snapshots:

Include snapshots for easier review.

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
