### PR TITLE
test(eda): add tests for intermediate compute functions

### DIFF
--- a/dataprep/tests/eda/test_config.py
+++ b/dataprep/tests/eda/test_config.py
@@ -7,7 +7,16 @@ import numpy as np
 import random
 import pytest
 
-from ...eda import plot, plot_correlation, plot_missing, create_report
+from ...eda import (
+    plot,
+    plot_correlation,
+    plot_missing,
+    compute,
+    compute_correlation,
+    compute_missing,
+    create_report,
+)
+from ...eda.configs import Config
 from ...eda.utils import to_dask
 
 
@@ -31,23 +40,48 @@ def test_sanity_compute_1(simpledf: dd.DataFrame) -> None:
         kde_bins = random.randint(20, 50)
         wordfreq_top_words = random.randint(20, 50)
         heatmap_ngroups = random.randint(20, 50)
-        plot(simpledf, config={"hist.bins": hist_bins, "hist.yscale": "log"})
-        plot(simpledf, config={"bar.bars": bar_bars, "bar.yscale": "log", "bar.color": "#123456"})
-        plot(simpledf, config={"kde.bins": kde_bins, "kde.yscale": "log"})
-        plot(simpledf, config={"wordfreq.top_words": wordfreq_top_words})
-        plot(simpledf, config={"heatmap.ngroups": heatmap_ngroups})
+
+        config = {"hist.bins": hist_bins, "hist.yscale": "log"}
+        compute(simpledf, cfg=config)
+        plot(simpledf, config=config)
+
+        config = {"bar.bars": bar_bars, "bar.yscale": "log", "bar.color": "#123456"}
+        compute(simpledf, cfg=config)
+        plot(simpledf, config=config)
+
+        config = {"kde.bins": kde_bins, "kde.yscale": "log"}
+        compute(simpledf, cfg=config)
+        plot(simpledf, config=config)
+
+        config = {"wordfreq.top_words": wordfreq_top_words}
+        compute(simpledf, cfg=config)
+        plot(simpledf, config=config)
+
+        config = {"heatmap.ngroups": heatmap_ngroups}
+        compute(simpledf, cfg=config)
+        plot(simpledf, config=config)
 
 
 def test_sanity_compute_2(simpledf: dd.DataFrame) -> None:
     for _ in range(5):
         spectrum_bins = random.randint(5, 20)
-        plot_missing(simpledf, config={"spectrum.bins": spectrum_bins})
+        config = {"spectrum.bins": spectrum_bins}
+        compute_missing(simpledf, cfg=config)
+        plot_missing(simpledf, config=config)
 
 
 def test_sanity_compute_3(simpledf: dd.DataFrame) -> None:
-    plot_correlation(simpledf, "a", "b", config={"scatter.sample_rate": 0.1})
-    plot_correlation(simpledf, "a", "b", config={"scatter.sample_size": 10000})
-    plot_correlation(simpledf, "a", "b", config={"scatter.sample_size": 100})
+    config = {"scatter.sample_rate": 0.1}
+    compute_correlation(simpledf, col1="a", col2="b", cfg=config)
+    plot_correlation(simpledf, "a", "b", config=config)
+
+    config = {"scatter.sample_size": 10000}
+    compute_correlation(simpledf, col1="a", col2="b", cfg=config)
+    plot_correlation(simpledf, "a", "b", config=config)
+
+    config = {"scatter.sample_size": 100}
+    compute_correlation(simpledf, col1="a", col2="b", cfg=config)
+    plot_correlation(simpledf, "a", "b", config=config)
 
 
 def test_report(simpledf: dd.DataFrame) -> None:


### PR DESCRIPTION
# Description
Closes #780
Add some test cases for `compute`, `compute_correlation` and `compute_missing` with customized configuration

# How Has This Been Tested?
By running all the tests locally

# Snapshots:
Not available for this issue

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have already squashed the commits and make the commit message conform to the project standard.
- [x] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
