### PR TITLE
Ensure npartitions is passed to dask as int

### DIFF
--- a/dataprep/clean/utils.py
+++ b/dataprep/clean/utils.py
@@ -6,6 +6,7 @@ import json
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
+from math import ceil
 
 
 NULL_VALUES = {
@@ -69,7 +70,7 @@ def to_dask(df: Union[pd.DataFrame, dd.DataFrame]) -> dd.DataFrame:
         return df
 
     df_size = df.memory_usage(deep=True).sum()
-    npartitions = np.ceil(df_size / 128 / 1024 / 1024)  # 128 MB partition size
+    npartitions = ceil(df_size / 128 / 1024 / 1024)  # 128 MB partition size
     return dd.from_pandas(df, npartitions=npartitions)
 
 

--- a/dataprep/tests/clean/test_clean_phone.py
+++ b/dataprep/tests/clean/test_clean_phone.py
@@ -586,3 +586,32 @@ def test_validate_series(df_phone: pd.DataFrame) -> None:
         name="messy_phone",
     )
     assert srs_check.equals(srs_valid)
+
+
+def test_npartition_type() -> None:
+    """
+    related to #901
+    """
+    df = pd.DataFrame(
+        {
+            "phone": [
+                "555-234-5678",
+                "(555) 234-5678",
+                "555.234.5678",
+                "555/234/5678",
+                15551234567,
+                "(1) 555-234-5678",
+                "+1 (234) 567-8901 x. 1234",
+                "2345678901 extension 1234",
+                "2345678",
+                "800-299-JUNK",
+                "1-866-4ZIPCAR",
+                "123 ABC COMPANY",
+                "+66 91 889 8948",
+                "hello",
+                np.nan,
+                "NULL",
+            ]
+        }
+    )
+    clean_phone(df, "phone")


### PR DESCRIPTION
Using `np.ceil` return a float, which triggers errors downstream.

```python
In [5]: import numpy as np

In [6]: np.ceil(1.0001)
Out[6]: 2.0
```

For a reproducible error example, see this question: https://stackoverflow.com/questions/72453608/dataprep-eda-typeerror-please-provide-npartitions-as-an-int-or-possibly-as-non.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already squashed the commits and make the commit message conform to the project standard.
- [ ] I have already marked the commit with "BREAKING CHANGE" or "Fixes #" if needed.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
